### PR TITLE
sql/mysql: add string types for integration tests

### DIFF
--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -142,10 +142,21 @@ func (s *mysqlSuite) TestAddColumns() {
 		&schema.Column{Name: "d", Type: &schema.ColumnType{Raw: "longblob", Type: &schema.BinaryType{T: "longblob"}}},
 		&schema.Column{Name: "e", Type: &schema.ColumnType{Raw: "binary", Type: &schema.BinaryType{T: "binary"}}},
 		&schema.Column{Name: "f", Type: &schema.ColumnType{Raw: "varbinary(255)", Type: &schema.BinaryType{T: "varbinary(255)"}}},
+		&schema.Column{Name: "g", Type: &schema.ColumnType{Type: &schema.StringType{T: "varchar", Size: 255}}},
+		&schema.Column{Name: "h", Type: &schema.ColumnType{Raw: "varchar(255)", Type: &schema.StringType{T: "varchar(255)"}}},
+		&schema.Column{Name: "i", Type: &schema.ColumnType{Raw: "tinytext", Type: &schema.StringType{T: "tinytext"}}},
+		&schema.Column{Name: "j", Type: &schema.ColumnType{Raw: "mediumtext", Type: &schema.StringType{T: "mediumtext"}}},
+		&schema.Column{Name: "k", Type: &schema.ColumnType{Raw: "text", Type: &schema.StringType{T: "text"}}},
+		&schema.Column{Name: "l", Type: &schema.ColumnType{Raw: "longtext", Type: &schema.StringType{T: "longtext"}}},
+		&schema.Column{Name: "m", Type: &schema.ColumnType{Type: &schema.DecimalType{T: "decimal", Precision: 10, Scale: 6}}},
+		&schema.Column{Name: "n", Type: &schema.ColumnType{Type: &schema.DecimalType{T: "numeric", Precision: 10, Scale: 2}}},
+		&schema.Column{Name: "o", Type: &schema.ColumnType{Type: &schema.FloatType{T: "float", Precision: 2}}},
+		&schema.Column{Name: "p", Type: &schema.ColumnType{Type: &schema.FloatType{T: "double", Precision: 14}}},
+		&schema.Column{Name: "q", Type: &schema.ColumnType{Type: &schema.FloatType{T: "real", Precision: 14}}},
 	)
 	changes, err := s.drv.Diff().TableDiff(s.loadRealm().Schemas[0].Tables[0], usersT)
 	s.Require().NoError(err)
-	s.Len(changes, 6)
+	s.Len(changes, 17)
 	err = s.drv.Migrate().Exec(ctx, []schema.Change{&schema.ModifyTable{T: usersT, Changes: changes}})
 	s.Require().NoError(err)
 	s.ensureNoChange(usersT)

