### PR TITLE
cmd/action: env command constructor

### DIFF
--- a/cmd/action/env.go
+++ b/cmd/action/env.go
@@ -13,10 +13,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var envCmd = &cobra.Command{
-	Use:   "env",
-	Short: "Print atlas environment variables.",
-	Long: "`atlas env`" + `prints atlas environment information.
+func newEnvCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "env",
+		Short: "Print atlas environment variables.",
+		Long: "`atlas env`" + `prints atlas environment information.
 
 Every set environment param will be printed in the form of NAME=VALUE.
 
@@ -24,16 +25,17 @@ List of supported environment parameters:
 * *ATLAS_NO_UPDATE_NOTIFIER*: On any command, the CLI will check for new releases using the GitHub API.
   This check will happen at most once every 24 hours. To cancel this behavior, set the environment 
   variable "ATLAS_NO_UPDATE_NOTIFIER".`,
-	Run: func(cmd *cobra.Command, args []string) {
-		keys := []string{update.AtlasNoUpdateNotifier}
-		for _, k := range keys {
-			if v, ok := os.LookupEnv(k); ok {
-				RootCmd.Println(fmt.Sprintf("%s=%s", k, v))
+		Run: func(cmd *cobra.Command, args []string) {
+			keys := []string{update.AtlasNoUpdateNotifier}
+			for _, k := range keys {
+				if v, ok := os.LookupEnv(k); ok {
+					cmd.Println(fmt.Sprintf("%s=%s", k, v))
+				}
 			}
-		}
-	},
+		},
+	}
 }
 
 func init() {
-	RootCmd.AddCommand(envCmd)
+	RootCmd.AddCommand(newEnvCmd())
 }


### PR DESCRIPTION
in prep for working on unit tests for atlas cmd with @elad-n I'm organizing this command a little. 