### PR TITLE
doc/website: align the atlas icon in the docs

### DIFF
--- a/doc/website/src/css/custom.css
+++ b/doc/website/src/css/custom.css
@@ -13,6 +13,11 @@
   height: 65px;
 }
 
+.navbar__logo {
+  display: flex;
+  align-items: center;
+}
+
 .footer__title {
   font-size: 22px;
 }


### PR DESCRIPTION
DESCRIPTION
icon position is wrongly placed.

The reason is that the build version adds a div that dosnt exist in the local dev env (navbar__logo).  see attachments 

build
![Screen Shot 2022-01-18 at 12 52 41](https://user-images.githubusercontent.com/9443953/149924034-20affdea-2ea8-4ca6-a162-ee480ed189ad.png)

local
![Screen Shot 2022-01-18 at 12 52 55](https://user-images.githubusercontent.com/9443953/149924041-c5e3e3d3-599b-41ae-a921-80fd195a436a.png)
