### PR TITLE
sql/postgres: minor fixes for postgres before release

### DIFF
--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -465,7 +465,7 @@ func FromIndex(idx *schema.Index) (*sqlspec.Index, error) {
 func columnsOnly(idx *schema.Index) ([]*schemaspec.Ref, bool) {
 	parts := make([]*schemaspec.Ref, len(idx.Parts))
 	for i, p := range idx.Parts {
-		if p.C == nil || p.Desc || len(p.Attrs) > 0 {
+		if p.C == nil || p.Desc {
 			return nil, false
 		}
 		parts[i] = colRef(p.C.Name, idx.Table.Name)

--- a/sql/postgres/migrate.go
+++ b/sql/postgres/migrate.go
@@ -563,7 +563,7 @@ func (s *state) alterColumn(b *sqlx.Builder, k schema.ChangeKind, c *schema.Colu
 		case k.Is(schema.ChangeAttr):
 			id, ok := identity(c.Attrs)
 			if !ok {
-				return fmt.Errorf("unexpected attribute change: %v", c.Attrs)
+				return fmt.Errorf("unexpected attribute change (expect IDENTITY): %v", c.Attrs)
 			}
 			// The syntax for altering identity columns is identical to sequence_options.
 			// https://www.postgresql.org/docs/current/sql-altersequence.html


### PR DESCRIPTION
1. index-spec does not support custom attributes atm.
2. return more meaningful error in case of un supported postgres features in HCL (IDENTITY attribute for columns).