### PR TITLE
atlas: preparations for referenced column types

### DIFF
--- a/schema/schemaspec/extension.go
+++ b/schema/schemaspec/extension.go
@@ -277,10 +277,17 @@ func setPtr(field reflect.Value, val Value) error {
 		field.Set(reflect.ValueOf(val))
 		return nil
 	}
-	if x, ok := val.(*RawExpr); ok {
-		i := field.Interface()
-		if _, ok := i.(*Type); ok {
-			field.Set(reflect.ValueOf(&Type{T: x.X}))
+	// If we are setting a Type field handle RawExpr and Ref specifically.
+	if _, ok := field.Interface().(*Type); ok {
+		switch t := val.(type) {
+		case *RawExpr:
+			field.Set(reflect.ValueOf(&Type{T: t.X}))
+			return nil
+		case *Ref:
+			field.Set(reflect.ValueOf(&Type{
+				T:     t.V,
+				IsRef: true,
+			}))
 			return nil
 		}
 	}

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -96,6 +96,7 @@ type (
 	Type struct {
 		T     string
 		Attrs []*Attr
+		IsRef bool
 	}
 )
 

--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -39,7 +39,7 @@ func Realm(schemas []*sqlspec.Schema, tables []*sqlspec.Table, convertTable Conv
 	for _, schemaSpec := range schemas {
 		var schemaTables []*sqlspec.Table
 		for _, tableSpec := range tables {
-			name, err := schemaName(tableSpec.Schema)
+			name, err := SchemaName(tableSpec.Schema)
 			if err != nil {
 				return nil, fmt.Errorf("specutil: cannot extract schema name for table %q: %w", tableSpec.Name, err)
 			}
@@ -72,7 +72,7 @@ func Schema(spec *sqlspec.Schema, tables []*sqlspec.Table, convertTable ConvertT
 		m[table] = ts
 	}
 	for _, tbl := range sch.Tables {
-		if err := linkForeignKeys(tbl, sch, m[tbl]); err != nil {
+		if err := LinkForeignKeys(tbl, sch, m[tbl]); err != nil {
 			return nil, err
 		}
 	}
@@ -211,10 +211,10 @@ func PrimaryKey(spec *sqlspec.PrimaryKey, parent *schema.Table) (*schema.Index, 
 	}, nil
 }
 
-// linkForeignKeys creates the foreign keys defined in the Table's spec by creating references
+// LinkForeignKeys creates the foreign keys defined in the Table's spec by creating references
 // to column in the provided Schema. It is assumed that the schema contains all of the tables
 // referenced by the FK definitions in the spec.
-func linkForeignKeys(tbl *schema.Table, sch *schema.Schema, table *sqlspec.Table) error {
+func LinkForeignKeys(tbl *schema.Table, sch *schema.Schema, table *sqlspec.Table) error {
 	for _, spec := range table.ForeignKeys {
 		fk := &schema.ForeignKey{
 			Symbol:   spec.Symbol,
@@ -464,7 +464,8 @@ func FromCheck(s *schema.Check) *sqlspec.Check {
 	}
 }
 
-func schemaName(ref *schemaspec.Ref) (string, error) {
+// SchemaName returns the name from a ref to a schema.
+func SchemaName(ref *schemaspec.Ref) (string, error) {
 	parts := strings.Split(ref.V, ".")
 	if len(parts) < 2 || parts[0] != "$schema" {
 		return "", fmt.Errorf("expected ref format of $schema.name")

--- a/sql/internal/specutil/spec.go
+++ b/sql/internal/specutil/spec.go
@@ -79,7 +79,8 @@ func Marshal(v interface{}, marshaler schemaspec.Marshaler, schemaSpec func(sche
 
 // Unmarshal unmarshals an Atlas DDL document using an unmarshaler into v. Unmarshal uses the
 // given convertTable function to convert a *sqlspec.Table into a *schema.Table.
-func Unmarshal(data []byte, unmarshaler schemaspec.Unmarshaler, v interface{}, convertTable func(spec *sqlspec.Table, parent *schema.Schema) (*schema.Table, error)) error {
+func Unmarshal(data []byte, unmarshaler schemaspec.Unmarshaler, v interface{},
+	convertTable ConvertTableFunc) error {
 	var d doc
 	if err := unmarshaler.UnmarshalSpec(data, &d); err != nil {
 		return err

--- a/sql/mysql/sqlspec.go
+++ b/sql/mysql/sqlspec.go
@@ -175,6 +175,7 @@ func columnSpec(c *schema.Column, t *schema.Table) (*sqlspec.Column, error) {
 	return col, nil
 }
 
+// checkSpec converts from a concrete MySQL schema.Check into a sqlspec.Check.
 func checkSpec(s *schema.Check) *sqlspec.Check {
 	c := specutil.FromCheck(s)
 	if e := (Enforced{}); sqlx.Has(s.Attrs, &e) {

--- a/sql/mysql/sqlspec_test.go
+++ b/sql/mysql/sqlspec_test.go
@@ -661,10 +661,6 @@ func TestTypes(t *testing.T) {
 			expected: &schema.StringType{T: TypeLongText},
 		},
 		{
-			typeExpr: `enum("a","b")`,
-			expected: &schema.EnumType{T: "enum", Values: []string{"a", "b"}},
-		},
-		{
 			typeExpr: `set("a","b")`,
 			expected: &SetType{Values: []string{"a", "b"}},
 		},

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -129,7 +129,6 @@ var TypeRegistry = specutil.NewRegistry(
 		specutil.TypeSpec(TypeTimestamp),
 		specutil.AliasTypeSpec("timestamp_with_time_zone", TypeTimestampWTZ),
 		specutil.AliasTypeSpec("timestamp_without_time_zone", TypeTimestampWOTZ),
-		specutil.TypeSpec("enum", &schemaspec.TypeAttr{Name: "values", Kind: reflect.Slice, Required: true}),
 		specutil.AliasTypeSpec("double_precision", TypeDouble),
 		specutil.TypeSpec(TypeReal),
 		specutil.TypeSpec(TypeFloat8),


### PR DESCRIPTION
This PR introdues first steps to enable referenced column types. This is needed for the postgres implementation of enums.

The goal is to support HCL like the following:

```hcl
schema "sch" {}
table "tbl" {
  column "col" {
    type = enum.my_enum
  }
}
enum "my_enum" {
  values = ["on", "off"]
}
```

The first approach was to change `sqlspec.Table.Colum` from `*schemaspec.Type` to `schemaspec.Value` but handling a `Value` required different handling on `sqlspec.Table.Column.Type` and `sqlspec.Table.Column.Default` and the current structure didn't allow for this.

The current approach is valid too and all the implementation details are hidden from the actual `schema.Schema` the atlas internals work with.

Please note, that implementation for converting between `sqlspec.Schema` and `schema.Schema` will follow in another PR.