### PR TITLE
cmd/action: Parse schema name in postgres dsn

### DIFF
--- a/cmd/action/mux.go
+++ b/cmd/action/mux.go
@@ -106,14 +106,12 @@ func postgresSchema(dsn string) (string, error) {
 		// parse.
 		return "public", nil
 	}
-
 	// lib/pq supports setting default schemas via the `search_path` parameter
 	// in a dsn.
 	//
 	// See: https://github.com/lib/pq/blob/8446d16b8935fdf2b5c0fe333538ac395e3e1e4b/conn.go#L1155-L1165
-	queries := url.Query()
-	if queries.Has("search_path") {
-		return queries.Get("search_path"), nil
+	if schema := url.Query().Get("search_path"); schema != "" {
+		return schema, nil
 	}
 
 	return "public", nil

--- a/cmd/action/mux_test.go
+++ b/cmd/action/mux_test.go
@@ -116,3 +116,30 @@ func Test_SQLiteInMemory(t *testing.T) {
 	_, err := action.SchemaNameFromDSN("sqlite://file:test.db?cache=shared&mode=memory")
 	r.NoError(err)
 }
+
+func Test_PostgresSchemaDSN(t *testing.T) {
+	var tests = []struct {
+		dsn      string
+		expected string
+	}{
+		{
+			dsn:      "postgres://localhost:5432/dbname?search_path=foo",
+			expected: "foo",
+		},
+		{
+			dsn:      "postgres://localhost:5432/dbname",
+			expected: "public",
+		},
+		{
+			dsn:      "postgres://(bad:host)?search_path=foo",
+			expected: "public",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.dsn, func(t *testing.T) {
+			schema, err := action.SchemaNameFromDSN(tt.dsn)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, schema)
+		})
+	}
+}

--- a/cmd/action/mux_test.go
+++ b/cmd/action/mux_test.go
@@ -134,6 +134,10 @@ func Test_PostgresSchemaDSN(t *testing.T) {
 			dsn:      "postgres://(bad:host)?search_path=foo",
 			expected: "public",
 		},
+		{
+			dsn:      "postgres://localhost:5432/dbname?search_path=",
+			expected: "public",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.dsn, func(t *testing.T) {


### PR DESCRIPTION
`lib/pq` supports parsing runtime parameters from the DSN. Allowing for
configuration of the schema to inspect or apply on using the
`search_path` parameter.

Closes: #457