### PR TITLE
sql/internal/specutil: support marshaling unsupported types as sql() …

### DIFF
--- a/sql/internal/specutil/types.go
+++ b/sql/internal/specutil/types.go
@@ -167,6 +167,11 @@ func (r *TypeRegistry) findT(t string) (*schemaspec.TypeSpec, bool) {
 
 // Convert converts the schema.Type to a *schemaspec.Type.
 func (r *TypeRegistry) Convert(typ schema.Type) (*schemaspec.Type, error) {
+	if ut, ok := typ.(*schema.UnsupportedType); ok {
+		return &schemaspec.Type{
+			T: ut.T,
+		}, nil
+	}
 	rv := reflect.ValueOf(typ)
 	if rv.Kind() == reflect.Ptr {
 		rv = rv.Elem()
@@ -264,7 +269,7 @@ func (r *TypeRegistry) Type(typ *schemaspec.Type, extra []*schemaspec.Attr) (sch
 	nfa := typeNonFuncArgs(typeSpec)
 	picked := pickTypeAttrs(extra, nfa)
 	cp := &schemaspec.Type{
-		T:     typ.T,
+		T: typ.T,
 	}
 	cp.Attrs = appendIfNotExist(typ.Attrs, picked)
 	printType, err := r.PrintType(cp)

--- a/sql/mysql/sqlspec_test.go
+++ b/sql/mysql/sqlspec_test.go
@@ -287,6 +287,10 @@ func TestTypes(t *testing.T) {
 			expected: &schema.StringType{T: TypeChar, Size: 255},
 		},
 		{
+			typeExpr: `sql("custom")`,
+			expected: &schema.UnsupportedType{T: "custom"},
+		},
+		{
 			typeExpr: "binary(255)",
 			expected: &schema.BinaryType{T: TypeBinary, Size: 255},
 		},

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -166,6 +166,10 @@ func TestTypes(t *testing.T) {
 			expected: &BitType{T: TypeBit, Len: 10},
 		},
 		{
+			typeExpr: `hstore`,
+			expected: &UserDefinedType{T: "hstore"},
+		},
+		{
 			typeExpr: "bit_varying(10)",
 			expected: &BitType{T: TypeBitVar, Len: 10},
 		},

--- a/sql/sqlite/inspect.go
+++ b/sql/sqlite/inspect.go
@@ -226,7 +226,7 @@ func parseRawType(c string) (schema.Type, error) {
 	case "uuid":
 		return &UUIDType{T: t}, nil
 	default:
-		return nil, fmt.Errorf("unknown column type %q", t)
+		return &schema.UnsupportedType{T: t}, nil
 	}
 }
 

--- a/sql/sqlite/sqlspec_test.go
+++ b/sql/sqlite/sqlspec_test.go
@@ -162,6 +162,10 @@ func TestTypes(t *testing.T) {
 			expected: &schema.IntegerType{T: "int"},
 		},
 		{
+			typeExpr: `sql("custom")`,
+			expected: &schema.UnsupportedType{T: "custom"},
+		},
+		{
 			typeExpr: "tinyint(10)",
 			expected: &schema.IntegerType{T: "tinyint"},
 		},


### PR DESCRIPTION
…expressions in HCL for MySQL and SQLite

this brings support for bi-directional conversion of columns with 

```
type = sql("custom")
```

this PR solves the issue for MySQL and SQLite.
With Postgres there's a small issue @a8m and I will discuss tommorow