### PR TITLE
sql: drop the InspectTable option

### DIFF
--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -75,11 +75,6 @@ func (i *inspect) InspectSchema(ctx context.Context, name string, opts *schema.I
 	return s, nil
 }
 
-// InspectTable returns the schema description of the given table.
-func (i *inspect) InspectTable(ctx context.Context, name string, opts *schema.InspectTableOptions) (*schema.Table, error) {
-	return i.inspectTable(ctx, name, opts, nil)
-}
-
 func (i *inspect) inspectTable(ctx context.Context, name string, opts *schema.InspectTableOptions, top *schema.Schema) (*schema.Table, error) {
 	t, err := i.table(ctx, name, opts)
 	if err != nil {

--- a/sql/postgres/inspect.go
+++ b/sql/postgres/inspect.go
@@ -86,11 +86,6 @@ func (i *inspect) InspectSchema(ctx context.Context, name string, opts *schema.I
 	return s, nil
 }
 
-// InspectTable returns the schema description of the given table.
-func (i *inspect) InspectTable(ctx context.Context, name string, opts *schema.InspectTableOptions) (*schema.Table, error) {
-	return i.inspectTable(ctx, name, opts, nil)
-}
-
 func (i *inspect) inspectTable(ctx context.Context, name string, opts *schema.InspectTableOptions, top *schema.Schema) (*schema.Table, error) {
 	t, err := i.table(ctx, name, opts)
 	if err != nil {

--- a/sql/postgres/inspect_test.go
+++ b/sql/postgres/inspect_test.go
@@ -463,16 +463,6 @@ func (m mock) tableExists(schema, table string, exists bool) {
 		WillReturnRows(rows)
 }
 
-func (m mock) tableExistsInSchema(schema, table string, exists bool) {
-	rows := sqlmock.NewRows([]string{"table_schema", "table_comment"})
-	if exists {
-		rows.AddRow(schema, nil)
-	}
-	m.ExpectQuery(sqltest.Escape(tableSchemaQuery)).
-		WithArgs(table, schema).
-		WillReturnRows(rows)
-}
-
 func (m mock) noIndexes() {
 	m.ExpectQuery(sqltest.Escape(indexesQuery)).
 		WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "constraint_type", "predicate", "expression"}))

--- a/sql/schema/inspect.go
+++ b/sql/schema/inspect.go
@@ -53,16 +53,12 @@ type (
 	}
 
 	// Inspector is the interface implemented by the different database
-	// drivers for inspecting multiple tables.
+	// drivers for inspecting schema or databases.
 	Inspector interface {
 		// InspectSchema returns the schema description by its name. An empty name means the
 		// "attached schema" (e.g. SCHEMA() in MySQL or CURRENT_SCHEMA() in PostgreSQL).
 		// A NotExistError error is returned if the schema does not exists in the database.
 		InspectSchema(ctx context.Context, name string, opts *InspectOptions) (*Schema, error)
-
-		// InspectTable returns the table description by its name. A NotExistError
-		// error is returned if the table does not exists in the database.
-		InspectTable(ctx context.Context, name string, opts *InspectTableOptions) (*Table, error)
 
 		// InspectRealm returns the description of the connected database.
 		InspectRealm(ctx context.Context, opts *InspectRealmOption) (*Realm, error)

--- a/sql/sqlite/inspect.go
+++ b/sql/sqlite/inspect.go
@@ -86,25 +86,6 @@ func (i *inspect) InspectSchema(ctx context.Context, name string, opts *schema.I
 	return s, nil
 }
 
-// InspectTable returns the schema description of the given table.
-func (i *inspect) InspectTable(ctx context.Context, name string, opts *schema.InspectTableOptions) (*schema.Table, error) {
-	if opts != nil && opts.Schema != mainFile {
-		return nil, fmt.Errorf("sqlite: querying attached database is not supported. got: %q", opts.Schema)
-	}
-	s, err := i.InspectSchema(ctx, mainFile, &schema.InspectOptions{
-		Tables: []string{name},
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(s.Tables) == 0 {
-		return nil, &schema.NotExistError{
-			Err: fmt.Errorf("sqlite: table %q was not found", name),
-		}
-	}
-	return s.Tables[0], nil
-}
-
 func (i *inspect) inspectTable(ctx context.Context, t *schema.Table) (*schema.Table, error) {
 	if err := i.columns(ctx, t); err != nil {
 		return nil, err
@@ -659,7 +640,7 @@ const (
 	// Query to list attached database files.
 	databasesQuery = "SELECT `name`, `file` FROM pragma_database_list()"
 	// Query to list database tables.
-	tablesQuery = "SELECT `name`, `sql` FROM sqlite_master WHERE `type`='table' AND `name` NOT LIKE 'sqlite_%'"
+	tablesQuery = "SELECT `name`, `sql` FROM sqlite_master WHERE `type` = 'table' AND `name` NOT LIKE 'sqlite_%'"
 	// Query to list table information.
 	columnsQuery = "SELECT `name`, `type`, (not `notnull`) AS `nullable`, `dflt_value`, (`pk` <> 0) AS `pk`  FROM pragma_table_info('%s') ORDER BY `pk`, `cid`"
 	// Query to list table indexes.


### PR DESCRIPTION
Users should use `schema.Inspect` instead. Note that you should not give this PR too much attention because most of the inspection code will be changed tomorrow in order to reduce the number of queries on the database. 