### PR TITLE
sql/postgres: support marshaling array types in sqlspec

### DIFF
--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -257,12 +257,16 @@ func columnTypeSpec(t schema.Type) (*sqlspec.Column, error) {
 		return &sqlspec.Column{TypeName: t.T}, nil
 	case *schema.UnsupportedType:
 		return &sqlspec.Column{TypeName: t.T}, nil
-	case *NetworkType:
-		return &sqlspec.Column{TypeName: t.T}, nil
-	case *CurrencyType:
+	case *ArrayType:
 		return &sqlspec.Column{TypeName: t.T}, nil
 	case *BitType:
 		return bitSpec(t)
+	case *CurrencyType:
+		return &sqlspec.Column{TypeName: t.T}, nil
+	case *NetworkType:
+		return &sqlspec.Column{TypeName: t.T}, nil
+	case *UUIDType:
+		return &sqlspec.Column{TypeName: t.T}, nil
 	default:
 		return nil, fmt.Errorf("failed to convert column type %T to spec", t)
 	}

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -265,7 +265,11 @@ func columnTypeSpec(t schema.Type) (*sqlspec.Column, error) {
 		return &sqlspec.Column{TypeName: t.T}, nil
 	case *NetworkType:
 		return &sqlspec.Column{TypeName: t.T}, nil
+	case *SerialType:
+		return &sqlspec.Column{TypeName: t.T}, nil
 	case *UUIDType:
+		return &sqlspec.Column{TypeName: t.T}, nil
+	case *XMLType:
 		return &sqlspec.Column{TypeName: t.T}, nil
 	default:
 		return nil, fmt.Errorf("failed to convert column type %T to spec", t)


### PR DESCRIPTION
Note, apply still fails due to some wrong parsing logic in unmarshaling