### PR TITLE
sql/mysql: support modifying schema charset and collation attributes

### DIFF
--- a/sql/internal/sqlx/diff.go
+++ b/sql/internal/sqlx/diff.go
@@ -102,6 +102,7 @@ func (d *Diff) SchemaDiff(from, to *schema.Schema) ([]schema.Change, error) {
 	// Drop or modify attributes (collations, charset, etc).
 	if change := d.SchemaAttrDiff(from, to); len(change) > 0 {
 		changes = append(changes, &schema.ModifySchema{
+			S:       to,
 			Changes: change,
 		})
 	}
@@ -119,7 +120,7 @@ func (d *Diff) SchemaDiff(from, to *schema.Schema) ([]schema.Change, error) {
 		}
 		if len(change) > 0 {
 			changes = append(changes, &schema.ModifyTable{
-				T:       t1,
+				T:       t2,
 				Changes: change,
 			})
 		}
@@ -457,5 +458,22 @@ func Unquote(s string) (string, error) {
 		return strings.ReplaceAll(s[1:len(s)-1], "''", "'"), nil
 	default:
 		return s, nil
+	}
+}
+
+// SingleQuote quotes the given string with single quote.
+func SingleQuote(s string) (string, error) {
+	switch {
+	case IsQuoted(s, '\''):
+		return s, nil
+	case IsQuoted(s, '"'):
+		v, err := strconv.Unquote(s)
+		if err != nil {
+			return "", err
+		}
+		s = v
+		fallthrough
+	default:
+		return "'" + strings.ReplaceAll(s, "'", "''") + "'", nil
 	}
 }