--- a/sql/internal/sqlx/diff.go
+++ b/sql/internal/sqlx/diff.go
@@ -210,18 +210,9 @@ func (d *Diff) TableDiff(from, to *schema.Table) ([]schema.Change, error) {
 
 // columnChange returns the schema changes (if any) for migrating one column to the other.
 func (d *Diff) columnChange(from, to *schema.Column) (schema.ChangeKind, error) {
-	var change schema.ChangeKind
+	change := commentChange(from.Attrs, to.Attrs)
 	if from.Type.Null != to.Type.Null {
 		change |= schema.ChangeNull
-	}
-	change |= commentChange(from.Attrs, to.Attrs)
-	var c1, c2 schema.Collation
-	if Has(from.Attrs, &c1) != Has(to.Attrs, &c2) || c1.V != c2.V {
-		change |= schema.ChangeCollation
-	}
-	var cr1, cr2 schema.Charset
-	if Has(from.Attrs, &cr1) != Has(to.Attrs, &cr2) || cr1.V != cr2.V {
-		change |= schema.ChangeCharset
 	}
 	changed, err := d.ColumnTypeChanged(from, to)
 	if err != nil {
@@ -372,21 +363,12 @@ func ColumnTypeChanged(from, to *schema.Column) (bool, error) {
 	case *schema.BoolType:
 		toT := toT.(*schema.BoolType)
 		changed = fromT.T != toT.T
-	case *schema.DecimalType:
-		toT := toT.(*schema.DecimalType)
-		changed = fromT.T != toT.T || fromT.Scale != toT.Scale || fromT.Precision != toT.Precision
 	case *schema.EnumType:
 		toT := toT.(*schema.EnumType)
 		changed = !ValuesEqual(fromT.Values, toT.Values)
-	case *schema.FloatType:
-		toT := toT.(*schema.FloatType)
-		changed = fromT.T != toT.T || fromT.Precision != toT.Precision
 	case *schema.JSONType:
 		toT := toT.(*schema.JSONType)
 		changed = fromT.T != toT.T
-	case *schema.StringType:
-		toT := toT.(*schema.StringType)
-		changed = fromT.T != toT.T || fromT.Size != toT.Size
 	case *schema.SpatialType:
 		toT := toT.(*schema.SpatialType)
 		changed = fromT.T != toT.T

--- a/sql/mysql/convert.go
+++ b/sql/mysql/convert.go
@@ -33,14 +33,17 @@ func (d *Driver) FormatType(t schema.Type) (string, error) {
 	case *schema.DecimalType:
 		f = strings.ToLower(t.T)
 		if f == tDecimal || f == tNumeric {
-			f = fmt.Sprintf("%s(%d,%d)", f, t.Precision, t.Scale)
+			// In MySQL, NUMERIC is implemented as DECIMAL.
+			f = fmt.Sprintf("decimal(%d,%d)", t.Precision, t.Scale)
 		}
 	case *schema.EnumType:
 		f = fmt.Sprintf("enum(%s)", formatValues(t.Values))
 	case *schema.FloatType:
 		f = strings.ToLower(t.T)
-		if f == tFloat || f == tDouble || f == tReal {
-			f = fmt.Sprintf("%s(%d)", f, t.Precision)
+		// FLOAT with precision > 24, become DOUBLE.
+		// Also, REAL is a synonym for DOUBLE (if REAL_AS_FLOAT was not set).
+		if f == tFloat && t.Precision > 24 || f == tReal {
+			f = tDouble
 		}
 	case *schema.IntegerType:
 		f = strings.ToLower(t.T)

--- a/sql/mysql/diff.go
+++ b/sql/mysql/diff.go
@@ -201,7 +201,7 @@ func (d *diff) typeChanged(from, to *schema.Column) (bool, error) {
 	fromT, toT := from.Type.Type, to.Type.Type
 	var changed bool
 	switch fromT := fromT.(type) {
-	case *schema.BinaryType:
+	case *schema.BinaryType, *schema.DecimalType, *schema.FloatType:
 		changed = d.mustFormat(fromT) != d.mustFormat(toT)
 	case *schema.IntegerType:
 		toT := toT.(*schema.IntegerType)

--- a/sql/postgres/diff.go
+++ b/sql/postgres/diff.go
@@ -136,9 +136,15 @@ func (d *diff) typeChanged(from, to *schema.Column) (bool, error) {
 	case *schema.BinaryType:
 		toT := toT.(*schema.BinaryType)
 		changed = fromT.T != toT.T
+	case *schema.DecimalType:
+		toT := toT.(*schema.DecimalType)
+		changed = fromT.T != toT.T || fromT.Scale != toT.Scale || fromT.Precision != toT.Precision
 	case *EnumType:
 		toT := toT.(*schema.EnumType)
 		changed = fromT.T != toT.T || !sqlx.ValuesEqual(fromT.Values, toT.Values)
+	case *schema.FloatType:
+		toT := toT.(*schema.FloatType)
+		changed = fromT.T != toT.T || fromT.Precision != toT.Precision
 	case *schema.IntegerType:
 		toT := toT.(*schema.IntegerType)
 		// Unsigned integers are not supported.
@@ -149,6 +155,9 @@ func (d *diff) typeChanged(from, to *schema.Column) (bool, error) {
 	case *SerialType:
 		toT := toT.(*SerialType)
 		changed = fromT.T != toT.T || fromT.Precision != toT.Precision
+	case *schema.StringType:
+		toT := toT.(*schema.StringType)
+		changed = fromT.T != toT.T || fromT.Size != toT.Size
 	case *BitType:
 		toT := toT.(*BitType)
 		changed = fromT.T != toT.T || fromT.Len != toT.Len


### PR DESCRIPTION
Also, removed column-level collation/charset diffing, and will
add it back after v0.1