### PR TITLE
support different cty.Type for same field in HCL (needed for default exprs)

### DIFF
--- a/internal/integration/hclsqlspec/hclsqlspec_test.go
+++ b/internal/integration/hclsqlspec/hclsqlspec_test.go
@@ -21,12 +21,12 @@ table "users" {
 	column "id" {
 		type = "uint"
 		null = false
-		default = 123
+		default = expr(123)
 	}
-	column "age" {
-		type = "int"
+	column "active" {
+		type = "boolean"
 		null = false
-		default = 10
+		default = expr(true)
 	}
 }
 `)
@@ -47,10 +47,10 @@ table "users" {
 						Default:  &schemaspec.LiteralValue{V: "123"},
 					},
 					{
-						Name:     "age",
-						TypeName: "int",
+						Name:     "active",
+						TypeName: "boolean",
 						Null:     false,
-						Default:  &schemaspec.LiteralValue{V: "10"},
+						Default:  &schemaspec.LiteralValue{V: "true"},
 					},
 				},
 			},

--- a/schema/schemaspec/schemahcl/context_test.go
+++ b/schema/schemaspec/schemahcl/context_test.go
@@ -105,3 +105,18 @@ pet "garfield" {
 	require.NoError(t, err)
 	require.EqualValues(t, "/person/jon", ref)
 }
+
+func TestExpr(t *testing.T) {
+	f := `
+i = expr(1)
+b = expr(true)
+s = expr("xyz")
+`
+	res, err := Decode([]byte(f))
+	require.NoError(t, err)
+	attr, ok := res.Attr("i")
+	require.True(t, ok)
+	i, err := attr.Int()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, i)
+}

--- a/schema/schemaspec/schemahcl/hcl.go
+++ b/schema/schemaspec/schemahcl/hcl.go
@@ -74,6 +74,8 @@ func toAttrs(ctx *hcl.EvalContext, hclAttrs hclsyntax.Attributes) ([]*schemaspec
 		switch {
 		case isRef(value):
 			at.V = &schemaspec.Ref{V: value.GetAttr("__ref").AsString()}
+		case isExpr(value):
+			at.V = &schemaspec.LiteralValue{V: value.GetAttr("__expr").AsString()}
 		case value.Type().IsTupleType():
 			at.V, err = extractListValue(value)
 		default:
@@ -93,6 +95,10 @@ func toAttrs(ctx *hcl.EvalContext, hclAttrs hclsyntax.Attributes) ([]*schemaspec
 
 func isRef(v cty.Value) bool {
 	return v.Type().IsObjectType() && v.Type().HasAttribute("__ref")
+}
+
+func isExpr(v cty.Value) bool {
+	return v.Type().IsObjectType() && v.Type().HasAttribute("__expr")
 }
 
 func extractListValue(value cty.Value) (*schemaspec.ListValue, error) {


### PR DESCRIPTION
Suppose you have an extension `Column` with a field `Default` that can hold a `schemaspec.LiteralValue` (it can be of any type depending on the type the Column represents:

```go
type Column struct {
  Default *schemaspec.LiteralValue `spec:"default"`
}
```
This means in HCL it can be represented as:
```hcl
column {
  default = true
}
// OR
column {
   default = "hello"
}
```
HCL is fine with that. The problem is when we do the first pass through the HCL document and analyze the different Resource schemas (this is needed to support block and attribute reference expressions i.e `table.users.column.default`), we build a data structure that we pass into the HCL decoder that represents the document, HCL has the expectation that map values are of the same type and that is broken when a field of a "dynamic" type (such as `default` exists). 

To protect against this crash we check for this case and return:
```
schemahcl: failed extracting type definitions: schemahcl: field "default" must have a constant type. "cty.Number"!="cty.Bool"
```

To circumvent that, this PR adds a new function to our HCL dialect: `expr`. This function can take input of any type and wrap it in an object such as:

```go
cty.ObjectVal(map[string]cty.String{
  "__expr": "string representation of the expr"
})
```

Thus users, when needing to express a "literal" value can do:
```hcl
column {
  default = expr(true)
}
// AND
column {
   default = expr("hello")
}
```