### PR TITLE
sql/internal/specutil: sanity tests for all drivers

### DIFF
--- a/schema/schemaspec/schemahcl/opts.go
+++ b/schema/schemaspec/schemahcl/opts.go
@@ -77,7 +77,7 @@ func typeFuncSpec(typeSpec *schemaspec.TypeSpec) function.Function {
 		case reflect.String:
 			p.Type = cty.String
 			spec.Params = append(spec.Params, p)
-		case reflect.Int, reflect.Float32:
+		case reflect.Int, reflect.Float32, reflect.Int64:
 			p.Type = cty.Number
 			spec.Params = append(spec.Params, p)
 		case reflect.Bool:

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -72,6 +72,10 @@ type (
 		// T is the database identifier for the type.
 		T          string
 		Attributes []*TypeAttr
+		// RType is the reflect.Type of the schema.Type used to describe the TypeSpec.
+		// This field is optional and used to determine the TypeSpec in cases where the
+		// schema.Type does not have a `T` field.
+		RType reflect.Type
 	}
 
 	// TypeAttr describes an attribute of a TypeSpec, for example `varchar` fields

--- a/sql/internal/spectest/spectest.go
+++ b/sql/internal/spectest/spectest.go
@@ -12,17 +12,12 @@ import (
 
 // RegistrySanityTest runs a sanity for a TypeRegistry, generated a dummy *schemaspec.Type
 // then converting it to a schema.Type and back to a *schemaspec.Type.
-func RegistrySanityTest(t *testing.T,
-	registry *specutil.TypeRegistry,
-	formatter func(schema.Type) (string, error),
-	parser func(string) (schema.Type, error),
-) {
+func RegistrySanityTest(t *testing.T, registry *specutil.TypeRegistry, parser func(string) (schema.Type, error)) {
 	for _, ts := range registry.Specs() {
 		t.Run(ts.Name, func(t *testing.T) {
 			spec := dummyType(t, ts)
 			styp, err := registry.Type(spec, nil, parser)
 			require.NoError(t, err)
-			//_, err = formatter(styp)
 			require.NoErrorf(t, err, "failed formatting: %styp", err)
 			convert, err := registry.Convert(styp)
 			require.NoError(t, err)

--- a/sql/internal/spectest/spectest.go
+++ b/sql/internal/spectest/spectest.go
@@ -31,9 +31,9 @@ func RegistrySanityTest(t *testing.T, registry *specutil.TypeRegistry, parser fu
 	}
 }
 
-func contains(needle string, haystack []string) bool {
-	for _, item := range haystack {
-		if item == needle {
+func contains(s string, l []string) bool {
+	for i := range l {
+		if s == l[i] {
 			return true
 		}
 	}

--- a/sql/internal/spectest/spectest.go
+++ b/sql/internal/spectest/spectest.go
@@ -1,0 +1,53 @@
+package spectest
+
+import (
+	"reflect"
+	"testing"
+
+	"ariga.io/atlas/schema/schemaspec"
+	"ariga.io/atlas/sql/internal/specutil"
+	"ariga.io/atlas/sql/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func RegistrySanityTest(t *testing.T,
+	registry *specutil.TypeRegistry,
+	formatter func(schema.Type) (string, error),
+	parser func(string) (schema.Type, error),
+) {
+	for _, ts := range registry.Specs() {
+		t.Run(ts.Name, func(t *testing.T) {
+			spec := dummyType(t, ts)
+			styp, err := registry.Type(spec, nil, parser)
+			require.NoError(t, err)
+			//_, err = formatter(styp)
+			require.NoErrorf(t, err, "failed formatting: %styp", err)
+			convert, err := registry.Convert(styp)
+			require.NoError(t, err)
+			after, err := registry.Type(convert, nil, parser)
+			require.NoError(t, err)
+			require.EqualValues(t, styp, after)
+		})
+	}
+}
+
+func dummyType(t *testing.T, ts *schemaspec.TypeSpec) *schemaspec.Type {
+	spec := &schemaspec.Type{T: ts.T}
+	for _, attr := range ts.Attributes {
+		var a *schemaspec.Attr
+		switch attr.Kind {
+		case reflect.Int, reflect.Int64:
+			a = specutil.LitAttr(attr.Name, "2")
+		case reflect.String:
+			a = specutil.LitAttr(attr.Name, `"a"`)
+		case reflect.Slice:
+			a = specutil.ListAttr(attr.Name, `"a"`, `"b"`)
+		case reflect.Bool:
+			a = specutil.LitAttr(attr.Name, "false")
+		default:
+			t.Fatalf("unsupported kind: %s", attr.Kind)
+		}
+		spec.Attrs = append(spec.Attrs, a)
+	}
+	return spec
+}

--- a/sql/internal/spectest/spectest.go
+++ b/sql/internal/spectest/spectest.go
@@ -12,8 +12,11 @@ import (
 
 // RegistrySanityTest runs a sanity for a TypeRegistry, generated a dummy *schemaspec.Type
 // then converting it to a schema.Type and back to a *schemaspec.Type.
-func RegistrySanityTest(t *testing.T, registry *specutil.TypeRegistry, parser func(string) (schema.Type, error)) {
+func RegistrySanityTest(t *testing.T, registry *specutil.TypeRegistry, parser func(string) (schema.Type, error), skip []string) {
 	for _, ts := range registry.Specs() {
+		if contains(ts.Name, skip) {
+			continue
+		}
 		t.Run(ts.Name, func(t *testing.T) {
 			spec := dummyType(t, ts)
 			styp, err := registry.Type(spec, nil, parser)
@@ -26,6 +29,15 @@ func RegistrySanityTest(t *testing.T, registry *specutil.TypeRegistry, parser fu
 			require.EqualValues(t, styp, after)
 		})
 	}
+}
+
+func contains(needle string, haystack []string) bool {
+	for _, item := range haystack {
+		if item == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func dummyType(t *testing.T, ts *schemaspec.TypeSpec) *schemaspec.Type {

--- a/sql/internal/spectest/spectest.go
+++ b/sql/internal/spectest/spectest.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package spectest
 
 import (

--- a/sql/internal/spectest/spectest.go
+++ b/sql/internal/spectest/spectest.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// RegistrySanityTest runs a sanity for a TypeRegistry, generated a dummy *schemaspec.Type
+// then converting it to a schema.Type and back to a *schemaspec.Type.
 func RegistrySanityTest(t *testing.T,
 	registry *specutil.TypeRegistry,
 	formatter func(schema.Type) (string, error),

--- a/sql/internal/specutil/types_test.go
+++ b/sql/internal/specutil/types_test.go
@@ -62,7 +62,7 @@ func TestRegistry(t *testing.T) {
 	require.NoError(t, err)
 	err = r.Register(text)
 	require.EqualError(t, err, `specutil: type with T of "text" already registered`)
-	spec, ok := r.FindByName("text")
+	spec, ok := r.findName("text")
 	require.True(t, ok)
 	require.EqualValues(t, spec, text)
 }

--- a/sql/mysql/sqlspec.go
+++ b/sql/mysql/sqlspec.go
@@ -440,8 +440,22 @@ func hasCollate(attr []schema.Attr, parent []schema.Attr) (string, bool) {
 
 // TypeRegistry contains the supported TypeSpecs for the mysql driver.
 var TypeRegistry = specutil.NewRegistry(
-	specutil.TypeSpec(tEnum, &schemaspec.TypeAttr{Name: "values", Kind: reflect.Slice, Required: true}),
-	specutil.TypeSpec(tSet, &schemaspec.TypeAttr{Name: "values", Kind: reflect.Slice, Required: true}),
+	&schemaspec.TypeSpec{
+		Name: tEnum,
+		T:    tEnum,
+		Attributes: []*schemaspec.TypeAttr{
+			{Name: "values", Kind: reflect.Slice, Required: true},
+		},
+		RType: reflect.TypeOf(schema.EnumType{}),
+	},
+	&schemaspec.TypeSpec{
+		Name: tSet,
+		T:    tSet,
+		Attributes: []*schemaspec.TypeAttr{
+			{Name: "values", Kind: reflect.Slice, Required: true},
+		},
+		RType: reflect.TypeOf(SetType{}),
+	},
 	specutil.TypeSpec(tBit, specutil.SizeTypeAttr(false)),
 	specutil.TypeSpec(tInt, unsignedTypeAttr(), specutil.SizeTypeAttr(false)),
 	specutil.TypeSpec(tTinyInt, unsignedTypeAttr(), specutil.SizeTypeAttr(false)),
@@ -458,7 +472,7 @@ var TypeRegistry = specutil.NewRegistry(
 	specutil.TypeSpec(tTime),
 	specutil.TypeSpec(tDateTime),
 	specutil.TypeSpec(tYear),
-	specutil.TypeSpec(tVarchar, specutil.SizeTypeAttr(false)),
+	specutil.TypeSpec(tVarchar, specutil.SizeTypeAttr(true)),
 	specutil.TypeSpec(tChar, specutil.SizeTypeAttr(false)),
 	specutil.TypeSpec(tVarBinary, specutil.SizeTypeAttr(false)),
 	specutil.TypeSpec(tBinary, specutil.SizeTypeAttr(false)),

--- a/sql/mysql/sqlspec_test.go
+++ b/sql/mysql/sqlspec_test.go
@@ -902,7 +902,7 @@ func TestTypes(t *testing.T) {
 }
 
 func TestRegistrySanity(t *testing.T) {
-	spectest.RegistrySanityTest(t, TypeRegistry, FormatType, parseRawType)
+	spectest.RegistrySanityTest(t, TypeRegistry, parseRawType)
 }
 
 func hclEqual(t *testing.T, expected, actual []byte) {

--- a/sql/mysql/sqlspec_test.go
+++ b/sql/mysql/sqlspec_test.go
@@ -902,7 +902,7 @@ func TestTypes(t *testing.T) {
 }
 
 func TestRegistrySanity(t *testing.T) {
-	spectest.RegistrySanityTest(t, TypeRegistry, parseRawType)
+	spectest.RegistrySanityTest(t, TypeRegistry, parseRawType, nil)
 }
 
 func hclEqual(t *testing.T, expected, actual []byte) {

--- a/sql/mysql/sqlspec_test.go
+++ b/sql/mysql/sqlspec_test.go
@@ -7,6 +7,7 @@ import (
 
 	"ariga.io/atlas/schema/schemaspec"
 	"ariga.io/atlas/schema/schemaspec/schemahcl"
+	"ariga.io/atlas/sql/internal/spectest"
 	"ariga.io/atlas/sql/internal/specutil"
 	"ariga.io/atlas/sql/schema"
 	"ariga.io/atlas/sql/sqlspec"
@@ -898,6 +899,10 @@ func TestTypes(t *testing.T) {
 			hclEqual(t, []byte(doc), spec)
 		})
 	}
+}
+
+func TestRegistrySanity(t *testing.T) {
+	spectest.RegistrySanityTest(t, TypeRegistry, FormatType, parseRawType)
 }
 
 func hclEqual(t *testing.T, expected, actual []byte) {

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -370,7 +370,7 @@ func arrayType(t string) (string, bool) {
 // TypeRegistry contains the supported TypeSpecs for the postgres driver.
 var TypeRegistry = specutil.NewRegistry(
 	specutil.TypeSpec(tBit, &schemaspec.TypeAttr{Name: "len", Kind: reflect.Int64}),
-	specutil.AliasTypeSpec("bit_varying", tBitVar, specutil.SizeTypeAttr(true), &schemaspec.TypeAttr{Name: "len", Kind: reflect.Int64}),
+	specutil.AliasTypeSpec("bit_varying", tBitVar, &schemaspec.TypeAttr{Name: "len", Kind: reflect.Int64}),
 	specutil.TypeSpec(tVarChar, specutil.SizeTypeAttr(true)),
 	specutil.TypeSpec(tChar, specutil.SizeTypeAttr(true)),
 	specutil.TypeSpec(tCharacter, specutil.SizeTypeAttr(true)),
@@ -402,7 +402,7 @@ var TypeRegistry = specutil.NewRegistry(
 	specutil.TypeSpec(tTimestamp),
 	specutil.AliasTypeSpec("timestamp_with_time_zone", tTimestampWTZ),
 	specutil.AliasTypeSpec("timestamp_without_time_zone", tTimestampWOTZ),
-	//specutil.TypeSpec("enum", &schemaspec.TypeAttr{Name: "values", Kind: reflect.Slice, Required: true}),
+	specutil.TypeSpec("enum", &schemaspec.TypeAttr{Name: "values", Kind: reflect.Slice, Required: true}),
 	specutil.AliasTypeSpec("double_precision", tDouble),
 	specutil.TypeSpec(tReal),
 	specutil.TypeSpec(tFloat8),

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -369,8 +369,8 @@ func arrayType(t string) (string, bool) {
 
 // TypeRegistry contains the supported TypeSpecs for the postgres driver.
 var TypeRegistry = specutil.NewRegistry(
-	specutil.TypeSpec(tBit, specutil.SizeTypeAttr(true)),
-	specutil.AliasTypeSpec("bit_varying", tBitVar, specutil.SizeTypeAttr(true)),
+	specutil.TypeSpec(tBit, &schemaspec.TypeAttr{Name: "len", Kind: reflect.Int64}),
+	specutil.AliasTypeSpec("bit_varying", tBitVar, specutil.SizeTypeAttr(true), &schemaspec.TypeAttr{Name: "len", Kind: reflect.Int64}),
 	specutil.TypeSpec(tVarChar, specutil.SizeTypeAttr(true)),
 	specutil.TypeSpec(tChar, specutil.SizeTypeAttr(true)),
 	specutil.TypeSpec(tCharacter, specutil.SizeTypeAttr(true)),
@@ -402,7 +402,7 @@ var TypeRegistry = specutil.NewRegistry(
 	specutil.TypeSpec(tTimestamp),
 	specutil.AliasTypeSpec("timestamp_with_time_zone", tTimestampWTZ),
 	specutil.AliasTypeSpec("timestamp_without_time_zone", tTimestampWOTZ),
-	specutil.TypeSpec("enum", &schemaspec.TypeAttr{Name: "values", Kind: reflect.Slice, Required: true}),
+	//specutil.TypeSpec("enum", &schemaspec.TypeAttr{Name: "values", Kind: reflect.Slice, Required: true}),
 	specutil.AliasTypeSpec("double_precision", tDouble),
 	specutil.TypeSpec(tReal),
 	specutil.TypeSpec(tFloat8),

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -750,5 +750,5 @@ func TestTypes(t *testing.T) {
 }
 
 func TestRegistrySanity(t *testing.T) {
-	spectest.RegistrySanityTest(t, TypeRegistry, parseRawType)
+	spectest.RegistrySanityTest(t, TypeRegistry, parseRawType, []string{"enum"})
 }

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -7,6 +7,7 @@ import (
 
 	"ariga.io/atlas/schema/schemaspec"
 	"ariga.io/atlas/schema/schemaspec/schemahcl"
+	"ariga.io/atlas/sql/internal/spectest"
 	"ariga.io/atlas/sql/internal/specutil"
 	"ariga.io/atlas/sql/schema"
 	"ariga.io/atlas/sql/sqlspec"
@@ -746,4 +747,8 @@ func TestTypes(t *testing.T) {
 			require.EqualValues(t, string(hclwrite.Format([]byte(doc))), string(hclwrite.Format(spec)))
 		})
 	}
+}
+
+func TestRegistrySanity(t *testing.T) {
+	spectest.RegistrySanityTest(t, TypeRegistry, FormatType, parseRawType)
 }

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -750,5 +750,5 @@ func TestTypes(t *testing.T) {
 }
 
 func TestRegistrySanity(t *testing.T) {
-	spectest.RegistrySanityTest(t, TypeRegistry, FormatType, parseRawType)
+	spectest.RegistrySanityTest(t, TypeRegistry, parseRawType)
 }


### PR DESCRIPTION
Adding a sanity test for all driver type registries and fixing some bugs along the way. 

postgres enum needs some more love, but ill do that separately. 