### PR TITLE
sql/sqlspec: better support default values

### DIFF
--- a/internal/integration/go.sum
+++ b/internal/integration/go.sum
@@ -66,7 +66,6 @@ github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqO
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
-github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -242,7 +241,6 @@ github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
 github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
-github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -252,7 +250,6 @@ github.com/mattn/go-sqlite3 v1.14.9/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
-github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
@@ -276,7 +273,6 @@ github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pelletier/go-toml/v2 v2.0.0-beta.4 h1:GCs8ebsDtEH3RiO78+BvhHqj65d/I6tjESitJZc07Rc=
 github.com/pelletier/go-toml/v2 v2.0.0-beta.4/go.mod h1:ke6xncR3W76Ba8xnVxkrZG0js6Rd2BsQEAYrfgJ6eQA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -313,13 +309,11 @@ github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
-github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=

--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -538,6 +538,8 @@ create table atlas_defaults
 (
 	string varchar(255) default "hello_world",
 	quoted varchar(100) default 'never say "never"',
+	tBit bit(10) default b'10101',
+	ts timestamp default CURRENT_TIMESTAMP,
 	number int default 42
 )
 `
@@ -549,9 +551,12 @@ create table atlas_defaults
 		spec, err := mysql.MarshalSpec(realm.Schemas[0], hcl)
 		require.NoError(t, err)
 		var s schema.Schema
-		fmt.Println(string(spec))
 		err = mysql.UnmarshalSpec(spec, hcl, &s)
 		require.NoError(t, err)
+		t.dropTables(n)
+		t.applyHcl(string(spec))
+		fmt.Println(string(spec))
+		ensureNoChange(t, realm.Schemas[0].Tables[0])
 	})
 }
 

--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -555,7 +555,6 @@ create table atlas_defaults
 		require.NoError(t, err)
 		t.dropTables(n)
 		t.applyHcl(string(spec))
-		fmt.Println(string(spec))
 		ensureNoChange(t, realm.Schemas[0].Tables[0])
 	})
 }

--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -537,6 +537,7 @@ func TestMySQL_DefaultsHCL(t *testing.T) {
 create table atlas_defaults
 (
 	string varchar(255) default "hello_world",
+	quoted varchar(100) default 'never say "never"',
 	number int default 42
 )
 `
@@ -547,7 +548,10 @@ create table atlas_defaults
 		hcl := schemahcl.New(schemahcl.WithTypes(mysql.TypeRegistry.Specs()))
 		spec, err := mysql.MarshalSpec(realm.Schemas[0], hcl)
 		require.NoError(t, err)
+		var s schema.Schema
 		fmt.Println(string(spec))
+		err = mysql.UnmarshalSpec(spec, hcl, &s)
+		require.NoError(t, err)
 	})
 }
 

--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -530,6 +530,27 @@ func TestMySQL_CLI(t *testing.T) {
 	})
 }
 
