### PR TITLE
internal/integration/testdata/mysql: add tests for time precision def…

### DIFF
--- a/internal/integration/testdata/mysql/column-time-precision-maria.txt
+++ b/internal/integration/testdata/mysql/column-time-precision-maria.txt
@@ -17,6 +17,12 @@ table "foo" {
     null = false
     type = char(36)
   }
+  column "precision_default" {
+    null      = false
+    type      = timestamp
+    default   = sql("CURRENT_TIMESTAMP")
+    on_update = sql("CURRENT_TIMESTAMP")
+  }
   column "create_time" {
     null    = false
     type    = timestamp(6)
@@ -36,6 +42,7 @@ table "foo" {
 -- 1.sql --
 CREATE TABLE `foo` (
   `id` char(36) NOT NULL,
+  `precision_default` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   `create_time` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
   `update_time` datetime(6) NOT NULL DEFAULT current_timestamp(6) ON UPDATE current_timestamp(6),
   PRIMARY KEY (`id`)

--- a/internal/integration/testdata/mysql/column-time-precision-mysql.txt
+++ b/internal/integration/testdata/mysql/column-time-precision-mysql.txt
@@ -17,6 +17,12 @@ table "foo" {
     null = false
     type = char(36)
   }
+  column "precision_default" {
+    null      = false
+    type      = timestamp
+    default   = sql("CURRENT_TIMESTAMP")
+    on_update = sql("CURRENT_TIMESTAMP")
+  }
   column "create_time" {
     null    = false
     type    = timestamp(6)
@@ -36,6 +42,7 @@ table "foo" {
 -- 1.sql --
 CREATE TABLE `foo` (
   `id` char(36) NOT NULL,
+  `precision_default` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `create_time` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `update_time` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`)


### PR DESCRIPTION
…aults

Ensure MySQL driver does not appedn default precision of `0`.