### PR TITLE
sql/sqlspec: support marshaling index key parts

### DIFF
--- a/internal/integration/testdata/mysql/index-desc.txt
+++ b/internal/integration/testdata/mysql/index-desc.txt
@@ -1,0 +1,119 @@
+# Each test runs on a clean database.
+
+# Run this test only on MySQL 8 as it is not supported by other versions.
+only 8
+
+# Apply schema "1.hcl" on fresh database.
+apply 1.hcl
+cmpshow users 1.sql
+
+# Drop the "DESC" option from the key part.
+apply 2.hcl
+cmpshow users 2.sql
+# Use of "columns" instead of "on" should not trigger a change.
+synced 2-no-change.hcl
+
+apply 3.hcl
+cmpshow users 3.sql
+
+# Below files represent HCL and SQL. File names defined their index in
+# execution order. 1.hcl is executed first, 2.hcl executed second, etc.
+-- 1.hcl --
+schema "$db" {
+    charset = "$charset"
+    collation = "$collate"
+}
+
+table "users" {
+    schema = schema.$db
+    column "rank" {
+        type = bigint
+    }
+    index "rank_idx" {
+        on {
+            desc   = true
+            column = table.users.column.rank
+        }
+    }
+}
+
+-- 1.sql --
+CREATE TABLE `users` (
+  `rank` bigint NOT NULL,
+  KEY `rank_idx` (`rank` DESC)
+)
+
+-- 2.hcl --
+schema "$db" {
+    charset = "$charset"
+    collation = "$collate"
+}
+
+table "users" {
+    schema = schema.$db
+    column "rank" {
+        type = bigint
+    }
+    index "rank_idx" {
+        on {
+            column = table.users.column.rank
+        }
+    }
+}
+
+-- 2.sql --
+CREATE TABLE `users` (
+  `rank` bigint NOT NULL,
+  KEY `rank_idx` (`rank`)
+)
+
+
+-- 2-no-change.hcl --
+schema "$db" {
+    charset = "$charset"
+    collation = "$collate"
+}
+
+table "users" {
+    schema = schema.$db
+    column "rank" {
+        type = bigint
+    }
+    index "rank_idx" {
+        columns = [
+            table.users.column.rank,
+        ]
+    }
+}
+
+-- 3.hcl --
+schema "$db" {
+    charset = "$charset"
+    collation = "$collate"
+}
+
+table "users" {
+    schema = schema.$db
+    column "rank" {
+        type = bigint
+    }
+    column "score" {
+        type = int
+    }
+    index "rank_score_idx" {
+        on {
+            column = table.users.column.rank
+        }
+        on {
+            column = table.users.column.score
+            desc = true
+        }
+    }
+}
+
+-- 3.sql --
+CREATE TABLE `users` (
+  `rank` bigint NOT NULL,
+  `score` int NOT NULL,
+  KEY `rank_score_idx` (`rank`,`score` DESC)
+)

--- a/schema/schemaspec/extension_test.go
+++ b/schema/schemaspec/extension_test.go
@@ -15,6 +15,7 @@ type OwnerBlock struct {
 	FirstName string                   `spec:"first_name"`
 	Born      int                      `spec:"born"`
 	Active    bool                     `spec:"active"`
+	BoolPtr   *bool                    `spec:"bool_ptr"`
 	Lit       *schemaspec.LiteralValue `spec:"lit"`
 }
 
@@ -45,6 +46,7 @@ func TestExtension(t *testing.T) {
 			schemautil.StrLitAttr("first_name", "tzuri"),
 			schemautil.LitAttr("born", "2019"),
 			schemautil.LitAttr("active", "true"),
+			schemautil.LitAttr("bool_ptr", "true"),
 			schemautil.LitAttr("lit", "1000"),
 			schemautil.LitAttr("extra", "true"),
 		},
@@ -62,6 +64,8 @@ func TestExtension(t *testing.T) {
 	require.EqualValues(t, "name", owner.ID)
 	require.EqualValues(t, 2019, owner.Born)
 	require.EqualValues(t, true, owner.Active)
+	require.NotNil(t, owner.BoolPtr)
+	require.EqualValues(t, true, *owner.BoolPtr)
 	require.EqualValues(t, schemautil.LitAttr("lit", "1000").V, owner.Lit)
 	attr, ok := owner.Remain().Attr("extra")
 	require.True(t, ok)

--- a/schema/schemaspec/schemahcl/hcl.go
+++ b/schema/schemaspec/schemahcl/hcl.go
@@ -278,6 +278,11 @@ func (s *state) writeAttr(attr *schemaspec.Attr, body *hclwrite.Body) error {
 		fnc := fmt.Sprintf("sql(%q)", v.X)
 		body.SetAttributeRaw(attr.K, hclRawTokens(fnc))
 	case *schemaspec.ListValue:
+		// Skip scanning nil slices ([]T(nil)) by default. Users that
+		// want to print empty lists, should use make([]T, 0) instead.
+		if v.V == nil {
+			return nil
+		}
 		lst := make([]string, 0, len(v.V))
 		for _, item := range v.V {
 			switch v := item.(type) {

--- a/sql/sqlspec/sqlspec.go
+++ b/sql/sqlspec/sqlspec.go
@@ -51,9 +51,9 @@ type (
 
 	// IndexPart holds a specification for the index key part.
 	IndexPart struct {
-		Desc   bool            `spec:"desc"`
+		Desc   *bool           `spec:"desc"`
 		Column *schemaspec.Ref `spec:"column"`
-		Expr   string          `spec:"expr"`
+		Expr   *string         `spec:"expr"`
 		schemaspec.DefaultExtension
 	}
 


### PR DESCRIPTION
Also, added support for scanning and printing `string` and `bool` pointers. We can consider adding more types in the future if we'll see a need for this.  

testscript for PostgreSQL will be added in future PRs.