### PR TITLE
sql/mysql: reject CHARSET/COLLATE attributes for non-char columns on migrate

### DIFF
--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -930,27 +930,21 @@ create table atlas_types_sanity
 				}(),
 				Schema: realm.Schemas[0],
 				Columns: []*schema.Column{
-					{
-						Name: "tJSON",
-						Type: func() *schema.ColumnType {
-							if t.version == "Maria102" || t.version == "Maria103" {
-								return &schema.ColumnType{Type: &schema.StringType{T: "longtext"},
-									Raw: "longtext", Null: true}
+					func() *schema.Column {
+						c := &schema.Column{Name: "tJSON", Type: &schema.ColumnType{Type: &schema.JSONType{T: "json"}, Raw: "json", Null: true}}
+						switch t.version {
+						case "Maria107":
+							c.Attrs = []schema.Attr{}
+						case "Maria102", "Maria103":
+							c.Type.Raw = "longtext"
+							c.Type.Type = &schema.StringType{T: "longtext"}
+							c.Attrs = []schema.Attr{
+								&schema.Charset{V: "utf8mb4"},
+								&schema.Collation{V: "utf8mb4_bin"},
 							}
-							return &schema.ColumnType{Type: &schema.JSONType{T: "json"},
-								Raw: "json", Null: true}
-
-						}(),
-						Attrs: func() []schema.Attr {
-							if t.mariadb() {
-								return []schema.Attr{
-									&schema.Charset{V: "utf8mb4"},
-									&schema.Collation{V: "utf8mb4_bin"},
-								}
-							}
-							return nil
-						}(),
-					},
+						}
+						return c
+					}(),
 				},
 			}
 			require.EqualValues(t, &expected, ts)

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -391,15 +391,17 @@ func (i *inspect) checks(ctx context.Context, t *schema.Table) error {
 			check.Attrs = append(check.Attrs, &Enforced{})
 		}
 		t.Attrs = append(t.Attrs, check)
-		// In MariaDB, JSON is an alias to LONGTEXT, and the JSON_VALID
-		// CHECK constraint is automatically created for the column for
-		// versions >= 10.4.3. However, we expect tools like Atlas and
-		// Ent to manually add this CHECK for older versions of MariaDB.
+		// In MariaDB, JSON is an alias to LONGTEXT. For versions >= 10.4.3, the CHARSET and COLLATE set to utf8mb4
+		// and a CHECK constraint is automatically created for the column as well (i.e. JSON_VALID(`<c>`)). However,
+		// we expect tools like Atlas and Ent to manually add this CHECK for older versions of MariaDB.
 		if i.mariadb() {
 			c, ok := t.Column(check.Name)
 			if ok && c.Type.Raw == TypeLongText && check.Expr == fmt.Sprintf("json_valid(`%s`)", c.Name) {
 				c.Type.Raw = TypeJSON
 				c.Type.Type = &schema.JSONType{T: TypeJSON}
+				// Unset the inspected CHARSET/COLLATE attributes
+				// as they are valid only for character types.
+				c.UnsetCharset().UnsetCollation()
 			}
 		}
 

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -392,7 +392,7 @@ func (i *inspect) checks(ctx context.Context, t *schema.Table) error {
 		}
 		t.Attrs = append(t.Attrs, check)
 		// In MariaDB, JSON is an alias to LONGTEXT. For versions >= 10.4.3, the CHARSET and COLLATE set to utf8mb4
