### PR TITLE
sql/migrate: add template formatter

### DIFF
--- a/sql/migrate/migrate.go
+++ b/sql/migrate/migrate.go
@@ -210,8 +210,8 @@ type LocalDir struct {
 }
 
 // Open implements Dir.Open.
-func (dir *LocalDir) Open(name string) (File, error) {
-	return os.Create(filepath.Join(dir.dir, name))
+func (d *LocalDir) Open(name string) (File, error) {
+	return os.Create(filepath.Join(d.dir, name))
 }
 
 // NewLocalDir returns a new the Dir used by a Planner to work on the given local path.
@@ -264,8 +264,8 @@ var (
 // NewTemplateFormatter creates a new Formatter working with the given templates.
 //
 //	migrate.NewTemplateFormatter(
-//		template.Must(template.New("").Parse("{{now.Unix}}{{.Name}}.sql")),					// name template
-//		template.Must(template.New("").Parse("{{range .Changes}}{{println .Cmd}}{{end}}")),	// content template
+//		template.Must(template.New("").Parse("{{now.Unix}}{{.Name}}.sql")),                 // name template
+//		template.Must(template.New("").Parse("{{range .Changes}}{{println .Cmd}}{{end}}")), // content template
 //	)
 //
 func NewTemplateFormatter(templates ...*template.Template) (*TemplateFormatter, error) {
@@ -281,7 +281,7 @@ func NewTemplateFormatter(templates ...*template.Template) (*TemplateFormatter, 
 
 // Format implements the Formatter interface.
 func (t *TemplateFormatter) Format(plan *Plan) ([]File, error) {
-	var fs []File
+	fs := make([]File, 0, len(t.templates))
 	for _, tpl := range t.templates {
 		var n, c bytes.Buffer
 		if err := tpl.N.Execute(&n, plan); err != nil {

--- a/sql/migrate/migrate_test.go
+++ b/sql/migrate/migrate_test.go
@@ -1,0 +1,93 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
+package migrate_test
+
+import (
+	"bytes"
+	"io"
+	"strconv"
+	"testing"
+	"text/template"
+	"time"
+
+	"ariga.io/atlas/sql/migrate"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanner_WritePlan(t *testing.T) {
+	var mfs = &mockFS{}
+	plan := &migrate.Plan{
+		Name: "add_t1_and_t2",
+		Changes: []*migrate.Change{
+			{Cmd: "CREATE TABLE t1(c int);", Reverse: "DROP TABLE t1 IF EXISTS"},
+			{Cmd: "CREATE TABLE t2(c int)", Reverse: "DROP TABLE t2"},
+		},
+	}
+
+	// DefaultFormatter
+	pl := migrate.New(nil, mfs, migrate.DefaultFormatter)
+	require.NotNil(t, pl)
+	require.NoError(t, pl.WritePlan(plan))
+	v := strconv.FormatInt(time.Now().Unix(), 10)
+	require.Len(t, mfs.files, 2)
+	require.Equal(t, &file{
+		n: v + "_add_t1_and_t2.up.sql",
+		b: bytes.NewBufferString("CREATE TABLE t1(c int);\nCREATE TABLE t2(c int);\n"),
+	}, mfs.files[0])
+	require.Equal(t, &file{
+		n: v + "_add_t1_and_t2.down.sql",
+		b: bytes.NewBufferString("DROP TABLE t2;\nDROP TABLE t1 IF EXISTS;\n"),
+	}, mfs.files[1])
+
+	// Custom formatter (creates only "up" migration files).
+	fmt, err := migrate.NewTemplateFormatter(
+		template.Must(template.New("").Parse("{{.Name}}.sql")),
+		template.Must(template.New("").Parse("{{range .Changes}}{{println .Cmd}}{{end}}")),
+	)
+	require.NoError(t, err)
+	pl = migrate.New(nil, mfs, fmt)
+	require.NotNil(t, pl)
+	require.NoError(t, pl.WritePlan(plan))
+	require.Len(t, mfs.files, 3)
+	require.Equal(t, &file{
+		n: "add_t1_and_t2.sql",
+		b: bytes.NewBufferString("CREATE TABLE t1(c int);\nCREATE TABLE t2(c int)\n"),
+	}, mfs.files[2])
+}
+
+type (
+	mockFS struct {
+		files []*file
+	}
+	file struct {
+		n string
+		b *bytes.Buffer
+	}
+)
+
+func (f *file) Read(b []byte) (int, error) {
+	return f.b.Read(b)
+}
+
+func (f *file) Write(b []byte) (int, error) {
+	return f.b.Write(b)
+}
+
+func (f *file) Close() error { return nil }
+
+func (f *file) Name() string { return f.n }
+
+func (fs *mockFS) Open(name string) (io.ReadWriteCloser, error) {
+	for _, f := range fs.files {
+		if f.n == name {
+			return f, nil
+		}
+	}
+	f := &file{n: name, b: new(bytes.Buffer)}
+	fs.files = append(fs.files, f)
+	return f, nil
+}
+
+var _ io.ReadWriteCloser = (*file)(nil)


### PR DESCRIPTION
This PR adds `TemplateFormatter` which implements `Formatter` and uses `text/template.Template`s to define how migrations files are written.

A default formatter is given, that is compatible with [golang-migrate/migrate](https://github.com/golang-migrate/migrate).