### PR TITLE
sql/postgres: marshal HCL enum

### DIFF
--- a/schema/schemaspec/schemahcl/hcl.go
+++ b/schema/schemaspec/schemahcl/hcl.go
@@ -255,6 +255,11 @@ func (s *state) writeAttr(attr *schemaspec.Attr, body *hclwrite.Body) error {
 		expr := strings.ReplaceAll(v.V, "$", "")
 		body.SetAttributeRaw(attr.K, hclRawTokens(expr))
 	case *schemaspec.Type:
+		if v.IsRef {
+			expr := strings.ReplaceAll(v.T, "$", "")
+			body.SetAttributeRaw(attr.K, hclRawTokens(expr))
+			break
+		}
 		spec, ok := s.findTypeSpec(v.T)
 		if !ok {
 			v := fmt.Sprintf("sql(%q)", v.T)

--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -302,7 +302,7 @@ func FromSchema(s *schema.Schema, fn TableSpecFunc) (*sqlspec.Schema, []*sqlspec
 			return nil, nil, err
 		}
 		if s.Name != "" {
-			table.Schema = schemaRef(s.Name)
+			table.Schema = SchemaRef(s.Name)
 		}
 		tables = append(tables, table)
 	}
@@ -501,7 +501,8 @@ func colRef(cName string, tName string) *schemaspec.Ref {
 	}
 }
 
-func schemaRef(n string) *schemaspec.Ref {
+// SchemaRef returns the schemaspec.Ref to the schema with the given name.
+func SchemaRef(n string) *schemaspec.Ref {
 	return &schemaspec.Ref{V: "$schema." + n}
 }
 

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -201,6 +201,36 @@ enum "account_type" {
 	require.EqualValues(t, exp, &s)
 }
 
+func TestMarshalSpec_Enum(t *testing.T) {
+	s := schema.New("test").
+		AddTables(
+			schema.NewTable("account").
+				AddColumns(
+					schema.NewEnumColumn("account_type",
+						schema.EnumName("account_type"),
+						schema.EnumValues("private", "business"),
+					),
+				),
+		)
+	buf, err := MarshalSpec(s, hclState)
+	require.NoError(t, err)
+	const expected = `table "account" {
+  schema = schema.test
+  column "account_type" {
+    null = false
+    type = enum.account_type
+  }
+}
+schema "test" {
+}
+enum "account_type" {
+  schema = schema.test
+  values = ["private", "business", ]
+}
+`
+	require.EqualValues(t, expected, string(buf))
+}
+
 func TestTypes(t *testing.T) {
 	// TODO(rotemtam): enum, timestamptz, interval
 	for _, tt := range []struct {


### PR DESCRIPTION
This is the `Marshal` part of the postgres support for enums.