### PR TITLE
schema/schemaspec: bool attribute helpers

### DIFF
--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -206,7 +206,7 @@ func BoolVal(v Value) (bool, error) {
 	}
 	b, err := strconv.ParseBool(lit.V)
 	if err != nil {
-		return false, fmt.Errorf("failed parsing %q as bool: %w", lit.V, err)
+		return false, fmt.Errorf("schemaspec: failed parsing %q as bool: %w", lit.V, err)
 	}
 	return b, nil
 }

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -106,7 +106,7 @@ func (a *Attr) Ref() (string, error) {
 	return ref.V, nil
 }
 
-// Strings returns a slice of strings from the Value of the Attr. If The value is not a ListValue or the its
+// Strings returns a slice of strings from the Value of the Attr. If The value is not a ListValue or its
 // values cannot be converted to strings an error is returned.
 func (a *Attr) Strings() ([]string, error) {
 	lst, ok := a.V.(*ListValue)
@@ -117,7 +117,25 @@ func (a *Attr) Strings() ([]string, error) {
 	for _, item := range lst.V {
 		sv, err := StrVal(item)
 		if err != nil {
-			return nil, fmt.Errorf("schema: failed parsing item %q to string: %w", item, err)
+			return nil, fmt.Errorf("schemaspec: failed parsing item %q to string: %w", item, err)
+		}
+		out = append(out, sv)
+	}
+	return out, nil
+}
+
+// Bools returns a slice of bools from the Value of the Attr. If The value is not a ListValue or its
+// values cannot be converted to bools an error is returned.
+func (a *Attr) Bools() ([]bool, error) {
+	lst, ok := a.V.(*ListValue)
+	if !ok {
+		return nil, fmt.Errorf("schema: attribute %q is not a list", a.K)
+	}
+	out := make([]bool, 0, len(lst.V))
+	for _, item := range lst.V {
+		sv, err := BoolVal(item)
+		if err != nil {
+			return nil, fmt.Errorf("schemaspec: failed parsing item %q to bool: %w", item, err)
 		}
 		out = append(out, sv)
 	}
@@ -176,6 +194,17 @@ func StrVal(v Value) (string, error) {
 		return "", fmt.Errorf("schemaspec: expected %T to be LiteralValue", v)
 	}
 	return strconv.Unquote(lit.V)
+}
+
+// BoolVal returns the bool representation of v. If v is not a *LiteralValue
+// it returns an error. If the raw string representation of v cannot be read as
+// a bool, an error is returned as well.
+func BoolVal(v Value) (bool, error) {
+	lit, ok := v.(*LiteralValue)
+	if !ok {
+		return false, fmt.Errorf("schemaspec: expected %T to be LiteralValue", v)
+	}
+	return strconv.ParseBool(lit.V)
 }
 
 func (*LiteralValue) val() {}

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -129,7 +129,7 @@ func (a *Attr) Strings() ([]string, error) {
 func (a *Attr) Bools() ([]bool, error) {
 	lst, ok := a.V.(*ListValue)
 	if !ok {
-		return nil, fmt.Errorf("schema: attribute %q is not a list", a.K)
+		return nil, fmt.Errorf("schemaspec: attribute %q is not a list", a.K)
 	}
 	out := make([]bool, 0, len(lst.V))
 	for _, item := range lst.V {

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -135,7 +135,7 @@ func (a *Attr) Bools() ([]bool, error) {
 	for _, item := range lst.V {
 		b, err := BoolVal(item)
 		if err != nil {
-			return nil, fmt.Errorf("schemaspec: failed parsing item %q to bool: %w", item, err)
+			return nil, err
 		}
 		out = append(out, b)
 	}
@@ -204,7 +204,11 @@ func BoolVal(v Value) (bool, error) {
 	if !ok {
 		return false, fmt.Errorf("schemaspec: expected %T to be LiteralValue", v)
 	}
-	return strconv.ParseBool(lit.V)
+	b, err := strconv.ParseBool(lit.V)
+	if err != nil {
+		return false, fmt.Errorf("failed parsing %q as bool: %w", lit.V, err)
+	}
+	return b, nil
 }
 
 func (*LiteralValue) val() {}

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -133,11 +133,11 @@ func (a *Attr) Bools() ([]bool, error) {
 	}
 	out := make([]bool, 0, len(lst.V))
 	for _, item := range lst.V {
-		sv, err := BoolVal(item)
+		b, err := BoolVal(item)
 		if err != nil {
 			return nil, fmt.Errorf("schemaspec: failed parsing item %q to bool: %w", item, err)
 		}
-		out = append(out, sv)
+		out = append(out, b)
 	}
 	return out, nil
 }

--- a/schema/schemaspec/spec_test.go
+++ b/schema/schemaspec/spec_test.go
@@ -1,0 +1,29 @@
+package schemaspec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoolVal(t *testing.T) {
+	b, err := BoolVal(&LiteralValue{V: "true"})
+	require.NoError(t, err)
+	require.True(t, b)
+}
+
+func TestBools(t *testing.T) {
+	a := Attr{
+		K: "b",
+		V: &ListValue{
+			V: []Value{
+				&LiteralValue{V: "true"},
+				&LiteralValue{V: "false"},
+				&LiteralValue{V: "true"},
+			},
+		},
+	}
+	bls, err := a.Bools()
+	require.NoError(t, err)
+	require.EqualValues(t, []bool{true, false, true}, bls)
+}


### PR DESCRIPTION
prep work for supporting slices of literals in schemaspec (currently only *Ref is supported). 