-		// and a CHECK constraint is automatically created for the column as well (i.e. JSON_VALID(`<c>`)). However,
+		// and a CHECK constraint is automatically created for the column as well (i.e. JSON_VALID(`<C>`)). However,
 		// we expect tools like Atlas and Ent to manually add this CHECK for older versions of MariaDB.
 		if i.mariadb() {
 			c, ok := t.Column(check.Name)

--- a/sql/mysql/migrate.go
+++ b/sql/mysql/migrate.go
@@ -382,7 +382,7 @@ func (s *state) column(b *sqlx.Builder, t *schema.Table, c *schema.Column) error
 		switch a := a.(type) {
 		case *schema.Charset:
 			if !supportsCharset(c.Type.Type) {
-				return fmt.Errorf("column %q of type %T does not support the CHARSET", c.Name, c.Type.Type)
+				return fmt.Errorf("column %q of type %T does not support the CHARSE attribute", c.Name, c.Type.Type)
 			}
 			// Define the charset explicitly
 			// in case it is not the default.
@@ -391,7 +391,7 @@ func (s *state) column(b *sqlx.Builder, t *schema.Table, c *schema.Column) error
 			}
 		case *schema.Collation:
 			if !supportsCharset(c.Type.Type) {
-				return fmt.Errorf("column %q of type %T does not support the COLLATE", c.Name, c.Type.Type)
+				return fmt.Errorf("column %q of type %T does not support the COLLATE attribute", c.Name, c.Type.Type)
 			}
 			// Define the collation explicitly
 			// in case it is not the default.

--- a/sql/schema/dsl.go
+++ b/sql/schema/dsl.go
@@ -23,10 +23,22 @@ func (s *Schema) SetCharset(v string) *Schema {
 	return s
 }
 
+// UnsetCharset unsets the Charset attribute.
+func (s *Schema) UnsetCharset() *Schema {
+	del(&s.Attrs, &Charset{})
+	return s
+}
+
 // SetCollation sets or appends the Collation attribute
 // to the schema with the given value.
 func (s *Schema) SetCollation(v string) *Schema {
 	replaceOrAppend(&s.Attrs, &Collation{V: v})
+	return s
+}
+
+// UnsetCollation the Collation attribute.
+func (s *Schema) UnsetCollation() *Schema {
+	del(&s.Attrs, &Collation{})
 	return s
 }
 
@@ -70,10 +82,22 @@ func (t *Table) SetCharset(v string) *Table {
 	return t
 }
 
+// UnsetCharset unsets the Charset attribute.
+func (t *Table) UnsetCharset() *Table {
+	del(&t.Attrs, &Charset{})
+	return t
+}
+
 // SetCollation sets or appends the Collation attribute
 // to the table with the given value.
 func (t *Table) SetCollation(v string) *Table {
 	replaceOrAppend(&t.Attrs, &Collation{V: v})
+	return t
+}
+
+// UnsetCollation the Collation attribute.
+func (t *Table) UnsetCollation() *Table {
+	del(&t.Attrs, &Collation{})
 	return t
 }
 
@@ -398,10 +422,22 @@ func (c *Column) SetCharset(v string) *Column {
 	return c
 }
 
+// UnsetCharset unsets the Charset attribute.
+func (c *Column) UnsetCharset() *Column {
+	del(&c.Attrs, &Charset{})
+	return c
+}
+
 // SetCollation sets or appends the Collation attribute
 // to the column with the given value.
 func (c *Column) SetCollation(v string) *Column {
 	replaceOrAppend(&c.Attrs, &Collation{V: v})
+	return c
+}
+
+// UnsetCollation the Collation attribute.
+func (c *Column) UnsetCollation() *Column {
+	del(&c.Attrs, &Collation{})
 	return c
 }
 
@@ -594,4 +630,16 @@ func replaceOrAppend(attrs *[]Attr, v Attr) {
 		}
 	}
 	*attrs = append(*attrs, v)
+}
+
+// del searches an attribute of the same type as v in
+// the list and delete it.
+func del(attrs *[]Attr, v Attr) {
+	t := reflect.TypeOf(v)
+	for i := range *attrs {
+		if reflect.TypeOf((*attrs)[i]) == t {
+			*attrs = append((*attrs)[:i], (*attrs)[i+1:]...)
+			return
+		}
+	}
 }

--- a/sql/schema/dsl_test.go
+++ b/sql/schema/dsl_test.go
@@ -139,6 +139,8 @@ func TestSchema_SetCharset(t *testing.T) {
 	s.SetCharset("latin1")
 	require.Len(t, s.Attrs, 1)
 	require.Equal(t, &schema.Charset{V: "latin1"}, s.Attrs[0])
+	s.UnsetCharset()
+	require.Empty(t, s.Attrs)
 }
 
 func TestSchema_SetCollation(t *testing.T) {
@@ -150,6 +152,8 @@ func TestSchema_SetCollation(t *testing.T) {
 	s.SetCollation("latin1_swedish_ci")
 	require.Len(t, s.Attrs, 1)
 	require.Equal(t, &schema.Collation{V: "latin1_swedish_ci"}, s.Attrs[0])
+	s.UnsetCollation()
+	require.Empty(t, s.Attrs)
 }
 
 func TestSchema_SetComment(t *testing.T) {


### PR DESCRIPTION
- Reject CHARSET/COLLATE attributes for non-char columns on migration
- "Normalize" inspected JSON columns on MariaDB
- Add UnsetCollate and UnsetCharset