### PR TITLE
sql/internal/specutil: adding TypeRegistry for TypeSpecs

### DIFF
--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -67,8 +67,8 @@ type (
 
 	// TypeSpec represents a specification for defining a Type.
 	TypeSpec struct {
-		Name       string
-		T          string
+		Name       string // Name is the identifier for the type in an Atlas DDL document.
+		T          string // T is the database identifier for the type.
 		Attributes []*TypeAttr
 	}
 

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -67,8 +67,10 @@ type (
 
 	// TypeSpec represents a specification for defining a Type.
 	TypeSpec struct {
-		Name       string // Name is the identifier for the type in an Atlas DDL document.
-		T          string // T is the database identifier for the type.
+		// Name is the identifier for the type in an Atlas DDL document.
+		Name       string
+		 // T is the database identifier for the type.
+		T          string
 		Attributes []*TypeAttr
 	}
 

--- a/sql/internal/specutil/types.go
+++ b/sql/internal/specutil/types.go
@@ -2,6 +2,7 @@ package specutil
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"ariga.io/atlas/schema/schemaspec"
@@ -39,4 +40,43 @@ func PrintType(typ *schemaspec.Type, spec *schemaspec.TypeSpec) (string, error) 
 		mid = "(" + strings.Join(args, ",") + ")"
 	}
 	return typ.T + mid + suffix, nil
+}
+
+// TypeRegistry is a collection of *schemaspec.TypeSpec.
+type TypeRegistry struct {
+	r []*schemaspec.TypeSpec
+}
+
+// Register adds one or more TypeSpec to the registry.
+func (r *TypeRegistry) Register(specs ...*schemaspec.TypeSpec) error {
+	for _, s := range specs {
+		if _, exists := r.Find(s.T); exists {
+			return fmt.Errorf("specutil: type with T of %q already registered", s.T)
+		}
+		if _, exists := r.FindByName(s.Name); exists {
+			return fmt.Errorf("specutil: type with name of %q already registered", s.T)
+		}
+	}
+	r.r = append(r.r, specs...)
+	return nil
+}
+
+// FindByName searches the registry for types that have the provided name.
+func (r *TypeRegistry) FindByName(name string) (*schemaspec.TypeSpec, bool) {
+	for _, current := range r.r {
+		if current.Name == name {
+			return current, true
+		}
+	}
+	return nil, false
+}
+
+// Find searches the registry for types that have the provided T.
+func (r *TypeRegistry) Find(t string) (*schemaspec.TypeSpec, bool) {
+	for _, current := range r.r {
+		if current.T == t {
+			return current, true
+		}
+	}
+	return nil, false
 }

--- a/sql/internal/specutil/types.go
+++ b/sql/internal/specutil/types.go
@@ -1,4 +1,4 @@
-package sqlspec
+package specutil
 
 import (
 	"errors"

--- a/sql/internal/specutil/types_test.go
+++ b/sql/internal/specutil/types_test.go
@@ -50,3 +50,15 @@ func TestTypePrint(t *testing.T) {
 		})
 	}
 }
+
+func TestRegistry(t *testing.T) {
+	r := &TypeRegistry{}
+	text := &schemaspec.TypeSpec{Name: "text", T: "text"}
+	err := r.Register(text)
+	require.NoError(t, err)
+	err = r.Register(text)
+	require.EqualError(t, err, `specutil: type with T of "text" already registered`)
+	spec, ok := r.FindByName("text")
+	require.True(t, ok)
+	require.EqualValues(t, spec, text)
+}

--- a/sql/internal/specutil/types_test.go
+++ b/sql/internal/specutil/types_test.go
@@ -1,12 +1,10 @@
-package sqlspec_test
+package specutil
 
 import (
 	"reflect"
 	"testing"
 
 	"ariga.io/atlas/schema/schemaspec"
-	"ariga.io/atlas/sql/internal/specutil"
-	"ariga.io/atlas/sql/sqlspec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +28,7 @@ func TestTypePrint(t *testing.T) {
 		},
 		{
 			spec:     intSpec,
-			typ:      &schemaspec.Type{T: "int", Attributes: []*schemaspec.Attr{specutil.LitAttr("unsigned", "true")}},
+			typ:      &schemaspec.Type{T: "int", Attributes: []*schemaspec.Attr{LitAttr("unsigned", "true")}},
 			expected: "int unsigned",
 		},
 		{
@@ -41,12 +39,12 @@ func TestTypePrint(t *testing.T) {
 					{Name: "size", Kind: reflect.Int, Required: true},
 				},
 			},
-			typ:      &schemaspec.Type{T: "varchar", Attributes: []*schemaspec.Attr{specutil.LitAttr("size", "255")}},
+			typ:      &schemaspec.Type{T: "varchar", Attributes: []*schemaspec.Attr{LitAttr("size", "255")}},
 			expected: "varchar(255)",
 		},
 	} {
 		t.Run(tt.expected, func(t *testing.T) {
-			s, err := sqlspec.PrintType(tt.typ, tt.spec)
+			s, err := PrintType(tt.typ, tt.spec)
 			require.NoError(t, err)
 			require.EqualValues(t, tt.expected, s)
 		})


### PR DESCRIPTION
Stacked on #297 

Adding a new container type for working with TypeSpecs. This is added to make the needed changes to mysql/postgres for type-safe type definitions in Atlas DDL. 