### PR TITLE
Add support for SQL comments

### DIFF
--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -17,6 +17,7 @@ schema "schema" {
 table "table" {
 	column "col" {
 		type = integer
+		comment = "column comment"
 	}
 	column "age" {
 		type = integer
@@ -36,6 +37,7 @@ table "table" {
 			table.table.column.col,
 			table.table.column.age,
 		]
+		comment = "index comment"
 	}
 	foreign_key "accounts" {
 		columns = [
@@ -46,6 +48,7 @@ table "table" {
 		]
 		on_delete = "SET NULL"
 	}
+	comment = "table comment"
 }
 
 table "accounts" {
@@ -75,6 +78,9 @@ table "accounts" {
 							T: "integer",
 						},
 					},
+					Attrs: []schema.Attr{
+						&schema.Comment{Text: "column comment"},
+					},
 				},
 				{
 					Name: "age",
@@ -101,6 +107,9 @@ table "accounts" {
 						},
 					},
 				},
+			},
+			Attrs: []schema.Attr{
+				&schema.Comment{Text: "table comment"},
 			},
 		},
 		{
@@ -133,6 +142,9 @@ table "accounts" {
 			Parts: []*schema.IndexPart{
 				{SeqNo: 0, C: exp.Tables[0].Columns[0]},
 				{SeqNo: 1, C: exp.Tables[0].Columns[1]},
+			},
+			Attrs: []schema.Attr{
+				&schema.Comment{Text: "index comment"},
 			},
 		},
 	}

--- a/sql/schema/dsl.go
+++ b/sql/schema/dsl.go
@@ -452,6 +452,13 @@ func (i *Index) SetTable(t *Table) *Index {
 	return i
 }
 
+// SetComment sets or appends the Comment attribute
+// to the index with the given value.
+func (i *Index) SetComment(v string) *Index {
+	replaceOrAppend(&i.Attrs, &Comment{Text: v})
+	return i
+}
+
 // AddAttrs adds additional attributes to the index.
 func (i *Index) AddAttrs(attrs ...Attr) *Index {
 	i.Attrs = append(i.Attrs, attrs...)

--- a/sql/schema/dsl_test.go
+++ b/sql/schema/dsl_test.go
@@ -48,7 +48,9 @@ func TestSchema_AddTables(t *testing.T) {
 		SetPrimaryKey(schema.NewPrimaryKey(userColumns[0])).
 		SetComment("users table").
 		AddIndexes(
-			schema.NewUniqueIndex("unique_name").AddColumns(userColumns[2]),
+			schema.NewUniqueIndex("unique_name").
+				AddColumns(userColumns[2]).
+				SetComment("index comment"),
 		)
 	postColumns := []*schema.Column{
 		schema.NewIntColumn("id", "int"),
@@ -87,7 +89,12 @@ func TestSchema_AddTables(t *testing.T) {
 			users.PrimaryKey = &schema.Index{Unique: true, Parts: []*schema.IndexPart{{C: users.Columns[0]}}}
 			users.PrimaryKey.Table = users
 			users.Columns[0].Indexes = append(users.Columns[0].Indexes, users.PrimaryKey)
-			users.Indexes = append(users.Indexes, &schema.Index{Name: "unique_name", Unique: true, Parts: []*schema.IndexPart{{C: users.Columns[2]}}})
+			users.Indexes = append(users.Indexes, &schema.Index{
+				Name:   "unique_name",
+				Unique: true,
+				Parts:  []*schema.IndexPart{{C: users.Columns[2]}},
+				Attrs:  []schema.Attr{&schema.Comment{Text: "index comment"}},
+			})
 			users.Indexes[0].Table = users
 			users.Columns[2].Indexes = users.Indexes
 


### PR DESCRIPTION
This PR adds support for adding comments to the HCL. Opposed to the previous implementation where there was an `Comment` field added the the `sqlspec` structs this is no longer the case since SQLite for example does not support comments.

The current implementation also makes sure that no `commen = ""` attributes are rendered to the marshaled HCL if there are no comments.