### PR TITLE
sql/*: decoupling FormatType methods from driver

### DIFF
--- a/sql/mysql/convert.go
+++ b/sql/mysql/convert.go
@@ -13,7 +13,7 @@ import (
 
 // FormatType converts schema type to its column form in the database.
 // An error is returned if the type cannot be recognized.
-func (d *Driver) FormatType(t schema.Type) (string, error) {
+func FormatType(t schema.Type) (string, error) {
 	var f string
 	switch t := t.(type) {
 	case *BitType:
@@ -73,8 +73,8 @@ func (d *Driver) FormatType(t schema.Type) (string, error) {
 }
 
 // mustFormat calls to FormatType and panics in case of error.
-func (d *Driver) mustFormat(t schema.Type) string {
-	s, err := d.FormatType(t)
+func mustFormat(t schema.Type) string {
+	s, err := FormatType(t)
 	if err != nil {
 		panic(err)
 	}

--- a/sql/mysql/diff.go
+++ b/sql/mysql/diff.go
@@ -235,7 +235,7 @@ func (d *diff) typeChanged(from, to *schema.Column) (bool, error) {
 	var changed bool
 	switch fromT := fromT.(type) {
 	case *schema.BinaryType, *schema.BoolType, *schema.DecimalType, *schema.FloatType:
-		changed = d.mustFormat(fromT) != d.mustFormat(toT)
+		changed = mustFormat(fromT) != mustFormat(toT)
 	case *schema.EnumType:
 		toT := toT.(*schema.EnumType)
 		changed = !sqlx.ValuesEqual(fromT.Values, toT.Values)
@@ -261,7 +261,7 @@ func (d *diff) typeChanged(from, to *schema.Column) (bool, error) {
 		toT := toT.(*schema.JSONType)
 		changed = fromT.T != toT.T
 	case *schema.StringType:
-		changed = d.mustFormat(fromT) != d.mustFormat(toT)
+		changed = mustFormat(fromT) != mustFormat(toT)
 	case *schema.SpatialType:
 		toT := toT.(*schema.SpatialType)
 		changed = fromT.T != toT.T

--- a/sql/mysql/migrate.go
+++ b/sql/mysql/migrate.go
@@ -185,7 +185,7 @@ func (m *migrate) alterTable(ctx context.Context, t *schema.Table, changes []sch
 }
 
 func (m *migrate) column(b *sqlx.Builder, t *schema.Table, c *schema.Column) {
-	b.Ident(c.Name).P(m.mustFormat(c.Type.Type))
+	b.Ident(c.Name).P(mustFormat(c.Type.Type))
 	if !c.Type.Null {
 		b.P("NOT")
 	}

--- a/sql/postgres/convert.go
+++ b/sql/postgres/convert.go
@@ -15,7 +15,7 @@ import (
 
 // FormatType converts schema type to its column form in the database.
 // An error is returned if the type cannot be recognized.
-func (d *Driver) FormatType(t schema.Type) (string, error) {
+func FormatType(t schema.Type) (string, error) {
 	var f string
 	switch t := t.(type) {
 	case *ArrayType:
@@ -138,8 +138,8 @@ func (d *Driver) FormatType(t schema.Type) (string, error) {
 }
 
 // mustFormat calls to FormatType and panics in case of error.
-func (d *Driver) mustFormat(t schema.Type) string {
-	s, err := d.FormatType(t)
+func mustFormat(t schema.Type) string {
+	s, err := FormatType(t)
 	if err != nil {
 		panic(err)
 	}

--- a/sql/postgres/diff.go
+++ b/sql/postgres/diff.go
@@ -158,7 +158,7 @@ func (d *diff) typeChanged(from, to *schema.Column) (bool, error) {
 	case *schema.BinaryType, *schema.BoolType, *schema.DecimalType, *schema.FloatType,
 		*schema.IntegerType, *schema.JSONType, *schema.SpatialType, *schema.StringType,
 		*schema.TimeType, *BitType, *SerialType, *NetworkType, *UserDefinedType:
-		changed = d.mustFormat(toT) != d.mustFormat(fromT)
+		changed = mustFormat(toT) != mustFormat(fromT)
 	case *EnumType:
 		toT := toT.(*schema.EnumType)
 		changed = fromT.T != toT.T || !sqlx.ValuesEqual(fromT.Values, toT.Values)

--- a/sql/postgres/migrate.go
+++ b/sql/postgres/migrate.go
@@ -288,7 +288,7 @@ func (m *migrate) addIndexes(ctx context.Context, t *schema.Table, indexes ...*s
 }
 
 func (m *migrate) column(b *sqlx.Builder, c *schema.Column) {
-	b.Ident(c.Name).P(m.mustFormat(c.Type.Type))
+	b.Ident(c.Name).P(mustFormat(c.Type.Type))
 	if !c.Type.Null {
 		b.P("NOT")
 	}
@@ -317,7 +317,7 @@ func (m *migrate) alterColumn(b *sqlx.Builder, c *schema.ModifyColumn) {
 		b.P("ALTER COLUMN").Ident(c.To.Name)
 		switch {
 		case k.Is(schema.ChangeType):
-			b.P("TYPE").P(m.mustFormat(c.To.Type.Type))
+			b.P("TYPE").P(mustFormat(c.To.Type.Type))
 			if collate := (schema.Collation{}); sqlx.Has(c.To.Attrs, &collate) {
 				b.P("COLLATE", collate.V)
 			}

--- a/sql/sqlite/convert.go
+++ b/sql/sqlite/convert.go
@@ -15,7 +15,7 @@ import (
 // This is due to SQLite flexibility to allow any data types
 // and use a set of rules to define the type affinity.
 // See: https://www.sqlite.org/datatype3.html
-func (d *Driver) FormatType(t schema.Type) (string, error) {
+func FormatType(t schema.Type) (string, error) {
 	var f string
 	switch t := t.(type) {
 	case *schema.BoolType:
@@ -49,8 +49,8 @@ func (d *Driver) FormatType(t schema.Type) (string, error) {
 }
 
 // mustFormat calls to FormatType and panics in case of error.
-func (d *Driver) mustFormat(t schema.Type) string {
-	s, err := d.FormatType(t)
+func mustFormat(t schema.Type) string {
+	s, err := FormatType(t)
 	if err != nil {
 		panic(err)
 	}

--- a/sql/sqlite/migrate.go
+++ b/sql/sqlite/migrate.go
@@ -116,7 +116,7 @@ func (m *migrate) modifyTable(ctx context.Context, modify *schema.ModifyTable) e
 }
 
 func (m *migrate) column(b *sqlx.Builder, c *schema.Column) {
-	b.Ident(c.Name).P(m.mustFormat(c.Type.Type))
+	b.Ident(c.Name).P(mustFormat(c.Type.Type))
 	if !c.Type.Null {
 		b.P("NOT")
 	}


### PR DESCRIPTION
Working on the virtual types cleanup, I found myself needing these methods without the context of an active driver. 