+func TestMySQL_DefaultsHCL(t *testing.T) {
+	n := "atlas_defaults"
+	myRun(t, func(t *myTest) {
+		ddl := `
+create table atlas_defaults
+(
+	string varchar(255) default "hello_world",
+	number int default 42
+)
+`
+		t.dropTables(n)
+		_, err := t.db.Exec(ddl)
+		require.NoError(t, err)
+		realm := t.loadRealm()
+		hcl := schemahcl.New(schemahcl.WithTypes(mysql.TypeRegistry.Specs()))
+		spec, err := mysql.MarshalSpec(realm.Schemas[0], hcl)
+		require.NoError(t, err)
+		fmt.Println(string(spec))
+	})
+}
+
 func TestMySQL_Sanity(t *testing.T) {
 	n := "atlas_types_sanity"
 	t.Run("Common", func(t *testing.T) {

--- a/internal/integration/sqlite_test.go
+++ b/internal/integration/sqlite_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"ariga.io/atlas/schema/schemaspec/schemahcl"
-	"ariga.io/atlas/sql/mysql"
 	"ariga.io/atlas/sql/postgres"
 	"ariga.io/atlas/sql/schema"
 	"ariga.io/atlas/sql/sqlite"
@@ -405,7 +404,7 @@ create table atlas_defaults
 (
 	string varchar(255) default "hello_world",
 	quoted varchar(100) default 'never say "never"',
-	d date default 'now()',
+	d date default current_timestamp,
 	n integer default 0x100 
 )
 `
@@ -413,11 +412,11 @@ create table atlas_defaults
 		_, err := t.db.Exec(ddl)
 		require.NoError(t, err)
 		realm := t.loadRealm()
-		hcl := schemahcl.New(schemahcl.WithTypes(mysql.TypeRegistry.Specs()))
-		spec, err := mysql.MarshalSpec(realm.Schemas[0], hcl)
+		hcl := schemahcl.New(schemahcl.WithTypes(sqlite.TypeRegistry.Specs()))
+		spec, err := sqlite.MarshalSpec(realm.Schemas[0], hcl)
 		require.NoError(t, err)
 		var s schema.Schema
-		err = mysql.UnmarshalSpec(spec, hcl, &s)
+		err = sqlite.UnmarshalSpec(spec, hcl, &s)
 		require.NoError(t, err)
 		t.dropTables(n)
 		t.applyHcl(string(spec))

--- a/schema/schemaspec/extension.go
+++ b/schema/schemaspec/extension.go
@@ -274,10 +274,10 @@ func setPtr(field reflect.Value, val Value) error {
 		field.Set(reflect.ValueOf(val))
 		return nil
 	}
-	if rx, ok := val.(*RawExpr); ok {
+	if x, ok := val.(*RawExpr); ok {
 		i := field.Interface()
 		if _, ok := i.(*Type); ok {
-			field.Set(reflect.ValueOf(&Type{T: rx.X}))
+			field.Set(reflect.ValueOf(&Type{T: x.X}))
 			return nil
 		}
 	}

--- a/schema/schemaspec/extension.go
+++ b/schema/schemaspec/extension.go
@@ -257,11 +257,31 @@ func setField(field reflect.Value, attr *Attr) error {
 		}
 		field.SetBool(b)
 	case reflect.Ptr:
+		if err := setPtr(field, attr.V); err != nil {
+			return fmt.Errorf("schemaspec: failed setting pointer field %q: %w", attr.K, err)
+		}
+	case reflect.Interface:
 		field.Set(reflect.ValueOf(attr.V))
 	default:
 		return fmt.Errorf("schemaspec: unsupported field kind %q", field.Kind())
 	}
 	return nil
+}
+
+func setPtr(field reflect.Value, val Value) error {
+	rt := reflect.TypeOf(val)
+	if field.Type() == rt {
+		field.Set(reflect.ValueOf(val))
+		return nil
+	}
+	if rx, ok := val.(*RawExpr); ok {
+		i := field.Interface()
+		if _, ok := i.(*Type); ok {
+			field.Set(reflect.ValueOf(&Type{T: rx.X}))
+			return nil
+		}
+	}
+	return fmt.Errorf("unhandled pointer type %T", val)
 }
 
 // setSliceAttr sets the value of attr to the slice field. This function expects both the target field
@@ -394,6 +414,20 @@ func scanAttr(key string, r *Resource, field reflect.Value) error {
 		lit = fmt.Sprintf("%d", field.Int())
 	case reflect.Bool:
 		lit = strconv.FormatBool(field.Bool())
+	case reflect.Interface:
+		if field.IsNil() {
+			return nil
+		}
+		i := field.Interface()
+		v, ok := i.(Value)
+		if !ok {
+			return fmt.Errorf("schemaspec: unsupported interface type %T for field %q", i, key)
+		}
+		r.SetAttr(&Attr{
+			K: key,
+			V: v,
+		})
+		return nil
 	default:
 		return fmt.Errorf("schemaspec: unsupported field kind %q", field.Kind())
 	}

--- a/schema/schemaspec/schemahcl/context.go
+++ b/schema/schemaspec/schemahcl/context.go
@@ -153,6 +153,7 @@ var (
 		},
 	})
 	ctyTypeSpec = cty.Capsule("type", reflect.TypeOf(schemaspec.Type{}))
+	ctyRawExpr  = cty.Capsule("raw_expr", reflect.TypeOf(schemaspec.RawExpr{}))
 )
 
 // defRegistry returns a tree of blockDef structs representing the schema of the

--- a/schema/schemaspec/schemahcl/hcl.go
+++ b/schema/schemaspec/schemahcl/hcl.go
@@ -264,6 +264,7 @@ func (s *state) writeAttr(attr *schemaspec.Attr, body *hclwrite.Body) error {
 		}
 		body.SetAttributeRaw(attr.K, hclRawTokens(st))
 	case *schemaspec.LiteralValue:
+
 		body.SetAttributeRaw(attr.K, hclRawTokens(v.V))
 	case *schemaspec.ListValue:
 		lst := make([]string, 0, len(v.V))

--- a/schema/schemaspec/schemahcl/hcl.go
+++ b/schema/schemaspec/schemahcl/hcl.go
@@ -117,6 +117,8 @@ func toAttrs(ctx *hcl.EvalContext, hclAttrs hclsyntax.Attributes) ([]*schemaspec
 		switch {
 		case isRef(value):
 			at.V = &schemaspec.Ref{V: value.GetAttr("__ref").AsString()}
+		case value.Type() == ctyRawExpr:
+			at.V = value.EncapsulatedValue().(*schemaspec.RawExpr)
 		case value.Type() == ctyTypeSpec:
 			at.V = value.EncapsulatedValue().(*schemaspec.Type)
 		case value.Type().IsTupleType():
@@ -247,6 +249,7 @@ func labels(r *schemaspec.Resource) []string {
 }
 
 func (s *state) writeAttr(attr *schemaspec.Attr, body *hclwrite.Body) error {
+	attr = normalizeLiterals(attr)
 	switch v := attr.V.(type) {
 	case *schemaspec.Ref:
 		expr := strings.ReplaceAll(v.V, "$", "")
@@ -264,8 +267,11 @@ func (s *state) writeAttr(attr *schemaspec.Attr, body *hclwrite.Body) error {
 		}
 		body.SetAttributeRaw(attr.K, hclRawTokens(st))
 	case *schemaspec.LiteralValue:
-
 		body.SetAttributeRaw(attr.K, hclRawTokens(v.V))
+	case *schemaspec.RawExpr:
+		// TODO(rotemtam): the func name should be decided on contextual basis.
+		fnc := fmt.Sprintf("sql(%q)", v.X)
+		body.SetAttributeRaw(attr.K, hclRawTokens(fnc))
 	case *schemaspec.ListValue:
 		lst := make([]string, 0, len(v.V))
 		for _, item := range v.V {
@@ -284,6 +290,21 @@ func (s *state) writeAttr(attr *schemaspec.Attr, body *hclwrite.Body) error {
 		return fmt.Errorf("schemacl: unknown literal type %T", v)
 	}
 	return nil
+}
+
+// normalizeLiterals transforms attriburtes with LiteralValue that cannot be
+// written as correct HCL into RawExpr.
+func normalizeLiterals(attr *schemaspec.Attr) *schemaspec.Attr {
+	lv, ok := attr.V.(*schemaspec.LiteralValue)
+	if !ok {
+		return attr
+	}
+	exp := "x = " + lv.V
+	p := hclparse.NewParser()
+	if _, diag := p.ParseHCL([]byte(exp), ""); diag != nil {
+		return &schemaspec.Attr{K: attr.K, V: &schemaspec.RawExpr{X: lv.V}}
+	}
+	return attr
 }
 
 func (s *state) findTypeSpec(t string) (*schemaspec.TypeSpec, bool) {

--- a/schema/schemaspec/schemahcl/opts.go
+++ b/schema/schemaspec/schemahcl/opts.go
@@ -56,7 +56,7 @@ func WithTypes(typeSpecs []*schemaspec.TypeSpec) Option {
 				ctx.Functions[typeSpec.Name] = typeFuncSpec(typeSpec)
 			}
 		}
-		ctx.Functions["sql"] = rawTypeImpl()
+		ctx.Functions["sql"] = rawExprImpl()
 		return ctx
 	}
 	return func(config *Config) {
@@ -65,15 +65,15 @@ func WithTypes(typeSpecs []*schemaspec.TypeSpec) Option {
 	}
 }
 
-func rawTypeImpl() function.Function {
+func rawExprImpl() function.Function {
 	return function.New(&function.Spec{
 		Params: []function.Parameter{
 			{Name: "def", Type: cty.String, AllowNull: false},
 		},
-		Type: function.StaticReturnType(ctyTypeSpec),
+		Type: function.StaticReturnType(ctyRawExpr),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			t := &schemaspec.Type{T: args[0].AsString()}
-			return cty.CapsuleVal(ctyTypeSpec, t), nil
+			t := &schemaspec.RawExpr{X: args[0].AsString()}
+			return cty.CapsuleVal(ctyRawExpr, t), nil
 		},
 	})
 }

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -256,6 +256,7 @@ func (s *TypeSpec) Attr(name string) (*TypeAttr, bool) {
 }
 
 func (*LiteralValue) val() {}
+func (*RawExpr) val() {}
 func (*ListValue) val()    {}
 func (*Ref) val()          {}
 func (*Type) val()         {}

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -256,7 +256,6 @@ func (s *TypeSpec) Attr(name string) (*TypeAttr, bool) {
 }
 
 func (*LiteralValue) val() {}
-func (*RawExpr) val()      {}
 func (*ListValue) val()    {}
 func (*Ref) val()          {}
 func (*Type) val()         {}

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -31,6 +31,11 @@ type (
 		V string
 	}
 
+	// RawExpr implements Value and represents any raw expression.
+	RawExpr struct {
+		X string
+	}
+
 	// ListValue implements Value and represents a list of Values.
 	ListValue struct {
 		V []Value
@@ -251,6 +256,7 @@ func (s *TypeSpec) Attr(name string) (*TypeAttr, bool) {
 }
 
 func (*LiteralValue) val() {}
+func (*RawExpr) val()      {}
 func (*ListValue) val()    {}
 func (*Ref) val()          {}
 func (*Type) val()         {}

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -256,7 +256,7 @@ func (s *TypeSpec) Attr(name string) (*TypeAttr, bool) {
 }
 
 func (*LiteralValue) val() {}
-func (*RawExpr) val() {}
+func (*RawExpr) val()      {}
 func (*ListValue) val()    {}
 func (*Ref) val()          {}
 func (*Type) val()         {}

--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -325,10 +325,10 @@ func toValue(expr schema.Expr) (schemaspec.Value, error) {
 		if err != nil {
 			return nil, err
 		}
+		return &schemaspec.LiteralValue{V: v}, nil
 	default:
 		return nil, fmt.Errorf("converting expr %T to literal value", expr)
 	}
-	return &schemaspec.LiteralValue{V: v}, nil
 }
 
 func normalizeQuotes(s string) (string, error) {

--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -7,6 +7,7 @@ package specutil
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"ariga.io/atlas/schema/schemaspec"
@@ -310,12 +311,22 @@ func toLitValue(expr schema.Expr) (*schemaspec.LiteralValue, error) {
 	case *schema.RawExpr:
 		v = expr.X
 	case *schema.Literal:
-		v = expr.V
+		v = normalizeQuotes(expr.V)
 	default:
 		return nil, fmt.Errorf("converting expr %T to literal value", expr)
 	}
-	//v = fmt.Sprintf("expr(%q)", v)
 	return &schemaspec.LiteralValue{V: v}, nil
+}
+
+func normalizeQuotes(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	// If string is quoted with single quotes:
+	if strings.HasPrefix(s, `'`) && strings.HasSuffix(s, `'`) {
+		return strconv.Quote(s[1 : len(s)-1])
+	}
+	return s
 }
 
 // FromIndex converts schema.Index to sqlspec.Index

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -9,6 +9,7 @@ import (
 
 	"ariga.io/atlas/schema/schemaspec"
 	"ariga.io/atlas/sql/internal/specutil"
+	"ariga.io/atlas/sql/internal/sqlx"
 	"ariga.io/atlas/sql/schema"
 	"ariga.io/atlas/sql/sqlspec"
 )
@@ -90,7 +91,7 @@ func fixDefaultQuotes(value schemaspec.Value) error {
 	if !ok {
 		return nil
 	}
-	if len(lv.V) > 2 && strings.HasPrefix(lv.V, "\"") && strings.HasSuffix(lv.V, "\"") {
+	if sqlx.IsQuoted(lv.V, '"') {
 		uq, err := strconv.Unquote(lv.V)
 		if err != nil {
 			return err

--- a/sql/sqlspec/sqlspec.go
+++ b/sql/sqlspec/sqlspec.go
@@ -26,10 +26,10 @@ type (
 
 	// Column holds a specification for a column in an SQL table.
 	Column struct {
-		Name    string                   `spec:",name"`
-		Null    bool                     `spec:"null"`
-		Type    *schemaspec.Type         `spec:"type"`
-		Default *schemaspec.LiteralValue `spec:"default"`
+		Name    string           `spec:",name"`
+		Null    bool             `spec:"null"`
+		Type    *schemaspec.Type `spec:"type"`
+		Default schemaspec.Value `spec:"default"`
 		schemaspec.DefaultExtension
 	}
 


### PR DESCRIPTION
sqlspec.Column Default attribute is now a `schemaspec.Value` that can contain either `LiteralValue` or `RawExpr`. 

This is currently integration-tested on MySQL and SQLite. 