### PR TITLE
sql/mysql: support unmarshal on update expressions in HCL

### DIFF
--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -600,45 +600,47 @@ func TestMySQL_Sanity(t *testing.T) {
 		ddl := `
 create table atlas_types_sanity
 (
-    tBit                 bit(10)              default b'100'               null,
-    tInt                 int(10)              default 4                not null,
-    tTinyInt             tinyint(10)          default 8                    null,
-    tSmallInt            smallint(10)         default 2                    null,
-    tMediumInt           mediumint(10)        default 11                   null,
-    tBigInt              bigint(10)           default 4                    null,
-    tDecimal             decimal              default 4                    null,
-    tNumeric             numeric              default 4                not null,
-    tFloat               float(10, 0)         default 4                    null,
-    tDouble              double(10, 0)        default 4                    null,
-    tReal                double(10, 0)        default 4                    null,
-    tTimestamp           timestamp            default CURRENT_TIMESTAMP    null,
-    tTimestampFraction   timestamp(6)         default CURRENT_TIMESTAMP(6) null,
-    tDate                date                                              null,
-    tTime                time                                              null,
-    tDateTime            datetime                                          null,
-    tYear                year                                              null,
-    tVarchar             varchar(10)          default 'Titan'              null,
-    tChar                char(25)             default 'Olimpia'        not null,
-    tVarBinary           varbinary(30)        default 'Titan'              null,
-    tBinary              binary(5)            default 'Titan'              null,
-    tBlob                blob(5)              default                      null,
-    tTinyBlob            tinyblob                                          null,
-    tMediumBlob          mediumblob           default                      null,
-    tLongBlob            longblob             default                      null,
-    tText                text(13)             default                      null,
-    tTinyText            tinytext             default                      null,
-    tMediumText          mediumtext           default                      null,
-    tLongText            longtext             default                      null,
-    tEnum                enum('a','b')        default                      null,
-    tSet                 set('a','b')         default                      null,
-    tGeometry            geometry             default                      null,
-    tPoint               point                default                      null,
-    tMultiPoint          multipoint           default                      null,
-    tLineString          linestring           default                      null,
-    tMultiLineString     multilinestring      default                      null,
-    tPolygon             polygon              default                      null,
-    tMultiPolygon        multipolygon         default                      null,
-    tGeometryCollection  geometrycollection   default                      null
+    tBit                        bit(10)              default b'100'                                              null,
+    tInt                        int(10)              default 4                                               not null,
+    tTinyInt                    tinyint(10)          default 8                                                   null,
+    tSmallInt                   smallint(10)         default 2                                                   null,
+    tMediumInt                  mediumint(10)        default 11                                                  null,
+    tBigInt                     bigint(10)           default 4                                                   null,
+    tDecimal                    decimal              default 4                                                   null,
+    tNumeric                    numeric              default 4                                               not null,
+    tFloat                      float(10, 0)         default 4                                                   null,
+    tDouble                     double(10, 0)        default 4                                                   null,
+    tReal                       double(10, 0)        default 4                                                   null,
+    tTimestamp                  timestamp            default CURRENT_TIMESTAMP                                   null,
+    tTimestampFraction          timestamp(6)         default CURRENT_TIMESTAMP(6)                                null,
+    tTimestampOnUpdate          timestamp            default CURRENT_TIMESTAMP    ON UPDATE CURRENT_TIMESTAMP    null,
+    tTimestampFractionOnUpdate  timestamp(6)         default CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) null,
+    tDate                       date                                                                             null,
+    tTime                       time                                                                             null,
+    tDateTime                   datetime                                                                         null,
+    tYear                       year                                                                             null,
+    tVarchar                    varchar(10)          default 'Titan'                                             null,
+    tChar                       char(25)             default 'Olimpia'                                       not null,
+    tVarBinary                  varbinary(30)        default 'Titan'                                             null,
+    tBinary                     binary(5)            default 'Titan'                                             null,
+    tBlob                       blob(5)              default                                                     null,
+    tTinyBlob                   tinyblob                                                                         null,
+    tMediumBlob                 mediumblob           default                                                     null,
+    tLongBlob                   longblob             default                                                     null,
+    tText                       text(13)             default                                                     null,
+    tTinyText                   tinytext             default                                                     null,
+    tMediumText                 mediumtext           default                                                     null,
+    tLongText                   longtext             default                                                     null,
+    tEnum                       enum('a','b')        default                                                     null,
+    tSet                        set('a','b')         default                                                     null,
+    tGeometry                   geometry             default                                                     null,
+    tPoint                      point                default                                                     null,
+    tMultiPoint                 multipoint           default                                                     null,
+    tLineString                 linestring           default                                                     null,
+    tMultiLineString            multilinestring      default                                                     null,
+    tPolygon                    polygon              default                                                     null,
+    tMultiPolygon               multipolygon         default                                                     null,
+    tGeometryCollection         geometrycollection   default                                                     null
 ) CHARSET = latin1 COLLATE latin1_swedish_ci;
 `
 		myRun(t, func(t *myTest) {
@@ -746,6 +748,52 @@ create table atlas_types_sanity
 								}
 								return "CURRENT_TIMESTAMP(6)"
 							}(),
+						},
+					},
+					{
+						Name: "tTimestampOnUpdate",
+						Type: &schema.ColumnType{Type: &schema.TimeType{T: "timestamp"},
+							Raw: "timestamp", Null: true},
+						Default: &schema.RawExpr{
+							X: func() string {
+								if t.mariadb() {
+									return "current_timestamp()"
+								}
+								return "CURRENT_TIMESTAMP"
+							}(),
+						},
+						Attrs: []schema.Attr{
+							&mysql.OnUpdate{
+								A: func() string {
+									if t.mariadb() {
+										return "current_timestamp()"
+									}
+									return "CURRENT_TIMESTAMP"
+								}(),
+							},
+						},
+					},
+					{
+						Name: "tTimestampFractionOnUpdate",
+						Type: &schema.ColumnType{Type: &schema.TimeType{T: "timestamp", Precision: 6},
+							Raw: "timestamp(6)", Null: true},
+						Default: &schema.RawExpr{
+							X: func() string {
+								if t.mariadb() {
+									return "current_timestamp(6)"
+								}
+								return "CURRENT_TIMESTAMP(6)"
+							}(),
+						},
+						Attrs: []schema.Attr{
+							&mysql.OnUpdate{
+								A: func() string {
+									if t.mariadb() {
+										return "current_timestamp(6)"
+									}
+									return "CURRENT_TIMESTAMP(6)"
+								}(),
+							},
 						},
 					},
 					{

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -455,13 +455,13 @@ var reTimeOnUpdate = regexp.MustCompile(`(?i)^(?:default_generated )?on update (
 // extraAttr parses the EXTRA column from the INFORMATION_SCHEMA.COLUMNS table
 // and appends its parsed representation to the column.
 func (i *inspect) extraAttr(t *schema.Table, c *schema.Column, extra string) error {
-	canon := strings.ToLower(extra)
+	el := strings.ToLower(extra)
 	switch {
-	case canon == "", canon == "null": // ignore.
-	case canon == defaultGen:
+	case el == "", el == "null": // ignore.
+	case el == defaultGen:
 		// The column has an expression default value
 		// and it is handled in Driver.addColumn.
-	case canon == autoIncrement:
+	case el == autoIncrement:
 		a := &AutoIncrement{}
 		// A table can have only one AUTO_INCREMENT column. If it was returned as NULL
 		// from INFORMATION_SCHEMA, it is due to information_schema_stats_expiry and we

--- a/sql/mysql/inspect_test.go
+++ b/sql/mysql/inspect_test.go
@@ -383,10 +383,10 @@ func TestDriver_InspectTable(t *testing.T) {
 					{Name: "c1", Type: &schema.ColumnType{Raw: "date", Type: &schema.TimeType{T: "date"}}},
 					{Name: "c2", Type: &schema.ColumnType{Raw: "datetime", Type: &schema.TimeType{T: "datetime"}}},
 					{Name: "c3", Type: &schema.ColumnType{Raw: "time", Type: &schema.TimeType{T: "time"}}},
-					{Name: "c4", Type: &schema.ColumnType{Raw: "timestamp", Type: &schema.TimeType{T: "timestamp"}}, Default: &schema.RawExpr{X: "CURRENT_TIMESTAMP"}, Attrs: []schema.Attr{&OnUpdate{A: "on update current_timestamp"}}},
+					{Name: "c4", Type: &schema.ColumnType{Raw: "timestamp", Type: &schema.TimeType{T: "timestamp"}}, Default: &schema.RawExpr{X: "CURRENT_TIMESTAMP"}, Attrs: []schema.Attr{&OnUpdate{A: "current_timestamp"}}},
 					{Name: "c5", Type: &schema.ColumnType{Raw: "year(4)", Type: &schema.TimeType{T: "year", Precision: 4}}},
 					{Name: "c6", Type: &schema.ColumnType{Raw: "year", Type: &schema.TimeType{T: "year"}}},
-					{Name: "c7", Type: &schema.ColumnType{Raw: "timestamp(6)", Type: &schema.TimeType{T: "timestamp", Precision: 6}}, Default: &schema.RawExpr{X: "CURRENT_TIMESTAMP(6)"}, Attrs: []schema.Attr{&OnUpdate{A: "on update current_timestamp(6)"}}},
+					{Name: "c7", Type: &schema.ColumnType{Raw: "timestamp(6)", Type: &schema.TimeType{T: "timestamp", Precision: 6}}, Default: &schema.RawExpr{X: "CURRENT_TIMESTAMP(6)"}, Attrs: []schema.Attr{&OnUpdate{A: "current_timestamp(6)"}}},
 				}, t.Columns)
 			},
 		},

--- a/sql/mysql/inspect_test.go
+++ b/sql/mysql/inspect_test.go
@@ -383,10 +383,10 @@ func TestDriver_InspectTable(t *testing.T) {
 					{Name: "c1", Type: &schema.ColumnType{Raw: "date", Type: &schema.TimeType{T: "date"}}},
 					{Name: "c2", Type: &schema.ColumnType{Raw: "datetime", Type: &schema.TimeType{T: "datetime"}}},
 					{Name: "c3", Type: &schema.ColumnType{Raw: "time", Type: &schema.TimeType{T: "time"}}},
-					{Name: "c4", Type: &schema.ColumnType{Raw: "timestamp", Type: &schema.TimeType{T: "timestamp"}}, Default: &schema.RawExpr{X: "CURRENT_TIMESTAMP"}, Attrs: []schema.Attr{&OnUpdate{A: "current_timestamp"}}},
+					{Name: "c4", Type: &schema.ColumnType{Raw: "timestamp", Type: &schema.TimeType{T: "timestamp"}}, Default: &schema.RawExpr{X: "CURRENT_TIMESTAMP"}, Attrs: []schema.Attr{&OnUpdate{A: "CURRENT_TIMESTAMP"}}},
 					{Name: "c5", Type: &schema.ColumnType{Raw: "year(4)", Type: &schema.TimeType{T: "year", Precision: 4}}},
 					{Name: "c6", Type: &schema.ColumnType{Raw: "year", Type: &schema.TimeType{T: "year"}}},
-					{Name: "c7", Type: &schema.ColumnType{Raw: "timestamp(6)", Type: &schema.TimeType{T: "timestamp", Precision: 6}}, Default: &schema.RawExpr{X: "CURRENT_TIMESTAMP(6)"}, Attrs: []schema.Attr{&OnUpdate{A: "current_timestamp(6)"}}},
+					{Name: "c7", Type: &schema.ColumnType{Raw: "timestamp(6)", Type: &schema.TimeType{T: "timestamp", Precision: 6}}, Default: &schema.RawExpr{X: "CURRENT_TIMESTAMP(6)"}, Attrs: []schema.Attr{&OnUpdate{A: "CURRENT_TIMESTAMP(6)"}}},
 				}, t.Columns)
 			},
 		},

--- a/sql/mysql/sqlspec.go
+++ b/sql/mysql/sqlspec.go
@@ -116,7 +116,7 @@ func convertColumn(spec *sqlspec.Column, _ *schema.Table) (*schema.Column, error
 	if attr, ok := spec.Attr("on_update"); ok {
 		exp, ok := attr.V.(*schemaspec.RawExpr)
 		if !ok {
-			return nil, fmt.Errorf("unexpected type %T for atrribute \"on_update\"", attr.V)
+			return nil, fmt.Errorf(`unexpected type %T for atrribute "on_update"`, attr.V)
 		}
 		c.AddAttrs(&OnUpdate{A: exp.X})
 	}

--- a/sql/mysql/sqlspec.go
+++ b/sql/mysql/sqlspec.go
@@ -114,11 +114,11 @@ func convertColumn(spec *sqlspec.Column, _ *schema.Table) (*schema.Column, error
 		return nil, err
 	}
 	if attr, ok := spec.Attr("on_update"); ok {
-		s, err := attr.String()
-		if err != nil {
-			return nil, err
+		exp, ok := attr.V.(*schemaspec.RawExpr)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type %T for atrribute \"on_update\"", attr.V)
 		}
-		c.AddAttrs(&OnUpdate{A: s})
+		c.AddAttrs(&OnUpdate{A: exp.X})
 	}
 	return c, err
 }

--- a/sql/mysql/sqlspec_test.go
+++ b/sql/mysql/sqlspec_test.go
@@ -30,6 +30,15 @@ table "table" {
 	column "account_name" {
 		type = varchar(32)
 	}
+	column "created_at" {
+		type    = datetime(4)
+		default = sql("now(4)")
+	}
+	column "updated_at" {
+		type      = timestamp(6)
+		default   = sql("current_timestamp(6)")
+		on_update = sql("current_timestamp(6)")
+	}
 	primary_key {
 		columns = [table.table.column.col]
 	}
@@ -128,6 +137,27 @@ table "accounts" {
 							Size: 32,
 						},
 					},
+				},
+				{
+					Name: "created_at",
+					Type: &schema.ColumnType{
+						Type: &schema.TimeType{
+							T:         TypeDateTime,
+							Precision: 4,
+						},
+					},
+					Default: &schema.RawExpr{X: "now(4)"},
+				},
+				{
+					Name: "updated_at",
+					Type: &schema.ColumnType{
+						Type: &schema.TimeType{
+							T:         TypeTimestamp,
+							Precision: 6,
+						},
+					},
+					Default: &schema.RawExpr{X: "current_timestamp(6)"},
+					Attrs:   []schema.Attr{&OnUpdate{A: "current_timestamp(6)"}},
 				},
 			},
 			Attrs: []schema.Attr{


### PR DESCRIPTION
This is the "reverse" part to #486, unmarshaling HCL like shown into Go Types.