### PR TITLE
schema/schemaspec/schemahcl: support variadic type spec attributes

### DIFF
--- a/schema/schemaspec/schemahcl/context_test.go
+++ b/schema/schemaspec/schemahcl/context_test.go
@@ -352,9 +352,9 @@ x = from_ctx
 }
 
 func TestWithTypes(t *testing.T) {
-	f := `first  = int
-second = bool
-sized  = varchar(255)
+	f := `first    = int
+second   = bool
+sized    = varchar(255)
 variadic = enum("a","b","c")
 `
 	s := New(

--- a/schema/schemaspec/schemahcl/hcl.go
+++ b/schema/schemaspec/schemahcl/hcl.go
@@ -301,11 +301,18 @@ func hclType(spec *schemaspec.TypeSpec, typ *schemaspec.Type) (string, error) {
 		if !ok {
 			continue
 		}
-		lit, ok := arg.V.(*schemaspec.LiteralValue)
-		if !ok {
-			return "", errors.New("expecting literal value")
+		switch val := arg.V.(type) {
+		case *schemaspec.LiteralValue:
+			args = append(args, val.V)
+		case *schemaspec.ListValue:
+			for _, li := range val.V {
+				lit, ok := li.(*schemaspec.LiteralValue)
+				if !ok {
+					return "", errors.New("expecting literal value")
+				}
+				args = append(args, lit.V)
+			}
 		}
-		args = append(args, lit.V)
 	}
 	return fmt.Sprintf("%s(%s)", typ.T, strings.Join(args, ",")), nil
 }

--- a/schema/schemaspec/schemahcl/opts.go
+++ b/schema/schemaspec/schemahcl/opts.go
@@ -1,7 +1,6 @@
 package schemahcl
 
 import (
-	"fmt"
 	"reflect"
 
 	"ariga.io/atlas/schema/schemaspec"
@@ -80,7 +79,6 @@ func WithTypes(typeSpecs []*schemaspec.TypeSpec) Option {
 						T: typeSpec.T,
 					}
 					if spec.VarParam != nil {
-						fmt.Println(spec)
 						lst := &schemaspec.ListValue{}
 						for _, arg := range args {
 							v, err := extractLiteralValue(arg)

--- a/schema/schemaspec/schemahcl/opts.go
+++ b/schema/schemaspec/schemahcl/opts.go
@@ -119,16 +119,3 @@ func typeFuncArgs(spec *schemaspec.TypeSpec) []*schemaspec.TypeAttr {
 	}
 	return args
 }
-
-// typeVariadicFuncArgs returns the type attributes that are configured via a variadic
-// type definition, for example in an enum("a", "b", "c").
-func typeVariadicFuncArgs(spec *schemaspec.TypeSpec) []*schemaspec.TypeAttr {
-	var args []*schemaspec.TypeAttr
-	for _, attr := range spec.Attributes {
-		if attr.Kind == reflect.Slice {
-			continue
-		}
-		args = append(args, attr)
-	}
-	return args
-}


### PR DESCRIPTION
Needed to support
```hcl
status = enum("on","off","unknown")

```