### PR TITLE
sql/mysql: avoid panic on migrate failure

### DIFF
--- a/sql/mysql/convert.go
+++ b/sql/mysql/convert.go
@@ -86,9 +86,10 @@ func FormatType(t schema.Type) (string, error) {
 	case *schema.TimeType:
 		f = strings.ToLower(t.T)
 	case *schema.UnsupportedType:
-		return "", fmt.Errorf("mysql: unsupported type: %q", t.T)
+		// Do not accept unsupported types as we should cover all cases.
+		return "", fmt.Errorf("unsupported type %q", t.T)
 	default:
-		return "", fmt.Errorf("mysql: invalid schema type: %T", t)
+		return "", fmt.Errorf("invalid schema type %T", t)
 	}
 	return f, nil
 }


### PR DESCRIPTION
Unsupported types should be rejected in MySQL, but should
not cause the migration process to fail/panic