### PR TITLE
schema/schemaspec: add File type

### DIFF
--- a/internal/integration/hclsqlspec/hclsqlspec_test.go
+++ b/internal/integration/hclsqlspec/hclsqlspec_test.go
@@ -315,7 +315,8 @@ table "accounts" {
 }
 
 func decode(f string) (*db, error) {
-	res, err := schemahcl.Decode([]byte(f))
+	codec := schemahcl.New()
+	res, err := codec.Decode([]byte(f))
 	if err != nil {
 		return nil, err
 	}

--- a/schema/schemaspec/schemahcl/codec.go
+++ b/schema/schemaspec/schemahcl/codec.go
@@ -11,17 +11,17 @@ func New() *Codec {
 	return &Codec{}
 }
 
-// Encode implements schemaspec.Encoder.
+// encode implements schemaspec.Encoder.
 func (*Codec) Encode(f *schemaspec.File) ([]byte, error) {
-	return Encode(&schemaspec.Resource{
+	return encode(&schemaspec.Resource{
 		Attrs:    f.Attrs,
 		Children: f.Resources,
 	})
 }
 
-// Decode implements schemaspec.Decoder.
+// decode implements schemaspec.Decoder.
 func (*Codec) Decode(body []byte) (*schemaspec.File, error) {
-	r, err := Decode(body)
+	r, err := decode(body)
 	if err != nil {
 		return nil, err
 	}

--- a/schema/schemaspec/schemahcl/codec.go
+++ b/schema/schemaspec/schemahcl/codec.go
@@ -1,0 +1,32 @@
+package schemahcl
+
+import "ariga.io/atlas/schema/schemaspec"
+
+// Codec implements schemaspec.Codec for Atlas HCL files.
+type Codec struct {
+}
+
+// New returns a new Codec.
+func New() *Codec {
+	return &Codec{}
+}
+
+// Encode implements schemaspec.Encoder.
+func (*Codec) Encode(f *schemaspec.File) ([]byte, error) {
+	return Encode(&schemaspec.Resource{
+		Attrs:    f.Attrs,
+		Children: f.Resources,
+	})
+}
+
+// Decode implements schemaspec.Decoder.
+func (*Codec) Decode(body []byte) (*schemaspec.File, error) {
+	r, err := Decode(body)
+	if err != nil {
+		return nil, err
+	}
+	return &schemaspec.File{
+		Attrs:     r.Attrs,
+		Resources: r.Children,
+	}, nil
+}

--- a/schema/schemaspec/schemahcl/context_test.go
+++ b/schema/schemaspec/schemahcl/context_test.go
@@ -34,9 +34,13 @@ config "defaults" {
 	description = "generic"
 }
 `
-	res, err := Decode([]byte(f))
+	codec := New()
+	file, err := codec.Decode([]byte(f))
 	require.NoError(t, err)
-	home := res.Children[2]
+
+	home, ok := file.Find("endpoint").Named("home")
+	require.True(t, ok)
+
 	attr, ok := home.Attr("addr")
 	require.True(t, ok)
 	s, err := attr.String()
@@ -76,12 +80,17 @@ country "israel" {
 	}
 }
 `
-	res, err := Decode([]byte(f))
+	codec := New()
+	res, err := codec.Decode([]byte(f))
 	require.NoError(t, err)
-	israel := res.Children[0]
+
+	israel, ok := res.Find("country").Named("israel")
+	require.True(t, ok)
+
 	givatyaim := israel.Children[2]
 	attr, ok := givatyaim.Attr("phone_area_code")
 	require.True(t, ok)
+
 	s, err := attr.String()
 	require.NoError(t, err)
 	require.EqualValues(t, "03", s)
@@ -97,9 +106,13 @@ pet "garfield" {
 	owner = person.jon
 }
 `
-	res, err := Decode([]byte(f))
+	codec := New()
+	file, err := codec.Decode([]byte(f))
 	require.NoError(t, err)
-	garfield := res.Children[1]
+
+	garfield, ok := file.Find("pet").Named("garfield")
+	require.True(t, ok)
+
 	attr, ok := garfield.Attr("owner")
 	require.True(t, ok)
 	ref, err := attr.Ref()
@@ -122,9 +135,12 @@ group "lion_kings" {
 	]
 }
 `
-	res, err := Decode([]byte(f))
+	codec := New()
+	file, err := codec.Decode([]byte(f))
 	require.NoError(t, err)
-	group := res.Children[2]
+	group, ok := file.Find("group").Named("lion_kings")
+	require.True(t, ok)
+
 	members, ok := group.Attr("members")
 	require.True(t, ok)
 	require.EqualValues(t,
@@ -156,6 +172,7 @@ person "jane" {
 	}
 }
 `
-	_, err := Decode([]byte(f))
+	codec := New()
+	_, err := codec.Decode([]byte(f))
 	require.NoError(t, err)
 }

--- a/schema/schemaspec/schemahcl/hcl.go
+++ b/schema/schemaspec/schemahcl/hcl.go
@@ -21,8 +21,8 @@ type container struct {
 	Body hcl.Body `hcl:",remain"`
 }
 
-// Decode decodes the input Atlas HCL document and returns a *schemaspec.Resource representing it.
-func Decode(body []byte) (*schemaspec.Resource, error) {
+// decode decodes the input Atlas HCL document and returns a *schemaspec.Resource representing it.
+func decode(body []byte) (*schemaspec.Resource, error) {
 	parser := hclparse.NewParser()
 	srcHCL, diag := parser.ParseHCL(body, "")
 	if diag.HasErrors() {
@@ -154,9 +154,9 @@ func toResource(ctx *hcl.EvalContext, block *hclsyntax.Block) (*schemaspec.Resou
 	return spec, nil
 }
 
-// Encode encodes the give *schemaspec.Resource into a byte slice containing an Atlas HCL
+// encode encodes the give *schemaspec.Resource into a byte slice containing an Atlas HCL
 // document representing it.
-func Encode(r *schemaspec.Resource) ([]byte, error) {
+func encode(r *schemaspec.Resource) ([]byte, error) {
 	f := hclwrite.NewFile()
 	body := f.Body()
 	for _, attr := range r.Attrs {

--- a/schema/schemaspec/schemahcl/hcl_test.go
+++ b/schema/schemaspec/schemahcl/hcl_test.go
@@ -15,7 +15,7 @@ b = true
 s = "hello, world"
 arr = ["yada", "yada", "yada"]
 `
-	resource, err := Decode([]byte(f))
+	resource, err := decode([]byte(f))
 	require.NoError(t, err)
 	require.Len(t, resource.Attrs, 4)
 
@@ -55,7 +55,7 @@ endpoint "/hello" {
 	timeout_ms = 100
 }
 `
-	resource, err := Decode([]byte(f))
+	resource, err := decode([]byte(f))
 	require.NoError(t, err)
 	require.Len(t, resource.Children, 1)
 	expected := &schemaspec.Resource{
@@ -113,11 +113,11 @@ task "code" {
 	}
 	for _, tt := range testCases {
 		t.Run(tt.Name, func(t *testing.T) {
-			resource, err := Decode([]byte(tt.Body))
+			resource, err := decode([]byte(tt.Body))
 			require.NoError(t, err)
-			bytes, err := Encode(resource)
+			bytes, err := encode(resource)
 			require.NoError(t, err)
-			again, err := Decode(bytes)
+			again, err := decode(bytes)
 			require.NoError(t, err)
 			require.EqualValues(t, resource, again, "expected resource to be the same after encoding")
 		})

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -63,7 +63,7 @@ type (
 		Decode([]byte) (*File, error)
 	}
 
-	// Codec is the interfae that groups Encoder and Deccoder.
+	// Codec is the interfae that groups Encoder and Decoder.
 	Codec interface {
 		Encoder
 		Decoder


### PR DESCRIPTION
This PR:

1. Add to the schemaspec package a new File type that represents a complete document.
2. Add to the schemaspec package Encoder, Decoder, and Codec interfaces.
```go
type Encoder interface {
  Encode(*schemaspec.File) ([]byte, error)
}
type Decoder interface {
  Decode([]byte) (*schemaspec.File, error)
}
type Codec interface {
  Encoder
  Decoder
}
```
3. Modify schemahcl to use the new interfaces.
