### PR TITLE
Feat/check

### DIFF
--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -26,9 +26,10 @@ type (
 	ColumnSpecFunc        func(*schema.Column, *schema.Table) (*sqlspec.Column, error)
 	ColumnTypeSpecFunc    func(schema.Type) (*sqlspec.Column, error)
 	TableSpecFunc         func(*schema.Table) (*sqlspec.Table, error)
-	PrimaryKeySpecFunc    func(index *schema.Index) (*sqlspec.PrimaryKey, error)
-	IndexSpecFunc         func(index *schema.Index) (*sqlspec.Index, error)
-	ForeignKeySpecFunc    func(fk *schema.ForeignKey) (*sqlspec.ForeignKey, error)
+	PrimaryKeySpecFunc    func(*schema.Index) (*sqlspec.PrimaryKey, error)
+	IndexSpecFunc         func(*schema.Index) (*sqlspec.Index, error)
+	ForeignKeySpecFunc    func(*schema.ForeignKey) (*sqlspec.ForeignKey, error)
+	CheckSpecFunc         func(*schema.Check) *sqlspec.Check
 )
 
 // Realm converts the schemas and tables into a schema.Realm.
@@ -293,7 +294,8 @@ func FromSchema(s *schema.Schema, fn TableSpecFunc) (*sqlspec.Schema, []*sqlspec
 }
 
 // FromTable converts a schema.Table to a sqlspec.Table.
