### PR TITLE
Add "auto approve" flag to "schema apply" command

### DIFF
--- a/cmd/action/apply.go
+++ b/cmd/action/apply.go
@@ -24,6 +24,7 @@ var (
 		Addr   string
 		DryRun bool
 		Schema []string
+		AutoApprove bool
 	}
 	// ApplyCmd represents the apply command.
 	ApplyCmd = &cobra.Command{
@@ -57,6 +58,7 @@ func init() {
 	ApplyCmd.Flags().BoolVarP(&ApplyFlags.DryRun, "dry-run", "", false, "Dry-run. Print SQL plan without prompting for execution")
 	ApplyCmd.Flags().StringVarP(&ApplyFlags.Addr, "addr", "", "127.0.0.1:5800", "used with -w, local address to bind the server to")
 	ApplyCmd.Flags().StringSliceVarP(&ApplyFlags.Schema, "schema", "s", nil, "Set schema name")
+	ApplyCmd.Flags().BoolVarP(&ApplyFlags.AutoApprove, "approve", "", false, "Auto approve. Apply the schema changes without prompting for approval")
 	cobra.CheckErr(ApplyCmd.MarkFlagRequired("dsn"))
 	cobra.CheckErr(ApplyCmd.MarkFlagRequired("file"))
 }
@@ -69,10 +71,10 @@ func CmdApplyRun(cmd *cobra.Command, args []string) {
 	}
 	d, err := defaultMux.OpenAtlas(ApplyFlags.DSN)
 	cobra.CheckErr(err)
-	applyRun(d, ApplyFlags.DSN, ApplyFlags.File, ApplyFlags.DryRun)
+	applyRun(d, ApplyFlags.DSN, ApplyFlags.File, ApplyFlags.DryRun, ApplyFlags.AutoApprove)
 }
 
-func applyRun(d *Driver, dsn string, file string, dryRun bool) {
+func applyRun(d *Driver, dsn string, file string, dryRun bool, autoApprove bool) {
 	ctx := context.Background()
 	schemas := ApplyFlags.Schema
 	if n, err := SchemaNameFromDSN(dsn); n != "" {
@@ -117,6 +119,12 @@ func applyRun(d *Driver, dsn string, file string, dryRun bool) {
 		schemaCmd.Println(c.Cmd)
 	}
 	if dryRun {
+		return
+	}
+	if autoApprove {
+		schemaCmd.Println("Applying changes (automatically approved with --approve flag)")
+		err = d.ApplyChanges(ctx, changes)
+		cobra.CheckErr(err)
 		return
 	}
 	prompt := promptui.Select{

--- a/doc/md/cli.md
+++ b/doc/md/cli.md
@@ -88,6 +88,7 @@ atlas schema apply -d "sqlite://file:ex1.db?_fk=1" -f atlas.hcl
 #### Flags
 ```
       --addr string      used with -w, local address to bind the server to (default "127.0.0.1:5800")
+      --auto-approve     Auto approve. Apply the schema changes without prompting for approval
       --dry-run          Dry-run. Print SQL plan without prompting for execution
   -d, --dsn string       [driver://username:password@protocol(address)/dbname?param=value] Select data source using the dsn format
   -f, --file string      [/path/to/file] file containing schema


### PR DESCRIPTION
Closes #519 

#### Summary

- Adds `--approve` boolean flag to `schema apply` command. Default: false. When true, applies schema changes to given DSN without prompting user for approval. Useful for CI environments

#### Notes

1. Please feel free to request any/all changes. I know nothing about Go standards, or about naming preferences within this project. I chose `--approve` instead of `--apply` because I felt like running `atlas schema apply --apply` would feel kind of strange, but I'm totally open to other naming options.
2. I built and tested this locally with a docker-compose setup. I've included my steps below in case it helps in eventually building out some community contributing guidelines.

<details>

Docker Compose config:

```yml
version: "3"
services:
  go:
    image: golang:1.18beta1-bullseye
    volumes:
      - .:/go/app
    command: bash
    depends_on:
      - db
    environment:
      DB_URL: postgres://postgres:postgres@db:5432/dev?sslmode=disable

  db:
    image: postgres:12.9-alpine
    ports:
      - "5432:5432"
    environment:
      POSTGRES_PASSWORD: postgres
      POSTGRES_USER: postgres
      POSTGRES_DB: development
    volumes:
      - db_data:/var/lib/postgresql/data

volumes:
  db_data:
```

Steps
1. Run the Go container: `docker-compose run --rm --service-ports go bash`
2. Attach to the Postgres container in a separate terminal tab: `docker-compose exec db bash`
    1. Connect to the "dev" database: `psql dev -U postgres`
    2. Create a sample table: `create table testing (id text, name text); \q`
    3. Create a new database to test the applied changes: `createdb testing -U postgres`
3. In the Go container, inspect the schema: `cd app && go run ./cmd/atlas schema inspect -d "$DB_URL" > atlas.hcl`
4. Apply the schema to the testing table: `go run ./cmd/atlas schema apply -d "postgres://postgres:postgres@db:5432/testing?sslmode=disable" -f atlas.hcl --approve`
5. Verify that the changes are applied in the Postgres container:

```
psql testing -U postgres
select * from testing;
=> should print the column names even though the table is empty
```

To run the integration tests, I followed the general idea from `.github/workflows/ci.yml`:

```
docker-compose up
go test -race -count=2 ./...
```

</details>