### PR TITLE
Postgres driver: don't require varchar length

### DIFF
--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -334,8 +334,8 @@ var TypeRegistry = specutil.NewRegistry(
 	specutil.WithSpecs(
 		specutil.TypeSpec(TypeBit, specutil.WithAttributes(&schemaspec.TypeAttr{Name: "len", Kind: reflect.Int64})),
 		specutil.AliasTypeSpec("bit_varying", TypeBitVar, specutil.WithAttributes(&schemaspec.TypeAttr{Name: "len", Kind: reflect.Int64})),
-		specutil.TypeSpec(TypeVarChar, specutil.WithAttributes(specutil.SizeTypeAttr(true))),
-		specutil.AliasTypeSpec("character_varying", TypeCharVar, specutil.WithAttributes(&schemaspec.TypeAttr{Name: "size", Kind: reflect.Int})),
+		specutil.TypeSpec(TypeVarChar, specutil.WithAttributes(specutil.SizeTypeAttr(false))),
+		specutil.AliasTypeSpec("character_varying", TypeCharVar, specutil.WithAttributes(specutil.SizeTypeAttr(false))),
 		specutil.TypeSpec(TypeChar, specutil.WithAttributes(specutil.SizeTypeAttr(true))),
 		specutil.TypeSpec(TypeCharacter, specutil.WithAttributes(specutil.SizeTypeAttr(true))),
 		specutil.TypeSpec(TypeInt2),

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -29,6 +29,12 @@ table "table" {
 	column "account_name" {
 		type = varchar(32)
 	}
+	column "varchar_length_is_not_required" {
+		type = varchar()
+	}
+	column "character_varying_length_is_not_required" {
+		type = character_varying()
+	}
 	column "tags" {
 		type = hstore
 	}
@@ -126,6 +132,24 @@ enum "account_type" {
 						Type: &schema.StringType{
 							T:    "varchar",
 							Size: 32,
+						},
+					},
+				},
+				{
+					Name: "varchar_length_is_not_required",
+					Type: &schema.ColumnType{
+						Type: &schema.StringType{
+							T:    "varchar",
+							Size: 0,
+						},
+					},
+				},
+				{
+					Name: "character_varying_length_is_not_required",
+					Type: &schema.ColumnType{
+						Type: &schema.StringType{
+							T:    "character varying",
+							Size: 0,
 						},
 					},
 				},

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -30,7 +30,7 @@ table "table" {
 		type = varchar(32)
 	}
 	column "varchar_length_is_not_required" {
-		type = varchar()
+		type = varchar
 	}
 	column "character_varying_length_is_not_required" {
 		type = character_varying()

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -33,7 +33,7 @@ table "table" {
 		type = varchar
 	}
 	column "character_varying_length_is_not_required" {
-		type = character_varying()
+		type = character_varying
 	}
 	column "tags" {
 		type = hstore


### PR DESCRIPTION
Problem: when using Postgres driver, the `character_varying()` does not require a length attribute:

https://github.com/ariga/atlas/blob/ce25dd8f5ae3f594644e6bfb3414b1532bfa3d0b/sql/postgres/sqlspec.go#L338

...yet `varchar()` does:

https://github.com/ariga/atlas/blob/ce25dd8f5ae3f594644e6bfb3414b1532bfa3d0b/sql/postgres/sqlspec.go#L337

The [official PostgreSQL documentation](https://www.postgresql.org/docs/9.3/datatype-character.html) treats these two identically:

>The notations `varchar(n)` and `char(n)` are aliases for character `varying(n)` and `character(n)`, respectively.

Solution: allow `varchar()` to be specified without the length, similarly to `character_varying()`.