### PR TITLE
schema/schemaspec/schemahcl: support partial type arguments

### DIFF
--- a/schema/schemaspec/schemahcl/context_test.go
+++ b/schema/schemaspec/schemahcl/context_test.go
@@ -6,6 +6,7 @@ import (
 
 	"ariga.io/atlas/schema/schemaspec"
 	"ariga.io/atlas/schema/schemaspec/internal/schemautil"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"


### PR DESCRIPTION
bugfix: for types that have "optional" parameters, such as float on MySQL - ie in the DDL both float, float(10), and float(10,2) are legit, only `float` and `float(10,2)` were supported. this PR adds support for the partial invocation `float(10)`, to mimick the db DDL. 