### PR TITLE
Feat/hcl anon block

### DIFF
--- a/schema/schemaspec/schemahcl/context.go
+++ b/schema/schemaspec/schemahcl/context.go
@@ -54,12 +54,12 @@ func blockVars(b *hclsyntax.Body, parentAddr string, defs *blockDef) (map[string
 		if len(blocks) == 0 {
 			v[name] = cty.NullVal(def.asCty())
 		}
-		var anonCounter int
+		var unlabeled int
 		for _, blk := range blocks {
 			blkName := blockName(blk)
 			if blkName == "" {
-				blkName = strconv.Itoa(anonCounter)
-				anonCounter++
+				blkName = strconv.Itoa(unlabeled)
+				unlabeled++
 			}
 			attrs := attrMap(blk.Body.Attributes)
 			// Fill missing attributes with zero values.

--- a/schema/schemaspec/schemahcl/context_test.go
+++ b/schema/schemaspec/schemahcl/context_test.go
@@ -99,20 +99,32 @@ continent = country.israel.metadata.geo.continent
 		Country struct {
 			Metadata []*Metadata `spec:"metadata"`
 		}
+		Test struct {
+			Countries    []*Country      `spec:"country"`
+			MetadataRef  *schemaspec.Ref `spec:"metadata"`
+			PhonePrefix  string          `spec:"phone_prefix"`
+			PhonePrefix2 string          `spec:"phone_prefix_2"`
+			Continent    string          `spec:"continent"`
+		}
 	)
-	var test struct {
-		Countries    []*Country      `spec:"country"`
-		MetadataRef  *schemaspec.Ref `spec:"metadata"`
-		PhonePrefix  string          `spec:"phone_prefix"`
-		PhonePrefix2 string          `spec:"phone_prefix_2"`
-		Continent    string          `spec:"continent"`
-	}
+	var test Test
 	err := Unmarshal([]byte(f), &test)
 	require.NoError(t, err)
-	require.EqualValues(t, "972", test.PhonePrefix)
-	require.EqualValues(t, "123", test.PhonePrefix2)
-	require.EqualValues(t, "asia", test.Continent)
-	require.EqualValues(t, "$country.israel.$metadata.0", test.MetadataRef.V)
+	require.EqualValues(t, test, Test{
+		Countries: []*Country{
+			{
+				Metadata: []*Metadata{
+					{PhonePrefix: "972"},
+					{PhonePrefix: "123"},
+					{Continent: "asia"},
+				},
+			},
+		},
+		MetadataRef:  &schemaspec.Ref{V: "$country.israel.$metadata.0"},
+		PhonePrefix:  "972",
+		PhonePrefix2: "123",
+		Continent:    "asia",
+	})
 }
 
 func TestNestedReferences(t *testing.T) {


### PR DESCRIPTION
this PR adds support for anonymous blocks in Atlas HCL. 

Suppose a block such as:
```hcl
country "israel" {
    metadata {
        phone_prefix = "972"
    }
    metadata "geo" {
		continent = "asia"
    }
}
```

Now the anonymous blocks can be referred to using:
```hcl
metadata  = country.israel.metadata.0 // reference to the block
phone_prefix = country.israel.metadata.0.phone_prefix // reference to an attribute of the block
```