### PR TITLE
schema/schemaspec/schemahcl: support Marshal

### DIFF
--- a/schema/schemaspec/extension.go
+++ b/schema/schemaspec/extension.go
@@ -285,8 +285,7 @@ func scanPtr(key string, r *Resource, field reflect.Value) error {
 	case reflect.TypeOf(LiteralValue{}):
 		attr.V = &LiteralValue{V: field.Elem().FieldByName("V").String()}
 	case reflect.TypeOf(Ref{}):
-		v := field.Elem().FieldByName("V").String()
-		attr.V = &Ref{V: v}
+		attr.V = &Ref{V: field.Elem().FieldByName("V").String()}
 	default:
 		return fmt.Errorf("schemaspec: unsupported pointer to %s", field.Elem().String())
 	}

--- a/schema/schemaspec/extension.go
+++ b/schema/schemaspec/extension.go
@@ -281,13 +281,13 @@ func (r *Resource) Scan(ext interface{}) error {
 
 func scanPtr(key string, r *Resource, field reflect.Value) error {
 	attr := &Attr{K: key}
-	switch field.Elem().Type() {
+	switch e := field.Elem(); e.Type() {
 	case reflect.TypeOf(LiteralValue{}):
-		attr.V = &LiteralValue{V: field.Elem().FieldByName("V").String()}
+		attr.V = &LiteralValue{V: e.FieldByName("V").String()}
 	case reflect.TypeOf(Ref{}):
-		attr.V = &Ref{V: field.Elem().FieldByName("V").String()}
+		attr.V = &Ref{V: e.FieldByName("V").String()}
 	default:
-		return fmt.Errorf("schemaspec: unsupported pointer to %s", field.Elem().String())
+		return fmt.Errorf("schemaspec: unsupported pointer to %s", e)
 	}
 	r.SetAttr(attr)
 	return nil

--- a/schema/schemaspec/extension.go
+++ b/schema/schemaspec/extension.go
@@ -258,14 +258,9 @@ func (r *Resource) Scan(ext interface{}) error {
 			if field.IsNil() {
 				continue
 			}
-			if field.Elem().Type() != reflect.TypeOf(LiteralValue{}) {
-				return fmt.Errorf("schemaspec: pointer to non LiteralValue")
+			if err := scanPtr(ft.tag, r, field); err != nil {
+				return err
 			}
-			v := field.Elem().FieldByName("V").String()
-			r.SetAttr(&Attr{
-				K: ft.tag,
-				V: &LiteralValue{V: v},
-			})
 		default:
 			if err := scanAttr(ft.tag, r, field); err != nil {
 				return err
@@ -281,6 +276,21 @@ func (r *Resource) Scan(ext interface{}) error {
 		r.SetAttr(attr)
 	}
 	r.Children = append(r.Children, extra.Children...)
+	return nil
+}
+
+func scanPtr(key string, r *Resource, field reflect.Value) error {
+	attr := &Attr{K: key}
+	switch field.Elem().Type() {
+	case reflect.TypeOf(LiteralValue{}):
+		attr.V = &LiteralValue{V: field.Elem().FieldByName("V").String()}
+	case reflect.TypeOf(Ref{}):
+		v := field.Elem().FieldByName("V").String()
+		attr.V = &Ref{V: v}
+	default:
+		return fmt.Errorf("schemaspec: unsupported pointer to %s", field.Elem().String())
+	}
+	r.SetAttr(attr)
 	return nil
 }
 

--- a/schema/schemaspec/extension_test.go
+++ b/schema/schemaspec/extension_test.go
@@ -127,6 +127,32 @@ func TestNested(t *testing.T) {
 	require.EqualValues(t, pet, scan)
 }
 
+func TestRef(t *testing.T) {
+	type A struct {
+		Name string          `spec:",name"`
+		User *schemaspec.Ref `spec:"user"`
+	}
+	schemaspec.Register("res", &A{})
+	resource := &schemaspec.Resource{
+		Name: "x",
+		Type: "res",
+		Attrs: []*schemaspec.Attr{
+			{
+				K: "user",
+				V: &schemaspec.Ref{V: "$user.rotemtam"},
+			},
+		},
+	}
+	tgt := A{}
+	err := resource.As(&tgt)
+	require.NoError(t, err)
+	require.EqualValues(t, &schemaspec.Ref{V: "$user.rotemtam"}, tgt.User)
+	scan := &schemaspec.Resource{}
+	err = scan.Scan(&tgt)
+	require.NoError(t, err)
+	require.EqualValues(t, resource, scan)
+}
+
 func TestListRef(t *testing.T) {
 	type A struct {
 		Name  string            `spec:",name"`

--- a/schema/schemaspec/schemahcl/hcl_test.go
+++ b/schema/schemaspec/schemahcl/hcl_test.go
@@ -66,7 +66,7 @@ func TestResource(t *testing.T) {
 		},
 	}
 	require.EqualValues(t, expected, test.Endpoints[0])
-	marshal, err := Marshal(&test)
+	buf, err := Marshal(&test)
 	require.NoError(t, err)
-	require.EqualValues(t, f, string(marshal))
+	require.EqualValues(t, f, string(buf))
 }

--- a/schema/schemaspec/schemahcl/hcl_test.go
+++ b/schema/schemaspec/schemahcl/hcl_test.go
@@ -7,8 +7,7 @@ import (
 )
 
 func TestAttributes(t *testing.T) {
-	f := `
-i = 1
+	f := `i = 1
 b = true
 s = "hello, world"
 `
@@ -22,17 +21,19 @@ s = "hello, world"
 	require.EqualValues(t, 1, test.Int)
 	require.EqualValues(t, true, test.Bool)
 	require.EqualValues(t, "hello, world", test.Str)
+	marshal, err := Marshal(&test)
+	require.NoError(t, err)
+	require.EqualValues(t, f, string(marshal))
 }
 
 func TestResource(t *testing.T) {
-	f := `
-endpoint "/hello" {
-	handler {
-		active = true
-		addr = ":8080"
-	}
-	description = "the hello handler"
-	timeout_ms = 100
+	f := `endpoint "/hello" {
+  description = "the hello handler"
+  timeout_ms  = 100
+  handler {
+    active = true
+    addr   = ":8080"
+  }
 }
 `
 	type (
@@ -65,50 +66,7 @@ endpoint "/hello" {
 		},
 	}
 	require.EqualValues(t, expected, test.Endpoints[0])
-}
-
-func TestReEncode(t *testing.T) {
-	testCases := []struct {
-		Name, Body string
-	}{
-		{
-			Name: "attr",
-			Body: `year = 2021`,
-		},
-		{
-			Name: "simple resource",
-			Body: `project "atlas" {
-	started_year = 2021
-	useful = true
-}`,
-		},
-		{
-			Name: "nested resource",
-			Body: `author "rotemtam" {
-	package "schemahcl" {
-		lang = "go"
-	}
-}`,
-		},
-		{
-			Name: "block reference",
-			Body: `user "rotemtam" {
-}
-task "code" {
-	owner = user.rotemtam
-}
-`,
-		},
-	}
-	for _, tt := range testCases {
-		t.Run(tt.Name, func(t *testing.T) {
-			resource, err := decode([]byte(tt.Body))
-			require.NoError(t, err)
-			bytes, err := Encode(resource)
-			require.NoError(t, err)
-			again, err := decode(bytes)
-			require.NoError(t, err)
-			require.EqualValues(t, resource, again, "expected resource to be the same after encoding")
-		})
-	}
+	marshal, err := Marshal(&test)
+	require.NoError(t, err)
+	require.EqualValues(t, f, string(marshal))
 }


### PR DESCRIPTION
also fixing a big in schemaspec.Resource `Scan` where *Ref fields were not properly supported. 