### PR TITLE
cmd/action: document no update env param

### DIFF
--- a/cmd/action/env.go
+++ b/cmd/action/env.go
@@ -1,0 +1,28 @@
+package action
+
+import (
+	"fmt"
+	"os"
+
+	"ariga.io/atlas/cmd/action/internal/update"
+	"github.com/spf13/cobra"
+)
+
+var envCmd = &cobra.Command{
+	Use:   "env",
+	Short: "Print atlas env params",
+	Long: `"ATLAS_NO_UPDATE_NOTIFIER": On any command, the CLI will check for updates with the GitHub public API once
+	every 24 hours. To cancel this behavior, set the environment parameter "ATLAS_NO_UPDATE_NOTIFIER".`,
+	Run: func(cmd *cobra.Command, args []string) {
+		keys := []string{update.AtlasNoUpdateNotifier}
+		for _, k := range keys {
+			if v, ok := os.LookupEnv(k); ok {
+				RootCmd.Println(fmt.Sprintf("%s=%s", k, v))
+			}
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(envCmd)
+}

--- a/cmd/action/internal/update/update.go
+++ b/cmd/action/internal/update/update.go
@@ -32,6 +32,11 @@ type (
 	}
 )
 
+const (
+	// AtlasNoUpdateNotifier when enabled it cancels checking for update
+	AtlasNoUpdateNotifier = "ATLAS_NO_UPDATE_NOTIFIER"
+)
+
 // CheckForUpdate implements a notification to the user when a later release is available
 // 1. Check release file ~/.atlas/release.json for latest known release and poll time
 // 2. If last poll was more than 24h, poll GitHub public API https://docs.github.com/en/rest/reference/releases#get-the-latest-release
@@ -53,7 +58,7 @@ func CheckForUpdate(version string, logF func(i ...interface{})) {
 }
 
 func enabled(version string) bool {
-	if _, ok := os.LookupEnv("ATLAS_NO_UPDATE_NOTIFIER"); ok {
+	if _, ok := os.LookupEnv(AtlasNoUpdateNotifier); ok {
 		return false
 	}
 	if _, ok := os.LookupEnv("GITHUB_ACTIONS"); ok {

--- a/cmd/atlas/main.go
+++ b/cmd/atlas/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"ariga.io/atlas/cmd/action"
@@ -16,7 +15,7 @@ func main() {
 	err := action.RootCmd.Execute()
 	// Print error from command
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
+		action.RootCmd.PrintErrln("Error:", err)
 	}
 	// Check for update
 	action.CheckForUpdate()

--- a/doc/md/CLI/atlas.md
+++ b/doc/md/CLI/atlas.md
@@ -10,6 +10,7 @@ A database toolkit.
 
 ### SEE ALSO
 
+* [atlas env](atlas_env.md)	 - Print atlas env params
 * [atlas schema](atlas_schema.md)	 - Work with atlas schemas
 * [atlas version](atlas_version.md)	 - Show atlas CLI version
 

--- a/doc/md/CLI/atlas_env.md
+++ b/doc/md/CLI/atlas_env.md
@@ -1,0 +1,23 @@
+## atlas env
+
+Print atlas env params
+
+### Synopsis
+
+"ATLAS_NO_UPDATE_NOTIFIER": On any command, the CLI will check for updates with the GitHub public API once
+	every 24 hours. To cancel this behavior, set the environment parameter "ATLAS_NO_UPDATE_NOTIFIER".
+
+```
+atlas env [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for env
+```
+
+### SEE ALSO
+
+* [atlas](atlas.md)	 - A database toolkit.
+


### PR DESCRIPTION
add atlas env command.
The long help describes all the available env' parameters.
When activating the cmd it prints the env params (when set).

This design is similar to what Go CLI does.
