### PR TITLE
cmd/action: add version

### DIFF
--- a/cmd/action/internal/build/build.go
+++ b/cmd/action/internal/build/build.go
@@ -1,0 +1,19 @@
+package build
+
+import (
+	"runtime/debug"
+)
+
+// Version is dynamically set by the release script.
+var Version = "DEV"
+
+// Date is dynamically set at build time in the release script.
+var Date = "" // YYYY-MM-DD
+
+func init() {
+	if Version == "DEV" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
+			Version = info.Main.Version
+		}
+	}
+}

--- a/cmd/action/version.go
+++ b/cmd/action/version.go
@@ -1,0 +1,47 @@
+package action
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"ariga.io/atlas/cmd/action/internal/build"
+	"github.com/spf13/cobra"
+)
+
+var (
+	versionCmd = &cobra.Command{
+		Use:    "version",
+		Hidden: true,
+		Run:    cmdVersionRun,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+	RootCmd.Version = build.Version
+
+}
+
+func cmdVersionRun(cmd *cobra.Command, args []string) {
+	RootCmd.Print(format(build.Version, build.Date))
+}
+
+func format(version, buildDate string) string {
+	version = strings.TrimPrefix(version, "v")
+	var dateStr string
+	if buildDate != "" {
+		dateStr = fmt.Sprintf(" (%s)", buildDate)
+	}
+	return fmt.Sprintf("atlas version %s%s\n%s\n", version, dateStr, changelogURL(version))
+}
+
+func changelogURL(version string) string {
+	path := "https://github.com/ariga/atlas"
+	r := regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[\w.]+)?$`)
+	if !r.MatchString(version) {
+		return fmt.Sprintf("%s/releases/latest", path)
+	}
+	url := fmt.Sprintf("%s/releases/tag/v%s", path, strings.TrimPrefix(version, "v"))
+	return url
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -171,6 +171,28 @@ func testCLISchemaApply(t T, h string, dsn string) {
 	require.NotNil(t, u)
 }
 
+func TestCLIVersion(t *testing.T) {
+	// Required to have a clean "stderr" while running first time.
+	err := exec.Command("go", "run", "-mod=mod", "ariga.io/atlas/cmd/atlas").Run()
+	require.NoError(t, err)
+	cmd := exec.Command("go", "run",
+		"-ldflags",
+		"-X ariga.io/atlas/cmd/action/internal/build.Version=v0.1.2 -X ariga.io/atlas/cmd/action/internal/build.Date=2018-04-03",
+		"ariga.io/atlas/cmd/atlas",
+		"version",
+	)
+	stdout, stderr := bytes.NewBuffer(nil), bytes.NewBuffer(nil)
+	cmd.Stderr = stderr
+	cmd.Stdout = stdout
+	expected := `atlas version 0.1.2 (2018-04-03)
+https://github.com/ariga/atlas/releases/tag/v0.1.2
+`
+	require.NoError(t, cmd.Run(), stderr.String())
+	require.NoError(t, err)
+	require.Empty(t, stderr.String())
+	require.Equal(t, expected, stdout.String())
+}
+
 func ensureNoChange(t T, tables ...*schema.Table) {
 	realm := t.loadRealm()
 	require.Equal(t, len(realm.Schemas[0].Tables), len(tables))


### PR DESCRIPTION
```go run  -ldflags "-X ariga.io/atlas/cmd/action/internal/build.Version=v0.1.1 -X 'ariga.io/atlas/cmd/action/internal/build.Date=$(Date +'%Y-%m-%d')'" ./cmd/atlas version```

shows version, date of compilation and release notes (github link)