### PR TITLE
sql/mysql: support index types

### DIFF
--- a/internal/integration/testdata/mysql/index-type.txt
+++ b/internal/integration/testdata/mysql/index-type.txt
@@ -1,0 +1,44 @@
+apply 1.hcl
+cmpshow users 1.sql
+
+# Drop an index.
+apply 2.hcl
+cmpshow users 2.sql
+
+-- 1.hcl --
+schema "$db" {}
+
+table "users" {
+  schema = schema.$db
+  column "text" {
+    null = false
+    type = text
+  }
+  index "users_text" {
+    type = FULLTEXT
+    columns = [column.text]
+  }
+}
+
+-- 1.sql --
+CREATE TABLE `users` (
+  `text` text NOT NULL,
+  FULLTEXT KEY `users_text` (`text`)
+)
+
+-- 2.hcl --
+schema "$db" {}
+
+table "users" {
+  schema = schema.$db
+  column "text" {
+    null = false
+    type = text
+  }
+}
+
+-- 2.sql --
+CREATE TABLE `users` (
+  `text` text NOT NULL
+)
+

--- a/internal/integration/testdata/postgres/index-type.txt
+++ b/internal/integration/testdata/postgres/index-type.txt
@@ -19,11 +19,11 @@ table "users" {
     type = jsonb
   }
   index "users_name" {
-    using = HASH
+    type = HASH
     columns = [column.name]
   }
   index "users_data" {
-    using = GIN
+    type = GIN
     columns = [column.data]
   }
 }
@@ -56,7 +56,7 @@ table "users" {
     # Index without "using" defaults to BTREE.
   }
   index "users_data" {
-    using = BTREE
+    type = BTREE
     columns = [column.data]
   }
 }