-func FromTable(t *schema.Table, colFn ColumnSpecFunc, pkFn PrimaryKeySpecFunc, idxFn IndexSpecFunc, fkFn ForeignKeySpecFunc) (*sqlspec.Table, error) {
+func FromTable(t *schema.Table, colFn ColumnSpecFunc, pkFn PrimaryKeySpecFunc, idxFn IndexSpecFunc,
+	fkFn ForeignKeySpecFunc, ckFn CheckSpecFunc) (*sqlspec.Table, error) {
 	spec := &sqlspec.Table{
 		Name: t.Name,
 	}
@@ -324,6 +326,11 @@ func FromTable(t *schema.Table, colFn ColumnSpecFunc, pkFn PrimaryKeySpecFunc, i
 			return nil, err
 		}
 		spec.ForeignKeys = append(spec.ForeignKeys, f)
+	}
+	for _, attr := range t.Attrs {
+		if c, ok := attr.(*schema.Check); ok {
+			spec.Checks = append(spec.Checks, ckFn(c))
+		}
 	}
 	convertCommentFromSchema(t.Attrs, &spec.Extra.Attrs)
 	return spec, nil
@@ -396,7 +403,7 @@ func normalizeQuotes(s string) (string, error) {
 	return s, nil
 }
 
-// FromIndex converts schema.Index to sqlspec.Index
+// FromIndex converts schema.Index to sqlspec.Index.
 func FromIndex(idx *schema.Index) (*sqlspec.Index, error) {
 	c := make([]*schemaspec.Ref, 0, len(idx.Parts))
 	for _, p := range idx.Parts {
@@ -414,7 +421,7 @@ func FromIndex(idx *schema.Index) (*sqlspec.Index, error) {
 	return i, nil
 }
 
-// FromForeignKey converts schema.ForeignKey to sqlspec.ForeignKey
+// FromForeignKey converts schema.ForeignKey to sqlspec.ForeignKey.
 func FromForeignKey(s *schema.ForeignKey) (*sqlspec.ForeignKey, error) {
 	c := make([]*schemaspec.Ref, 0, len(s.Columns))
 	for _, v := range s.Columns {
@@ -431,6 +438,15 @@ func FromForeignKey(s *schema.ForeignKey) (*sqlspec.ForeignKey, error) {
 		OnDelete:   s.OnDelete,
 		OnUpdate:   s.OnUpdate,
 	}, nil
+}
+
+// FromCheck converts schema.Check to sqlspec.Check.
+func FromCheck(s *schema.Check) *sqlspec.Check {
+	c := &sqlspec.Check{
+		Name: s.Name,
+		Expr: s.Expr,
+	}
+	return c
 }
 
 func schemaName(ref *schemaspec.Ref) (string, error) {

--- a/sql/mysql/sqlspec.go
+++ b/sql/mysql/sqlspec.go
@@ -78,7 +78,7 @@ var (
 // ForeignKeySpecs into ForeignKeys, as the target tables do not necessarily exist in the schema
 // at this point. Instead, the linking is done by the convertSchema function.
 func convertTable(spec *sqlspec.Table, parent *schema.Schema) (*schema.Table, error) {
-	t, err := specutil.Table(spec, parent, convertColumn, convertPrimaryKey, convertIndex)
+	t, err := specutil.Table(spec, parent, convertColumn, specutil.PrimaryKey, specutil.Index, convertCheck)
 	if err != nil {
 		return nil, err
 	}
@@ -88,14 +88,13 @@ func convertTable(spec *sqlspec.Table, parent *schema.Schema) (*schema.Table, er
 	return t, err
 }
 
-// convertPrimaryKey converts a sqlspec.PrimaryKey to a schema.Index.
-func convertPrimaryKey(spec *sqlspec.PrimaryKey, parent *schema.Table) (*schema.Index, error) {
-	return specutil.PrimaryKey(spec, parent)
-}
-
-// convertIndex converts an sqlspec.Index to a schema.Index.
-func convertIndex(spec *sqlspec.Index, parent *schema.Table) (*schema.Index, error) {
-	return specutil.Index(spec, parent)
+// convertCheck converts a sqlspec.Check into a schema.Check.
+func convertCheck(spec *sqlspec.Check) *schema.Check {
+	c := specutil.Check(spec)
+	if spec.Enforced {
+		c.AddAttrs(&Enforced{})
+	}
+	return c
 }
 
 // convertColumn converts a sqlspec.Column into a schema.Column.

--- a/sql/mysql/sqlspec.go
+++ b/sql/mysql/sqlspec.go
@@ -132,7 +132,14 @@ func schemaSpec(s *schema.Schema) (*sqlspec.Schema, []*sqlspec.Table, error) {
 
 // tableSpec converts from a concrete MySQL sqlspec.Table to a schema.Table.
 func tableSpec(t *schema.Table) (*sqlspec.Table, error) {
-	ts, err := specutil.FromTable(t, columnSpec, specutil.FromPrimaryKey, specutil.FromIndex, specutil.FromForeignKey)
+	ts, err := specutil.FromTable(
+		t,
+		columnSpec,
+		specutil.FromPrimaryKey,
+		specutil.FromIndex,
+		specutil.FromForeignKey,
+		checkSpec,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -158,6 +165,15 @@ func columnSpec(c *schema.Column, t *schema.Table) (*sqlspec.Column, error) {
 		col.Extra.Attrs = append(col.Extra.Attrs, specutil.StrAttr("collation", c))
 	}
 	return col, nil
+}
+
+func checkSpec(s *schema.Check) *sqlspec.Check {
+	c := specutil.FromCheck(s)
+	var e Enforced
+	if sqlx.Has(s.Attrs, &e) {
+		c.Enforced = true
+	}
+	return c
 }
 
 // columnTypeSpec converts from a concrete MySQL schema.Type into sqlspec.Column Type.

--- a/sql/mysql/sqlspec_test.go
+++ b/sql/mysql/sqlspec_test.go
@@ -50,13 +50,14 @@ table "table" {
 		]
 		on_delete = "SET NULL"
 	}
-	comment = "table comment"
-	check {
-		expr = "price1 <> price2"
-	}
 	check "positive price" {
-		expr = "price > 0"
+		expr = "price1 > 0"
 	}
+	check {
+		expr     = "price1 <> price2"
+		enforced = true
+	}
+	comment = "table comment"
 }
 
 table "accounts" {
@@ -126,12 +127,15 @@ table "accounts" {
 				},
 			},
 			Attrs: []schema.Attr{
-				&schema.Comment{Text: "table comment"},
-				&schema.Check{Expr: "price1 <> price2"},
 				&schema.Check{
 					Name: "positive price",
 					Expr: "price1 > 0",
 				},
+				&schema.Check{
+					Expr:  "price1 <> price2",
+					Attrs: []schema.Attr{&Enforced{}},
+				},
+				&schema.Comment{Text: "table comment"},
 			},
 		},
 		{
@@ -174,7 +178,7 @@ table "accounts" {
 		{
 			Symbol:     "accounts",
 			Table:      exp.Tables[0],
-			Columns:    []*schema.Column{exp.Tables[0].Columns[2]},
+			Columns:    []*schema.Column{exp.Tables[0].Columns[4]},
 			RefTable:   exp.Tables[1],
 			RefColumns: []*schema.Column{exp.Tables[1].Columns[0]},
 			OnDelete:   schema.SetNull,

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -98,7 +98,14 @@ func schemaSpec(schem *schema.Schema) (*sqlspec.Schema, []*sqlspec.Table, error)
 
 // tableSpec converts from a concrete Postgres sqlspec.Table to a schema.Table.
 func tableSpec(tab *schema.Table) (*sqlspec.Table, error) {
-	return specutil.FromTable(tab, columnSpec, specutil.FromPrimaryKey, specutil.FromIndex, specutil.FromForeignKey)
+	return specutil.FromTable(
+		tab,
+		columnSpec,
+		specutil.FromPrimaryKey,
+		specutil.FromIndex,
+		specutil.FromForeignKey,
+		specutil.FromCheck,
+	)
 }
 
 // columnSpec converts from a concrete Postgres schema.Column into a sqlspec.Column.

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -28,17 +28,7 @@ func MarshalSpec(v interface{}, marshaler schemaspec.Marshaler) ([]byte, error) 
 // ForeignKeySpecs into ForeignKeys, as the target tables do not necessarily exist in the schema
 // at this point. Instead, the linking is done by the convertSchema function.
 func convertTable(spec *sqlspec.Table, parent *schema.Schema) (*schema.Table, error) {
-	return specutil.Table(spec, parent, convertColumn, convertPrimaryKey, convertIndex)
-}
-
-// convertPrimaryKey converts a sqlspec.PrimaryKey to a schema.Index.
-func convertPrimaryKey(spec *sqlspec.PrimaryKey, parent *schema.Table) (*schema.Index, error) {
-	return specutil.PrimaryKey(spec, parent)
-}
-
-// convertIndex converts an sqlspec.Index to a schema.Index.
-func convertIndex(spec *sqlspec.Index, parent *schema.Table) (*schema.Index, error) {
-	return specutil.Index(spec, parent)
+	return specutil.Table(spec, parent, convertColumn, specutil.PrimaryKey, specutil.Index, specutil.Check)
 }
 
 // convertColumn converts a sqlspec.Column into a schema.Column.

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -22,6 +22,9 @@ table "table" {
 	column "age" {
 		type = integer
 	}
+	column "price" {
+		type = int
+	}
 	column "account_name" {
 		type = varchar(32)
 	}
@@ -47,6 +50,9 @@ table "table" {
 			table.accounts.column.name,
 		]
 		on_delete = "SET NULL"
+	}
+	check "positive price" {
+		expr = "price > 0"
 	}
 	comment = "table comment"
 }
@@ -91,6 +97,14 @@ table "accounts" {
 					},
 				},
 				{
+					Name: "price",
+					Type: &schema.ColumnType{
+						Type: &schema.IntegerType{
+							T: TypeInt,
+						},
+					},
+				},
+				{
 					Name: "account_name",
 					Type: &schema.ColumnType{
 						Type: &schema.StringType{
@@ -109,6 +123,10 @@ table "accounts" {
 				},
 			},
 			Attrs: []schema.Attr{
+				&schema.Check{
+					Name: "positive price",
+					Expr: "price > 0",
+				},
 				&schema.Comment{Text: "table comment"},
 			},
 		},
@@ -152,7 +170,7 @@ table "accounts" {
 		{
 			Symbol:     "accounts",
 			Table:      exp.Tables[0],
-			Columns:    []*schema.Column{exp.Tables[0].Columns[2]},
+			Columns:    []*schema.Column{exp.Tables[0].Columns[3]},
 			RefTable:   exp.Tables[1],
 			RefColumns: []*schema.Column{exp.Tables[1].Columns[0]},
 			OnDelete:   schema.SetNull,

--- a/sql/sqlite/sqlspec.go
+++ b/sql/sqlite/sqlspec.go
@@ -24,17 +24,7 @@ func MarshalSpec(v interface{}, marshaler schemaspec.Marshaler) ([]byte, error) 
 // ForeignKeySpecs into ForeignKeys, as the target tables do not necessarily exist in the schema
 // at this point. Instead, the linking is done by the convertSchema function.
 func convertTable(spec *sqlspec.Table, parent *schema.Schema) (*schema.Table, error) {
-	return specutil.Table(spec, parent, convertColumn, convertPrimaryKey, convertIndex)
-}
-
-// convertPrimaryKey converts a sqlspec.PrimaryKey to a schema.Index.
-func convertPrimaryKey(spec *sqlspec.PrimaryKey, parent *schema.Table) (*schema.Index, error) {
-	return specutil.PrimaryKey(spec, parent)
-}
-
-// convertIndex converts an sqlspec.Index to a schema.Index.
-func convertIndex(spec *sqlspec.Index, parent *schema.Table) (*schema.Index, error) {
-	return specutil.Index(spec, parent)
+	return specutil.Table(spec, parent, convertColumn, specutil.PrimaryKey, specutil.Index, specutil.Check)
 }
 
 // convertColumn converts a sqlspec.Column into a schema.Column.

--- a/sql/sqlite/sqlspec.go
+++ b/sql/sqlite/sqlspec.go
@@ -54,7 +54,14 @@ func schemaSpec(schem *schema.Schema) (*sqlspec.Schema, []*sqlspec.Table, error)
 
 // tableSpec converts from a concrete SQLite sqlspec.Table to a schema.Table.
 func tableSpec(tab *schema.Table) (*sqlspec.Table, error) {
-	return specutil.FromTable(tab, columnSpec, specutil.FromPrimaryKey, specutil.FromIndex, specutil.FromForeignKey)
+	return specutil.FromTable(
+		tab,
+		columnSpec,
+		specutil.FromPrimaryKey,
+		specutil.FromIndex,
+		specutil.FromForeignKey,
+		specutil.FromCheck,
+	)
 }
 
 // columnSpec converts from a concrete SQLite schema.Column into a sqlspec.Column.

--- a/sql/sqlite/sqlspec_test.go
+++ b/sql/sqlite/sqlspec_test.go
@@ -24,6 +24,9 @@ table "table" {
 	column "age" {
 		type = integer
 	}
+	column "price" {
+		type = integer
+	}
 	column "account_name" {
 		type = varchar(32)
 	}
@@ -45,6 +48,9 @@ table "table" {
 			table.accounts.column.name,
 		]
 		on_delete = "SET NULL"
+	}
+	check "positive price" {
+		expr = "price > 0"
 	}
 }
 
@@ -82,6 +88,14 @@ table "accounts" {
 					},
 				},
 				{
+					Name: "price",
+					Type: &schema.ColumnType{
+						Type: &schema.IntegerType{
+							T: "integer",
+						},
+					},
+				},
+				{
 					Name: "account_name",
 					Type: &schema.ColumnType{
 						Type: &schema.StringType{
@@ -89,6 +103,12 @@ table "accounts" {
 							Size: 32,
 						},
 					},
+				},
+			},
+			Attrs: []schema.Attr{
+				&schema.Check{
+					Name: "positive price",
+					Expr: "price > 0",
 				},
 			},
 		},
@@ -129,7 +149,7 @@ table "accounts" {
 		{
 			Symbol:     "accounts",
 			Table:      exp.Tables[0],
-			Columns:    []*schema.Column{exp.Tables[0].Columns[2]},
+			Columns:    []*schema.Column{exp.Tables[0].Columns[3]},
 			RefTable:   exp.Tables[1],
 			RefColumns: []*schema.Column{exp.Tables[1].Columns[0]},
 			OnDelete:   schema.SetNull,

--- a/sql/sqlspec/sqlspec.go
+++ b/sql/sqlspec/sqlspec.go
@@ -50,8 +50,9 @@ type (
 
 	// Check holds a specification for a check constraint on a table.
 	Check struct {
-		Name string `spec:",name"`
-		Expr string `spec:"expr"`
+		Name     string `spec:",name"`
+		Expr     string `spec:"expr"`
+		Enforced bool   `spec:"enforced"`
 		schemaspec.DefaultExtension
 	}
 

--- a/sql/sqlspec/sqlspec.go
+++ b/sql/sqlspec/sqlspec.go
@@ -21,6 +21,7 @@ type (
 		PrimaryKey  *PrimaryKey     `spec:"primary_key"`
 		ForeignKeys []*ForeignKey   `spec:"foreign_key"`
 		Indexes     []*Index        `spec:"index"`
+		Checks      []*Check        `spec:"check"`
 		schemaspec.DefaultExtension
 	}
 
@@ -44,6 +45,13 @@ type (
 		Name    string            `spec:",name"`
 		Unique  bool              `spec:"unique"`
 		Columns []*schemaspec.Ref `spec:"columns"`
+		schemaspec.DefaultExtension
+	}
+
+	// Check holds a specification for a check constraint on a table.
+	Check struct {
+		Name string `spec:",name"`
+		Expr string `spec:"expr"`
 		schemaspec.DefaultExtension
 	}
 


### PR DESCRIPTION
This PR adds support for adding check constraints to the HCL. Since check constraints defined on a column will eventually end up defined on the table instead (after `show create table`) HCL only allows for check constraints on the table. In the future this can be extended, if it is needed.

A check constrained is defined as following:

```hcl
check "positive" {
  expr     = "c > 0" // c is column name
  enforced = false   // MySQL only
}
```
