### PR TITLE
specutil/convert: fix panic on missing schema ref in table block

### DIFF
--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -33,7 +33,7 @@ type (
 	CheckSpecFunc         func(*schema.Check) *sqlspec.Check
 )
 
-var missingRefErr = errors.New("expected ref format of $schema.name")
+var errMissingRef = errors.New("expected ref format of $schema.name")
 
 // Realm converts the schemas and tables into a schema.Realm.
 func Realm(schemas []*sqlspec.Schema, tables []*sqlspec.Table, convertTable ConvertTableFunc) (*schema.Realm, error) {
@@ -469,11 +469,11 @@ func FromCheck(s *schema.Check) *sqlspec.Check {
 // SchemaName returns the name from a ref to a schema.
 func SchemaName(ref *schemaspec.Ref) (string, error) {
 	if ref == nil {
-		return "", missingRefErr
+		return "", errMissingRef
 	}
 	parts := strings.Split(ref.V, ".")
 	if len(parts) < 2 || parts[0] != "$schema" {
-		return "", missingRefErr
+		return "", errMissingRef
 	}
 	return parts[1], nil
 }

--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -33,6 +33,8 @@ type (
 	CheckSpecFunc         func(*schema.Check) *sqlspec.Check
 )
 
+var missingRefErr = errors.New("expected ref format of $schema.name")
+
 // Realm converts the schemas and tables into a schema.Realm.
 func Realm(schemas []*sqlspec.Schema, tables []*sqlspec.Table, convertTable ConvertTableFunc) (*schema.Realm, error) {
 	r := &schema.Realm{}
@@ -466,9 +468,12 @@ func FromCheck(s *schema.Check) *sqlspec.Check {
 
 // SchemaName returns the name from a ref to a schema.
 func SchemaName(ref *schemaspec.Ref) (string, error) {
+	if ref == nil {
+		return "", missingRefErr
+	}
 	parts := strings.Split(ref.V, ".")
 	if len(parts) < 2 || parts[0] != "$schema" {
-		return "", fmt.Errorf("expected ref format of $schema.name")
+		return "", missingRefErr
 	}
 	return parts[1], nil
 }

--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -33,8 +33,6 @@ type (
 	CheckSpecFunc         func(*schema.Check) *sqlspec.Check
 )
 
-var errMissingRef = errors.New("expected ref format of $schema.name")
-
 // Realm converts the schemas and tables into a schema.Realm.
 func Realm(schemas []*sqlspec.Schema, tables []*sqlspec.Table, convertTable ConvertTableFunc) (*schema.Realm, error) {
 	r := &schema.Realm{}
@@ -469,11 +467,11 @@ func FromCheck(s *schema.Check) *sqlspec.Check {
 // SchemaName returns the name from a ref to a schema.
 func SchemaName(ref *schemaspec.Ref) (string, error) {
 	if ref == nil {
-		return "", errMissingRef
+		return "", errors.New("unexpected nil reference")
 	}
 	parts := strings.Split(ref.V, ".")
 	if len(parts) < 2 || parts[0] != "$schema" {
-		return "", errMissingRef
+		return "", errors.New("expected ref format of $schema.name")
 	}
 	return parts[1], nil
 }

--- a/sql/internal/specutil/convert_test.go
+++ b/sql/internal/specutil/convert_test.go
@@ -6,6 +6,7 @@ import (
 	"ariga.io/atlas/schema/schemaspec"
 	"ariga.io/atlas/sql/schema"
 	"ariga.io/atlas/sql/sqlspec"
+
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
When creating a "valid" HCL schema, and running it through Unmarshal, everything works, but if I add another schema block, and the `table` block doesn't have reference to to the schema, it panics.

For example, before the fix this is valid and works
```HCL
schema "test" {
}

table "accounts" {
  column "name" {
    type = varchar(32)
  }
  primary_key {
    columns = [table.accounts.column.name]
  }
}
```
But this panics:

```HCL
schema "test" {
}

schema "test2" {
}

table "accounts" {
  column "name" {
    type = varchar(32)
  }
  primary_key {
    columns = [table.accounts.column.name]
  }
}
```

**This fix will also enforce the usage of `schema = ` attribute in the `table` block and make it more consistent on all cases.**