--- a/schema/schemaspec/schemahcl/opts.go
+++ b/schema/schemaspec/schemahcl/opts.go
@@ -50,8 +50,8 @@ func New(opts ...Option) *state {
 //	table "t" {
 //		...
 //		index "i" {
-//			type = HASH		// Allowed.
-//			type = INVALID	// Not Allowed.
+//			type = HASH     // Allowed.
+//			type = INVALID  // Not Allowed.
 //		}
 //	}
 //

--- a/schema/schemaspec/schemahcl/opts.go
+++ b/schema/schemaspec/schemahcl/opts.go
@@ -45,13 +45,13 @@ func New(opts ...Option) *state {
 // option allows setting HASH or BTREE to the "using" attribute in
 // "index" block.
 //
-//	WithScopedEnums("table.index.using", "HASH", "BTREE")
+//	WithScopedEnums("table.index.type", "HASH", "BTREE")
 //
 //	table "t" {
 //		...
 //		index "i" {
-//			using = HASH	// Allowed.
-//			using = INVALID	// Not Allowed.
+//			type = HASH		// Allowed.
+//			type = INVALID	// Not Allowed.
 //		}
 //	}
 //

--- a/sql/mysql/diff.go
+++ b/sql/mysql/diff.go
@@ -243,7 +243,7 @@ func (*diff) autoIncChange(from, to []schema.Attr) schema.Change {
 // indexType returns the index type from its attribute.
 // The default type is BTREE if no type was specified.
 func indexType(attr []schema.Attr) *IndexType {
-	t := &IndexType{T: "BTREE"}
+	t := &IndexType{T: IndexTypeBTree}
 	if sqlx.Has(attr, t) {
 		t.T = strings.ToUpper(t.T)
 	}

--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -188,7 +188,11 @@ const (
 
 // Additional common constants in MySQL.
 const (
-	currentTS     = "current_timestamp"
-	defaultGen    = "default_generated"
-	autoIncrement = "auto_increment"
+	IndexTypeBTree    = "BTREE"
+	IndexTypeHash     = "HASH"
+	IndexTypeFullText = "FULLTEXT"
+	IndexTypeSpatial  = "SPATIAL"
+	currentTS         = "current_timestamp"
+	defaultGen        = "default_generated"
+	autoIncrement     = "auto_increment"
 )

--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -192,7 +192,8 @@ const (
 	IndexTypeHash     = "HASH"
 	IndexTypeFullText = "FULLTEXT"
 	IndexTypeSpatial  = "SPATIAL"
-	currentTS         = "current_timestamp"
-	defaultGen        = "default_generated"
-	autoIncrement     = "auto_increment"
+
+	currentTS     = "current_timestamp"
+	defaultGen    = "default_generated"
+	autoIncrement = "auto_increment"
 )

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -28,6 +28,9 @@ func (i *inspect) InspectRealm(ctx context.Context, opts *schema.InspectRealmOpt
 		return nil, err
 	}
 	r := schema.NewRealm(schemas...).SetCharset(i.charset).SetCollation(i.collate)
+	if len(schemas) == 0 {
+		return r, nil
+	}
 	if err := i.inspectTables(ctx, r, nil); err != nil {
 		return nil, err
 	}

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -772,7 +772,7 @@ type (
 	// IndexType represents an index type.
 	IndexType struct {
 		schema.Attr
-		T string // BTREE, FULLTEXT, HASH, RTREE
+		T string // BTREE, HASH, FULLTEXT, SPATIAL, RTREE
 	}
 
 	// BitType represents a bit type.

--- a/sql/mysql/migrate.go
+++ b/sql/mysql/migrate.go
@@ -213,20 +213,14 @@ func (s *state) addTable(add *schema.AddTable) error {
 		})
 		if pk := add.T.PrimaryKey; pk != nil {
 			b.Comma().P("PRIMARY KEY")
-			s.indexParts(b, pk.Parts)
-			s.attr(b, pk.Attrs...)
+			indexParts(b, pk.Parts)
 		}
 		if len(add.T.Indexes) > 0 {
 			b.Comma()
 		}
 		b.MapComma(add.T.Indexes, func(i int, b *sqlx.Builder) {
 			idx := add.T.Indexes[i]
-			if idx.Unique {
-				b.P("UNIQUE")
-			}
-			b.P("INDEX").Ident(idx.Name)
-			s.indexParts(b, idx.Parts)
-			s.attr(b, idx.Attrs...)
+			index(b, idx)
 		})
 		if len(add.T.ForeignKeys) > 0 {
 			b.Comma()
@@ -352,22 +346,12 @@ func (s *state) alterTable(t *schema.Table, changes []schema.Change) error {
 			reversible = false
 		case *schema.AddIndex:
 			b.P("ADD")
-			if change.I.Unique {
-				b.P("UNIQUE")
-			}
-			b.P("INDEX").Ident(change.I.Name)
-			s.indexParts(b, change.I.Parts)
-			s.attr(b, change.I.Attrs...)
+			index(b, change.I)
 			reverse.Comma().P("DROP INDEX").Ident(change.I.Name)
 		case *schema.DropIndex:
 			b.P("DROP INDEX").Ident(change.I.Name)
 			reverse.Comma().P("ADD")
-			if change.I.Unique {
-				reverse.P("UNIQUE")
-			}
-			reverse.P("INDEX").Ident(change.I.Name)
-			s.indexParts(reverse, change.I.Parts)
-			s.attr(reverse, change.I.Attrs...)
+			index(reverse, change.I)
 			reversible = true
 		case *schema.AddForeignKey:
 			b.P("ADD")
@@ -498,7 +482,29 @@ func (s *state) column(b *sqlx.Builder, t *schema.Table, c *schema.Column) error
 	return nil
 }
 
-func (s *state) indexParts(b *sqlx.Builder, parts []*schema.IndexPart) {
+func index(b *sqlx.Builder, idx *schema.Index) {
+	var t IndexType
+	if sqlx.Has(idx.Attrs, &t) {
+		t.T = strings.ToUpper(t.T)
+	}
+	switch {
+	case idx.Unique:
+		b.P("UNIQUE")
+	case t.T == IndexTypeFullText || t.T == IndexTypeSpatial:
+		b.P(t.T)
+	}
+	b.P("INDEX").Ident(idx.Name)
+	// Skip BTREE as it is the default type.
+	if t.T == IndexTypeHash {
+		b.P("USING", t.T)
+	}
+	indexParts(b, idx.Parts)
+	if c := (schema.Comment{}); sqlx.Has(idx.Attrs, &c) {
+		b.P("COMMENT", quote(c.Text))
+	}
+}
+
+func indexParts(b *sqlx.Builder, parts []*schema.IndexPart) {
 	b.Wrap(func(b *sqlx.Builder) {
 		b.MapComma(parts, func(i int, b *sqlx.Builder) {
 			switch part := parts[i]; {

--- a/sql/mysql/migrate_test.go
+++ b/sql/mysql/migrate_test.go
@@ -441,6 +441,7 @@ func TestPlanChanges(t *testing.T) {
 									},
 									Attrs: []schema.Attr{
 										&schema.Comment{Text: "comment"},
+										&IndexType{T: IndexTypeHash},
 									},
 								},
 							},
@@ -463,7 +464,7 @@ func TestPlanChanges(t *testing.T) {
 				Reversible: true,
 				Changes: []*migrate.Change{
 					{
-						Cmd:     "ALTER TABLE `users` ADD COLUMN `name` varchar(255) NOT NULL, ADD INDEX `id_key` (`id`) COMMENT \"comment\", ADD CONSTRAINT `id_nonzero` CHECK (id > 0) ENFORCED, AUTO_INCREMENT 1000",
+						Cmd:     "ALTER TABLE `users` ADD COLUMN `name` varchar(255) NOT NULL, ADD INDEX `id_key` USING HASH (`id`) COMMENT \"comment\", ADD CONSTRAINT `id_nonzero` CHECK (id > 0) ENFORCED, AUTO_INCREMENT 1000",
 						Reverse: "ALTER TABLE `users` DROP COLUMN `name`, DROP INDEX `id_key`, DROP CONSTRAINT `id_nonzero`, AUTO_INCREMENT 1",
 					},
 				},

--- a/sql/mysql/sqlspec.go
+++ b/sql/mysql/sqlspec.go
@@ -66,7 +66,7 @@ func MarshalSpec(v interface{}, marshaler schemaspec.Marshaler) ([]byte, error) 
 var (
 	hclState = schemahcl.New(
 		schemahcl.WithTypes(TypeRegistry.Specs()),
-		schemahcl.WithScopedEnums("table.index.type", IndexTypeBTree, IndexTypeHash),
+		schemahcl.WithScopedEnums("table.index.type", IndexTypeBTree, IndexTypeHash, IndexTypeFullText, IndexTypeSpatial),
 	)
 	// UnmarshalHCL unmarshals an Atlas HCL DDL document into v.
 	UnmarshalHCL = schemaspec.UnmarshalerFunc(func(bytes []byte, i interface{}) error {

--- a/sql/postgres/migrate.go
+++ b/sql/postgres/migrate.go
@@ -641,7 +641,7 @@ func (s *state) partAttrs(b *sqlx.Builder, p *schema.IndexPart) {
 func (s *state) index(b *sqlx.Builder, idx *schema.Index) {
 	// Avoid appending the default method.
 	if t := (IndexType{}); sqlx.Has(idx.Attrs, &t) && strings.ToUpper(t.T) != IndexTypeBTree {
-		b.P("USING").P(t.T)
+		b.P("USING", t.T)
 	}
 	s.indexParts(b, idx.Parts)
 	if p := (IndexPredicate{}); sqlx.Has(idx.Attrs, &p) {

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -93,7 +93,7 @@ func MarshalSpec(v interface{}, marshaler schemaspec.Marshaler) ([]byte, error) 
 var (
 	hclState = schemahcl.New(
 		schemahcl.WithTypes(TypeRegistry.Specs()),
-		schemahcl.WithScopedEnums("table.index.using", IndexTypeBTree, IndexTypeHash, IndexTypeGIN, IndexTypeGiST),
+		schemahcl.WithScopedEnums("table.index.type", IndexTypeBTree, IndexTypeHash, IndexTypeGIN, IndexTypeGiST),
 	)
 	// UnmarshalHCL unmarshals an Atlas HCL DDL document into v.
 	UnmarshalHCL = schemaspec.UnmarshalerFunc(func(bytes []byte, i interface{}) error {
@@ -205,7 +205,7 @@ func convertIndex(spec *sqlspec.Index, parent *schema.Table) (*schema.Index, err
 	if err != nil {
 		return nil, err
 	}
-	if attr, ok := spec.Attr("using"); ok {
+	if attr, ok := spec.Attr(IndexPartAttrChanged(from, to []*schema.IndexPart); ok {
 		t, err := attr.String()
 		if err != nil {
 			return nil, err
@@ -331,7 +331,7 @@ func indexSpec(idx *schema.Index) (*sqlspec.Index, error) {
 		return nil, err
 	}
 	if i := (IndexType{}); sqlx.Has(idx.Attrs, &i) {
-		spec.Extra.Attrs = append(spec.Extra.Attrs, specutil.VarAttr("using", strings.ToUpper(i.T)))
+		spec.Extra.Attrs = append(spec.Extra.Attrs, specutil.VarAttr("type", strings.ToUpper(i.T)))
 	}
 	return spec, nil
 }

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -205,7 +205,7 @@ func convertIndex(spec *sqlspec.Index, parent *schema.Table) (*schema.Index, err
 	if err != nil {
 		return nil, err
 	}
-	if attr, ok := spec.Attr(IndexPartAttrChanged(from, to []*schema.IndexPart); ok {
+	if attr, ok := spec.Attr("type"); ok {
 		t, err := attr.String()
 		if err != nil {
 			return nil, err

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -50,7 +50,7 @@ table "table" {
 		columns = [table.table.column.col]
 	}
 	index "index" {
-		using = HASH
+		type = HASH
 		unique = true
 		columns = [
 			table.table.column.col,
@@ -265,7 +265,7 @@ table "t" {
 		type = int
 	}
 	index "i" {
-		using = %s
+		type = %s
 		columns = [column.c]
 	}
 }


### PR DESCRIPTION
Also, renamed `index.using` to `index.type`. 