### PR TITLE
sql/postgres: unmarshal HCL enum

### DIFF
--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -41,7 +41,7 @@ func UnmarshalSpec(data []byte, unmarshaler schemaspec.Unmarshaler, v interface{
 	}
 	switch v := v.(type) {
 	case *schema.Realm:
-		realm, err := Realm(d)
+		realm, err := Realm(d.Schemas, d.Tables, d.Enums)
 		if err != nil {
 			return fmt.Errorf("specutil: failed converting to *schema.Realm: %w", err)
 		}
@@ -67,14 +67,14 @@ func MarshalSpec(v interface{}, marshaler schemaspec.Marshaler) ([]byte, error) 
 }
 
 // Realm converts the schemas and tables of the doc into a schema.Realm.
-func Realm(d doc) (*schema.Realm, error) {
+func Realm(schemas []*sqlspec.Schema, tables []*sqlspec.Table, enums []*Enum) (*schema.Realm, error) {
 	r := &schema.Realm{}
-	for _, schemaSpec := range d.Schemas {
+	for _, schemaSpec := range schemas {
 		var (
 			schemaTables []*sqlspec.Table
 			schemaEnums  []*Enum
 		)
-		for _, tableSpec := range d.Tables {
+		for _, tableSpec := range tables {
 			name, err := specutil.SchemaName(tableSpec.Schema)
 			if err != nil {
 				return nil, fmt.Errorf("specutil: cannot extract schema name for table %q: %w", tableSpec.Name, err)
@@ -83,7 +83,7 @@ func Realm(d doc) (*schema.Realm, error) {
 				schemaTables = append(schemaTables, tableSpec)
 			}
 		}
-		for _, enum := range d.Enums {
+		for _, enum := range enums {
 			name, err := specutil.SchemaName(enum.Schema)
 			if err != nil {
 				return nil, fmt.Errorf("specutil: cannot extract schema name for table %q: %w", enum.Name, err)

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -61,9 +61,16 @@ table "accounts" {
 	column "name" {
 		type = varchar(32)
 	}
+	column "type" {
+		type = enum.account_type
+	}
 	primary_key {
 		columns = [table.accounts.column.name]
 	}
+}
+
+enum "account_type" {
+	values = ["private", "business"]
 }
 `
 	var s schema.Schema
@@ -140,6 +147,15 @@ table "accounts" {
 						Type: &schema.StringType{
 							T:    "varchar",
 							Size: 32,
+						},
+					},
+				},
+				{
+					Name: "type",
+					Type: &schema.ColumnType{
+						Type: &EnumType{
+							T:      "account_type",
+							Values: []string{"private", "business"},
 						},
 					},
 				},


### PR DESCRIPTION
This is the `Unmarshal` part of the postgres support for enums.