--- a/sql/mysql/diff_test.go
+++ b/sql/mysql/diff_test.go
@@ -383,8 +383,8 @@ func TestDiff_SchemaDiff(t *testing.T) {
 	changes, err = drv.SchemaDiff(from, to)
 	require.NoError(t, err)
 	require.EqualValues(t, []schema.Change{
-		&schema.ModifySchema{Changes: []schema.Change{&schema.ModifyAttr{From: from.Attrs[0], To: to.Attrs[0]}}},
-		&schema.ModifyTable{T: from.Tables[0], Changes: []schema.Change{&schema.AddColumn{C: to.Tables[0].Columns[0]}}},
+		&schema.ModifySchema{S: to, Changes: []schema.Change{&schema.ModifyAttr{From: from.Attrs[0], To: to.Attrs[0]}}},
+		&schema.ModifyTable{T: to.Tables[0], Changes: []schema.Change{&schema.AddColumn{C: to.Tables[0].Columns[0]}}},
 		&schema.DropTable{T: from.Tables[1]},
 		&schema.AddTable{T: to.Tables[1]},
 	}, changes)
@@ -449,8 +449,8 @@ func TestDiff_RealmDiff(t *testing.T) {
 	changes, err := drv.RealmDiff(from, to)
 	require.NoError(t, err)
 	require.EqualValues(t, []schema.Change{
-		&schema.ModifySchema{Changes: []schema.Change{&schema.ModifyAttr{From: from.Schemas[0].Attrs[0], To: to.Schemas[0].Attrs[0]}}},
-		&schema.ModifyTable{T: from.Schemas[0].Tables[0], Changes: []schema.Change{&schema.AddColumn{C: to.Schemas[0].Tables[0].Columns[0]}}},
+		&schema.ModifySchema{S: to.Schemas[0], Changes: []schema.Change{&schema.ModifyAttr{From: from.Schemas[0].Attrs[0], To: to.Schemas[0].Attrs[0]}}},
+		&schema.ModifyTable{T: to.Schemas[0].Tables[0], Changes: []schema.Change{&schema.AddColumn{C: to.Schemas[0].Tables[0].Columns[0]}}},
 		&schema.DropSchema{S: from.Schemas[1]},
 		&schema.AddSchema{S: to.Schemas[1]},
 		&schema.AddTable{T: to.Schemas[1].Tables[0]},

--- a/sql/mysql/migrate.go
+++ b/sql/mysql/migrate.go
@@ -145,13 +145,13 @@ func (s *state) modifySchema(modify *schema.ModifySchema) error {
 			switch a := change.A.(type) {
 			case *schema.Charset:
 				if a.V != "" && a.V != s.charset {
-					b.Comma().P("CHARSET", a.V)
-					r.Comma().P("CHARSET", s.charset)
+					b.P("CHARSET", a.V)
+					r.P("CHARSET", s.charset)
 				}
 			case *schema.Collation:
 				if a.V != "" && a.V != s.collate {
-					b.Comma().P("COLLATE", a.V)
-					r.Comma().P("COLLATE", s.collate)
+					b.P("COLLATE", a.V)
+					r.P("COLLATE", s.collate)
 				}
 			default:
 				return fmt.Errorf("unexpected schema AddAttr: %T", a)
@@ -163,15 +163,15 @@ func (s *state) modifySchema(modify *schema.ModifySchema) error {
 				if !ok {
 					return fmt.Errorf("mismatch ModifyAttr attributes: %T != %T", change.To, change.From)
 				}
-				b.Comma().P("CHARSET", to.V)
-				r.Comma().P("CHARSET", from.V)
+				b.P("CHARSET", to.V)
+				r.P("CHARSET", from.V)
 			case *schema.Collation:
 				from, ok := change.From.(*schema.Collation)
 				if !ok {
 					return fmt.Errorf("mismatch ModifyAttr attributes: %T != %T", change.To, change.From)
 				}
-				b.Comma().P("COLLATE", to.V)
-				r.Comma().P("COLLATE", from.V)
+				b.P("COLLATE", to.V)
+				r.P("COLLATE", from.V)
 			default:
 				return fmt.Errorf("unexpected schema ModifyAttr: %T", change)
 			}

--- a/sql/postgres/diff_test.go
+++ b/sql/postgres/diff_test.go
@@ -312,7 +312,7 @@ func TestDiff_SchemaDiff(t *testing.T) {
 	changes, err := drv.SchemaDiff(from, to)
 	require.NoError(t, err)
 	require.EqualValues(t, []schema.Change{
-		&schema.ModifyTable{T: from.Tables[0], Changes: []schema.Change{&schema.AddColumn{C: to.Tables[0].Columns[0]}}},
+		&schema.ModifyTable{T: to.Tables[0], Changes: []schema.Change{&schema.AddColumn{C: to.Tables[0].Columns[0]}}},
 		&schema.DropTable{T: from.Tables[1]},
 		&schema.AddTable{T: to.Tables[1]},
 	}, changes)

--- a/sql/sqlite/diff.go
+++ b/sql/sqlite/diff.go
@@ -73,7 +73,15 @@ func (d *diff) typeChanged(from, to *schema.Column) (bool, error) {
 func (d *diff) defaultChanged(from, to *schema.Column) bool {
 	d1, ok1 := sqlx.DefaultValue(from)
 	d2, ok2 := sqlx.DefaultValue(to)
-	return ok1 != ok2 || d1 != d2
+	if ok1 != ok2 {
+		return true
+	}
+	if d1 == d2 {
+		return false
+	}
+	x1, err1 := sqlx.Unquote(d1)
+	x2, err2 := sqlx.Unquote(d2)
+	return err1 != nil || err2 != nil || x1 != x2
 }
 
 // IndexAttrChanged reports if the index attributes were changed.

--- a/sql/sqlite/diff_test.go
+++ b/sql/sqlite/diff_test.go
@@ -289,7 +289,7 @@ func TestDiff_SchemaDiff(t *testing.T) {
 	changes, err := drv.SchemaDiff(from, to)
 	require.NoError(t, err)
 	require.EqualValues(t, []schema.Change{
-		&schema.ModifyTable{T: from.Tables[0], Changes: []schema.Change{&schema.AddColumn{C: to.Tables[0].Columns[0]}}},
+		&schema.ModifyTable{T: to.Tables[0], Changes: []schema.Change{&schema.AddColumn{C: to.Tables[0].Columns[0]}}},
 		&schema.DropTable{T: from.Tables[1]},
 		&schema.AddTable{T: to.Tables[1]},
 	}, changes)


### PR DESCRIPTION
We can consider to add schema changes as ModifyCharset and ModifyCollation
in the future to avoid all the type assertion.