### PR TITLE
schema/schemaspec/schemahcl: don't break on type attributes that aren't defined as type arguments in sql

### DIFF
--- a/schema/schemaspec/schemahcl/context_test.go
+++ b/schema/schemaspec/schemahcl/context_test.go
@@ -359,8 +359,14 @@ sized  = varchar(255)
 	s := New(
 		WithTypes(
 			[]*schemaspec.TypeSpec{
-				{Name: "int", T: "int"},
 				{Name: "bool", T: "bool"},
+				{
+					Name: "int",
+					T:    "int",
+					Attributes: []*schemaspec.TypeAttr{
+						{Name: "unsigned", Kind: reflect.Bool, Required: false},
+					},
+				},
 				{
 					Name: "varchar",
 					T:    "varchar",

--- a/schema/schemaspec/schemahcl/hcl.go
+++ b/schema/schemaspec/schemahcl/hcl.go
@@ -311,9 +311,9 @@ func hclType(spec *schemaspec.TypeSpec, typ *schemaspec.Type) (string, error) {
 }
 
 func findAttr(attrs []*schemaspec.Attr, k string) (*schemaspec.Attr, bool) {
-	for _, atr := range attrs {
-		if atr.K == k {
-			return atr, true
+	for _, attr := range attrs {
+		if attr.K == k {
+			return attr, true
 		}
 	}
 	return nil, false


### PR DESCRIPTION
this is infra to support `TypeSpec`s that have attributes that aren't represented as "type arguments" (for example `unsigned` in integer types