### PR TITLE
cmd/atlas: connect postgres

### DIFF
--- a/cmd/atlas/mux.go
+++ b/cmd/atlas/mux.go
@@ -9,7 +9,6 @@ import (
 	"ariga.io/atlas/schema/schemaspec"
 	"ariga.io/atlas/sql/schema"
 	"github.com/go-sql-driver/mysql"
-	"github.com/jackc/pgconn"
 )
 
 type (
@@ -98,11 +97,7 @@ func schemaNameFromDSN(url string) (string, error) {
 		}
 		return cfg.DBName, err
 	case "postgres":
-		cfg, err := pgconn.ParseConfig(url)
-		if err != nil {
-			return "", err
-		}
-		return cfg.Database, err
+		return "public", nil
 	default:
 		return "", fmt.Errorf("unknown database type: %q", key)
 	}

--- a/cmd/atlas/mux.go
+++ b/cmd/atlas/mux.go
@@ -98,7 +98,7 @@ func schemaNameFromDSN(url string) (string, error) {
 		}
 		return cfg.DBName, err
 	case "postgres":
-		cfg, err := pgconn.ParseConfig(dsn)
+		cfg, err := pgconn.ParseConfig(url)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/atlas/provider.go
+++ b/cmd/atlas/provider.go
@@ -32,7 +32,8 @@ func mysqlProvider(dsn string) (*Driver, error) {
 	}, nil
 }
 func postgresProvider(dsn string) (*Driver, error) {
-	db, err := sql.Open("postgres", dsn)
+	url := "postgres://" + dsn
+	db, err := sql.Open("postgres", url)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- for now there isn't a schema flag.
- the deafult schema in postgres is public.
- fixed a small bug when parsing dsn.
