### PR TITLE
schema/schemaspec/schemahcl: support attributes that are lists of refs

### DIFF
--- a/schema/schemaspec/schemahcl/context_test.go
+++ b/schema/schemaspec/schemahcl/context_test.go
@@ -3,6 +3,7 @@ package schemahcl
 import (
 	"testing"
 
+	"ariga.io/atlas/schema/schemaspec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -104,4 +105,35 @@ pet "garfield" {
 	ref, err := attr.Ref()
 	require.NoError(t, err)
 	require.EqualValues(t, "$person.jon", ref)
+}
+
+func TestListRefs(t *testing.T) {
+	f := `
+user "simba" {
+	
+}
+user "mufasa" {
+
+}
+group "lion_kings" {
+	members = [
+		user.simba,
+		user.mufasa,
+	]
+}
+`
+	res, err := Decode([]byte(f))
+	require.NoError(t, err)
+	group := res.Children[2]
+	members, ok := group.Attr("members")
+	require.True(t, ok)
+	require.EqualValues(t,
+		&schemaspec.ListValue{
+			V: []schemaspec.Value{
+				&schemaspec.Ref{V: "$user.simba"},
+				&schemaspec.Ref{V: "$user.mufasa"},
+			},
+		},
+		members.V,
+	)
 }

--- a/schema/schemaspec/schemahcl/hcl.go
+++ b/schema/schemaspec/schemahcl/hcl.go
@@ -100,6 +100,10 @@ func extractListValue(value cty.Value) (*schemaspec.ListValue, error) {
 	it := value.ElementIterator()
 	for it.Next() {
 		_, v := it.Element()
+		if isRef(v) {
+			lst.V = append(lst.V, &schemaspec.Ref{V: v.GetAttr("__ref").AsString()})
+			continue
+		}
 		litv, err := extractLiteralValue(v)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
stacked on #161 
adds support for attributes that are lists of references to blocks:

```hcl
user "simba" {
	
}
user "mufasa" {
}
group "lion_kings" {
	members = [
		user.simba,
		user.mufasa,
	]
}
```