### PR TITLE
sql/internal/specutil: support omitting right-most zero-value optional param

### DIFF
--- a/sql/internal/specutil/types.go
+++ b/sql/internal/specutil/types.go
@@ -156,7 +156,7 @@ func (r *TypeRegistry) Convert(typ schema.Type) (*schemaspec.Type, error) {
 			s.Attrs = append([]*schemaspec.Attr{LitAttr(attr.Name, i)}, s.Attrs...)
 		case reflect.Bool:
 			v := field.Bool()
-			if v == false && len(s.Attrs) == 0 {
+			if !v && len(s.Attrs) == 0 {
 				break
 			}
 			b := strconv.FormatBool(v)

--- a/sql/internal/specutil/types_test.go
+++ b/sql/internal/specutil/types_test.go
@@ -109,12 +109,30 @@ func TestRegistryConvert(t *testing.T) {
 			typ:      &schema.IntegerType{T: "int", Unsigned: true},
 			expected: &schemaspec.Type{T: "int", Attrs: []*schemaspec.Attr{LitAttr("unsigned", "true")}},
 		},
+
 		{
-			typ: &schema.DecimalType{T: "decimal", Precision: 10, Scale: 2},
+			typ: &schema.DecimalType{T: "decimal", Precision: 10, Scale: 2}, // decimal(10,2)
 			expected: &schemaspec.Type{T: "decimal", Attrs: []*schemaspec.Attr{
 				LitAttr("precision", "10"),
 				LitAttr("scale", "2"),
 			}},
+		},
+		{
+			typ: &schema.DecimalType{T: "decimal", Precision: 10}, // decimal(10)
+			expected: &schemaspec.Type{T: "decimal", Attrs: []*schemaspec.Attr{
+				LitAttr("precision", "10"),
+			}},
+		},
+		{
+			typ: &schema.DecimalType{T: "decimal", Scale: 2}, // decimal(0,2)
+			expected: &schemaspec.Type{T: "decimal", Attrs: []*schemaspec.Attr{
+				LitAttr("precision", "0"),
+				LitAttr("scale", "2"),
+			}},
+		},
+		{
+			typ:      &schema.DecimalType{T: "decimal"}, // decimal
+			expected: &schemaspec.Type{T: "decimal"},
 		},
 		{
 			typ: &schema.EnumType{T: "enum", Values: []string{"on", "off"}},

--- a/sql/internal/specutil/types_test.go
+++ b/sql/internal/specutil/types_test.go
@@ -109,7 +109,6 @@ func TestRegistryConvert(t *testing.T) {
 			typ:      &schema.IntegerType{T: "int", Unsigned: true},
 			expected: &schemaspec.Type{T: "int", Attrs: []*schemaspec.Attr{LitAttr("unsigned", "true")}},
 		},
-
 		{
 			typ: &schema.DecimalType{T: "decimal", Precision: 10, Scale: 2}, // decimal(10,2)
 			expected: &schemaspec.Type{T: "decimal", Attrs: []*schemaspec.Attr{


### PR DESCRIPTION
this fixes a bug where a typespec has an optional (non-required) type attribute, and the resulting DDL representation was too verbose. For instance, in some dialects both `varchar` and `varchar(20)` are valid. In these cases the `size` attribute is optional. In these cases if the size was not specified it would be rendered as `varchar(0)`. 

This PR adds a fix where the right-most optional args that have the zero value are omitted. so default:
`varchar(0)` => `varchar`, `x(10,0)` => `x(10)`, `x(0,10)` => remains `x(0,10)`