### PR TITLE
schema/schemaspec/schemahcl: support nested blocks in references

### DIFF
--- a/schema/schemaspec/schemahcl/context.go
+++ b/schema/schemaspec/schemahcl/context.go
@@ -24,9 +24,6 @@ import (
 //		title = "{greeting.hebrew.word}, world!"
 //	}
 //
-// This currently only works for the top level blocks, nested blocks and their
-// attributes are not loaded into the eval context.
-// TODO(rotemtam): support nested blocks.
 func evalCtx(f *hcl.File) (*hcl.EvalContext, error) {
 	c := &container{}
 	if diag := gohcl.DecodeBody(f.Body, &hcl.EvalContext{}, c); diag.HasErrors() {
@@ -36,13 +33,22 @@ func evalCtx(f *hcl.File) (*hcl.EvalContext, error) {
 	if !ok {
 		return nil, fmt.Errorf("schemahcl: expected an hcl body")
 	}
-	types, err := extractTypes(b)
+	varMap, err := blockVarMap(b)
+	if err != nil {
+		return nil, err
+	}
+	out := &hcl.EvalContext{
+		Variables: varMap,
+	}
+	return out, nil
+}
+
+func blockVarMap(b *hclsyntax.Body) (map[string]cty.Value, error) {
+	types, err := typeDefs(b)
 	if err != nil {
 		return nil, fmt.Errorf("schemahcl: failed extracting type definitions: %w", err)
 	}
-	out := &hcl.EvalContext{
-		Variables: make(map[string]cty.Value),
-	}
+	out := make(map[string]cty.Value)
 	for n, typ := range types {
 		v := make(map[string]cty.Value)
 		for _, blk := range blocksOfType(b.Blocks, n) {
@@ -57,9 +63,19 @@ func evalCtx(f *hcl.File) (*hcl.EvalContext, error) {
 					attrs[n] = cty.NullVal(t)
 				}
 			}
+			varMap, err := blockVarMap(blk.Body)
+			if err != nil {
+				return nil, err
+			}
+			// Merge children blocks in.
+			for k, v := range varMap {
+				attrs[k] = v
+			}
 			v[name] = cty.ObjectVal(attrs)
 		}
-		out.Variables[n] = cty.MapVal(v)
+		if len(v) > 0 {
+			out[n] = cty.MapVal(v)
+		}
 	}
 	return out, nil
 }
@@ -93,11 +109,23 @@ func attrMap(attrs hclsyntax.Attributes) map[string]cty.Value {
 	return out
 }
 
-// extractTypes returns a map of block types in the document. Types are computed
+func typeDefs(b *hclsyntax.Body) (map[string]cty.Type, error) {
+	types, err := extractTypes(b)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]cty.Type)
+	for k, v := range types {
+		out[k] = cty.Object(v)
+	}
+	return out, nil
+}
+
+// extractTypes returns a map of block types a block. Types are computed
 // as an intersection fields in all instances. If conflicting field types are encountered
 // an error is returned.
 // TODO(rotemtam): type definitions should be fed into the hcl parser from the plugin system.
-func extractTypes(b *hclsyntax.Body) (map[string]cty.Type, error) {
+func extractTypes(b *hclsyntax.Body) (map[string]map[string]cty.Type, error) {
 	types := make(map[string]map[string]cty.Type)
 	for _, blk := range b.Blocks {
 		attrTypes := extractAttrTypes(&hcl.EvalContext{}, blk)
@@ -109,11 +137,7 @@ func extractTypes(b *hclsyntax.Body) (map[string]cty.Type, error) {
 			return nil, err
 		}
 	}
-	out := make(map[string]cty.Type)
-	for k, v := range types {
-		out[k] = cty.Object(v)
-	}
-	return out, nil
+	return types, nil
 }
 
 func mergeAttrTypes(target, other map[string]cty.Type) error {

--- a/schema/schemaspec/schemahcl/context_test.go
+++ b/schema/schemaspec/schemahcl/context_test.go
@@ -60,3 +60,28 @@ config "defaults" {
 	require.NoError(t, err)
 	require.EqualValues(t, "default: generic", interpolated)
 }
+
+func TestNestedReferences(t *testing.T) {
+	f := `
+country "israel" {
+	city "tel_aviv" {
+		phone_area_code = "03"
+	}
+	city "jerusalem" {
+		phone_area_code = "02"
+	}
+	city "givatayim" {
+		phone_area_code = country.israel.city.tel_aviv.phone_area_code
+	}
+}
+`
+	res, err := decode([]byte(f))
+	require.NoError(t, err)
+	israel := res.Children[0]
+	givatyaim := israel.Children[2]
+	attr, ok := givatyaim.Attr("phone_area_code")
+	require.True(t, ok)
+	s, err := attr.String()
+	require.NoError(t, err)
+	require.EqualValues(t, "03", s)
+}

--- a/schema/schemaspec/schemahcl/hcl_test.go
+++ b/schema/schemaspec/schemahcl/hcl_test.go
@@ -44,9 +44,18 @@ arr = ["yada", "yada", "yada"]
 	require.EqualValues(t, []string{"yada", "yada", "yada"}, arr)
 }
 
-func TestResource(t *testing.T) {
+func TestResourceNameValid(t *testing.T) {
 	f := `
 endpoint "/hello" {
+}
+`
+	_, err := decode([]byte(f))
+	require.EqualError(t, err, "schemahcl: resource names must contain only alphanumeric characters or underscores")
+}
+
+func TestResource(t *testing.T) {
+	f := `
+endpoint "hello" {
 	handler {
 		active = true
 		addr = ":8080"
@@ -59,8 +68,9 @@ endpoint "/hello" {
 	require.NoError(t, err)
 	require.Len(t, resource.Children, 1)
 	expected := &schemaspec.Resource{
-		Name: "/hello",
+		Name: "hello",
 		Type: "endpoint",
+		Addr: "/endpoint/hello",
 		Children: []*schemaspec.Resource{
 			{
 				Type: "handler",

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -10,6 +10,7 @@ type (
 	Resource struct {
 		Name     string
 		Type     string
+		Addr     string
 		Attrs    []*Attr
 		Children []*Resource
 	}
@@ -33,6 +34,11 @@ type (
 	// ListValue implements Value and represents a list of literal value (string, number, etc.)
 	ListValue struct {
 		V []string
+	}
+
+	// Ref is a reference to another Resource.
+	Ref struct {
+		Addr string
 	}
 )
 


### PR DESCRIPTION
This PR adds support for referncing attributes from nested blocks from within HCL documents.

For example, referencing a sub-block's attribute within the same block.


```hcl
country "israel" {
	city "tel_aviv" {
		phone_area_code = "03"
	}
	city "jerusalem" {
		phone_area_code = "02"
	}
	city "givatayim" {
		phone_area_code = country.israel.city.tel_aviv.phone_area_code
	}
}
```