### PR TITLE
sql/mysql: mysql schema to schemaspec - primary key

### DIFF
--- a/sql/mysql/convert.go
+++ b/sql/mysql/convert.go
@@ -288,7 +288,7 @@ func (d *Driver) SchemaSpec(schem *schema.Schema) (*schemaspec.Schema, []*schema
 
 // TableSpec converts from a concrete MySQL schemaspec.Table to a schema.Table.
 func (d *Driver) TableSpec(tab *schema.Table) (*schemaspec.Table, error) {
-	return schemautil.TableSpec(tab, d.ColumnSpec)
+	return schemautil.TableSpec(tab, d.ColumnSpec, d.PrimaryKeySpec)
 }
 
 // ColumnSpec converts from a concrete MySQL schema.Column into a schemaspec.Column.
@@ -305,6 +305,11 @@ func (d *Driver) ColumnSpec(col *schema.Column) (*schemaspec.Column, error) {
 			Attrs: ct.Attrs,
 		},
 	}, nil
+}
+
+// PrimaryKeySpec converts from a concrete MySQL schema.Index into a schemaspec.PrimaryKey.
+func (d *Driver) PrimaryKeySpec(idx *schema.Index) (*schemaspec.PrimaryKey, error) {
+	return schemautil.PrimaryKeySpec(idx)
 }
 
 // columnTypeSpec converts from a concrete MySQL schema.Type into schemaspec.Column Type.

--- a/sql/mysql/convert_test.go
+++ b/sql/mysql/convert_test.go
@@ -188,6 +188,9 @@ func TestSchemaSpec(t *testing.T) {
 					},
 				},
 			},
+			PrimaryKey: &schemaspec.PrimaryKey{
+				Columns: []*schemaspec.ColumnRef{{Table: "table", Name: "col"}},
+			},
 		},
 		{
 			Name: "accounts",
@@ -265,6 +268,12 @@ func TestSchemaSpec(t *testing.T) {
 					Spec: tables[1].Columns[0],
 				},
 			},
+		},
+	}
+	exp.Tables[0].PrimaryKey = &schema.Index{
+		Table: exp.Tables[0],
+		Parts: []*schema.IndexPart{
+			{SeqNo: 0, C: exp.Tables[0].Columns[0]},
 		},
 	}
 	require.EqualValues(t, exp, sch)


### PR DESCRIPTION
- convert mysql spec to schemaspec Primary Key.
