### PR TITLE
sql/internal/specutil: fix bug in Index method

### DIFF
--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -107,7 +107,10 @@ func Column(spec *sqlspec.Column, conv ConvertTypeFunc) (*schema.Column, error) 
 func Index(spec *sqlspec.Index, parent *schema.Table) (*schema.Index, error) {
 	parts := make([]*schema.IndexPart, 0, len(spec.Columns))
 	for seqno, c := range spec.Columns {
-		cn := c.V
+		cn, err := columnName(c)
+		if err != nil {
+			return nil, fmt.Errorf("specutil: failed converting column to index: %w", err)
+		}
 		col, ok := parent.Column(cn)
 		if !ok {
 			return nil, fmt.Errorf("sqlspec: unknown column %q in table %q", cn, parent.Name)

--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -113,7 +113,7 @@ func Index(spec *sqlspec.Index, parent *schema.Table) (*schema.Index, error) {
 		}
 		col, ok := parent.Column(cn)
 		if !ok {
-			return nil, fmt.Errorf("sqlspec: unknown column %q in table %q", cn, parent.Name)
+			return nil, fmt.Errorf("specutil: unknown column %q in table %q", cn, parent.Name)
 		}
 		parts = append(parts, &schema.IndexPart{
 			SeqNo: seqno,


### PR DESCRIPTION
a bug existed in specutil.Index existed where the method would look for the referenced column literally instead of unpacking the table and column names from the ref address. 