### PR TITLE
schema/schemaspec: add the Attr method to DefaultExtension

### DIFF
--- a/schema/schemaspec/extension.go
+++ b/schema/schemaspec/extension.go
@@ -30,6 +30,10 @@ func (d *DefaultExtension) Remain() *Resource {
 	return &d.Extra
 }
 
+func (d *DefaultExtension) Attr(name string) (*Attr, bool) {
+	return d.Extra.Attr(name)
+}
+
 type registry map[string]interface{}
 
 var (


### PR DESCRIPTION
needed later to lookup attributes on sqlspec.Column.