### PR TITLE
sql/sqlspec: adding function to print Type as string

### DIFF
--- a/sql/sqlspec/types.go
+++ b/sql/sqlspec/types.go
@@ -1,0 +1,42 @@
+package sqlspec
+
+import (
+	"errors"
+	"strings"
+
+	"ariga.io/atlas/schema/schemaspec"
+)
+
+// PrintType returns the string representation of a column type which can be parsed
+// by the driver into a schema.Type.
+func PrintType(typ *schemaspec.Type, spec *schemaspec.TypeSpec) (string, error) {
+	if len(spec.Attributes) == 0 {
+		return typ.T, nil
+	}
+	var (
+		args        []string
+		mid, suffix string
+	)
+	for _, arg := range typ.Attributes {
+		// TODO(rotemtam): make this part of the TypeSpec
+		if arg.K == "unsigned" {
+			b, err := arg.Bool()
+			if err != nil {
+				return "", err
+			}
+			if b {
+				suffix += " unsigned"
+			}
+			continue
+		}
+		lit, ok := arg.V.(*schemaspec.LiteralValue)
+		if !ok {
+			return "", errors.New("expecting literal value")
+		}
+		args = append(args, lit.V)
+	}
+	if len(args) > 0 {
+		mid = "(" + strings.Join(args, ",") + ")"
+	}
+	return typ.T + mid + suffix, nil
+}

--- a/sql/sqlspec/types_test.go
+++ b/sql/sqlspec/types_test.go
@@ -1,0 +1,54 @@
+package sqlspec_test
+
+import (
+	"reflect"
+	"testing"
+
+	"ariga.io/atlas/schema/schemaspec"
+	"ariga.io/atlas/sql/internal/specutil"
+	"ariga.io/atlas/sql/sqlspec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypePrint(t *testing.T) {
+	intSpec := &schemaspec.TypeSpec{
+		Name: "int",
+		T:    "int",
+		Attributes: []*schemaspec.TypeAttr{
+			{Name: "unsigned", Kind: reflect.Bool, Required: false},
+		},
+	}
+	for _, tt := range []struct {
+		spec     *schemaspec.TypeSpec
+		typ      *schemaspec.Type
+		expected string
+	}{
+		{
+			spec:     intSpec,
+			typ:      &schemaspec.Type{T: "int"},
+			expected: "int",
+		},
+		{
+			spec:     intSpec,
+			typ:      &schemaspec.Type{T: "int", Attributes: []*schemaspec.Attr{specutil.LitAttr("unsigned", "true")}},
+			expected: "int unsigned",
+		},
+		{
+			spec: &schemaspec.TypeSpec{
+				T:    "varchar",
+				Name: "varchar",
+				Attributes: []*schemaspec.TypeAttr{
+					{Name: "size", Kind: reflect.Int, Required: true},
+				},
+			},
+			typ:      &schemaspec.Type{T: "varchar", Attributes: []*schemaspec.Attr{specutil.LitAttr("size", "255")}},
+			expected: "varchar(255)",
+		},
+	} {
+		t.Run(tt.expected, func(t *testing.T) {
+			s, err := sqlspec.PrintType(tt.typ, tt.spec)
+			require.NoError(t, err)
+			require.EqualValues(t, tt.expected, s)
+		})
+	}
+}


### PR DESCRIPTION
Needed a way to go from `schemaspec.Type` to something the driver can parse into a `schema.Type`. 