### PR TITLE
sql/mysql: rename collation attribute to collate

### DIFF
--- a/doc/md/ddl/sql.mdx
+++ b/doc/md/ddl/sql.mdx
@@ -26,7 +26,7 @@ values={[
 ]}>
 <TabItem value="mysql">
 
-In MySQL and MariaDB, the `schema` resource can contain the `charset` and `collation` attributes. Read more about them
+In MySQL and MariaDB, the `schema` resource can contain the `charset` and `collate` attributes. Read more about them
 in [MySQL](https://dev.mysql.com/doc/refman/8.0/en/charset.html) or
 [MariaDB](https://mariadb.com/kb/en/setting-character-sets-and-collations/) websites.
 <br/>
@@ -34,9 +34,9 @@ in [MySQL](https://dev.mysql.com/doc/refman/8.0/en/charset.html) or
 ```hcl
 # Schema with attributes.
 schema "market" {
-  charset   = "utf8mb4"
-  collation = "utf8mb4_0900_ai_ci"
-  comment   = "A schema comment"
+  charset = "utf8mb4"
+  collate = "utf8mb4_0900_ai_ci"
+  comment = "A schema comment"
 }
 
 # Schema without attributes.
@@ -268,7 +268,7 @@ table "users" {
 
 ## Charset and Collation
 
-The `charset` and `collation` are attributes of `schema`, `table` and `column` and supported by MySQL, MariaDB and PostgreSQL.
+The `charset` and `collate` are attributes of `schema`, `table` and `column` and supported by MySQL, MariaDB and PostgreSQL.
 Read more about them in [MySQL](https://dev.mysql.com/doc/refman/8.0/en/charset.html),
 [MariaDB](https://mariadb.com/kb/en/setting-character-sets-and-collations/) and
 [PostgreSQL](https://www.postgresql.org/docs/current/collation.html) websites.
@@ -283,16 +283,16 @@ values={[
 
 ```hcl
 schema "public" {
-    charset   = "utf8mb4"
-    collation = "utf8mb4_0900_ai_ci"
+    charset = "utf8mb4"
+    collate = "utf8mb4_0900_ai_ci"
 }
 
 table "products" {
     column "name" {
-        type = text
-        collation = "binary"
+        type    = text
+        collate = "binary"
     }
-    collation = "utf8_general_ci"
+    collate = "utf8_general_ci"
 }
 ```
 
@@ -304,8 +304,8 @@ schema "public" {}
 
 table "products" {
     column "name" {
-        type = text
-        collation = "es_ES"
+        type    = text
+        collate = "es_ES"
     }
 }
 ```

--- a/doc/md/getting-started/02-inspecting.mdx
+++ b/doc/md/getting-started/02-inspecting.mdx
@@ -52,8 +52,8 @@ cat atlas.hcl
 View the output:
 ```hcl
 schema "example" {
-  charset   = "utf8mb4"
-  collation = "utf8mb4_0900_ai_ci"
+  charset = "utf8mb4"
+  collate = "utf8mb4_0900_ai_ci"
 }
 ```
 As you can see, Atlas inspected our (empty) database and wrote an Atlas HCL document 

--- a/internal/integration/testdata/mysql/column-add-drop.txt
+++ b/internal/integration/testdata/mysql/column-add-drop.txt
@@ -31,7 +31,7 @@ apply 0.hcl
 -- 1.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -59,7 +59,7 @@ CREATE TABLE `users` (
 -- 2.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -92,5 +92,5 @@ CREATE TABLE `users` (
 -- 0.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }

--- a/internal/integration/testdata/mysql/column-bool.txt
+++ b/internal/integration/testdata/mysql/column-bool.txt
@@ -14,7 +14,7 @@ synced 3.hcl
 -- 1.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -40,7 +40,7 @@ CREATE TABLE `users` (
 -- 2.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -59,7 +59,7 @@ table "users" {
 -- 3.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {

--- a/internal/integration/testdata/mysql/foreign-key-add.txt
+++ b/internal/integration/testdata/mysql/foreign-key-add.txt
@@ -20,7 +20,7 @@ cmpshow users posts 2.sql
 -- 1.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -36,7 +36,7 @@ table "users" {
 -- invalid-on-delete-action.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -70,7 +70,7 @@ table "posts" {
 -- invalid-on-update-action.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -104,7 +104,7 @@ table "posts" {
 -- 2.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {

--- a/internal/integration/testdata/mysql/foreign-key-modify-action.txt
+++ b/internal/integration/testdata/mysql/foreign-key-modify-action.txt
@@ -12,7 +12,7 @@ cmpshow users posts 2.sql
 -- 1.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -73,7 +73,7 @@ CREATE TABLE `posts` (
 -- 2.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {

--- a/internal/integration/testdata/mysql/index-add-drop.txt
+++ b/internal/integration/testdata/mysql/index-add-drop.txt
@@ -21,7 +21,7 @@ cmpshow users 1.sql
 -- 1.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -44,7 +44,7 @@ CREATE TABLE `users` (
 -- 2.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -74,7 +74,7 @@ CREATE TABLE `users` (
 -- 3.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {

--- a/internal/integration/testdata/mysql/index-desc.txt
+++ b/internal/integration/testdata/mysql/index-desc.txt
@@ -21,7 +21,7 @@ cmpshow users 3.sql
 -- 1.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -46,7 +46,7 @@ CREATE TABLE `users` (
 -- 2.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -71,7 +71,7 @@ CREATE TABLE `users` (
 -- 2-no-change.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {
@@ -89,7 +89,7 @@ table "users" {
 -- 3.hcl --
 schema "$db" {
     charset = "$charset"
-    collation = "$collate"
+    collate = "$collate"
 }
 
 table "users" {

--- a/sql/mysql/sqlspec.go
+++ b/sql/mysql/sqlspec.go
@@ -176,7 +176,7 @@ func schemaSpec(s *schema.Schema) (*sqlspec.Schema, []*sqlspec.Table, error) {
 		sc.Extra.Attrs = append(sc.Extra.Attrs, specutil.StrAttr("charset", c))
 	}
 	if c, ok := hasCollate(s.Attrs, nil); ok {
-		sc.Extra.Attrs = append(sc.Extra.Attrs, specutil.StrAttr("collation", c))
+		sc.Extra.Attrs = append(sc.Extra.Attrs, specutil.StrAttr("collate", c))
 	}
 	return sc, t, nil
 }
@@ -198,7 +198,7 @@ func tableSpec(t *schema.Table) (*sqlspec.Table, error) {
 		ts.Extra.Attrs = append(ts.Extra.Attrs, specutil.StrAttr("charset", c))
 	}
 	if c, ok := hasCollate(t.Attrs, t.Schema.Attrs); ok {
-		ts.Extra.Attrs = append(ts.Extra.Attrs, specutil.StrAttr("collation", c))
+		ts.Extra.Attrs = append(ts.Extra.Attrs, specutil.StrAttr("collate", c))
 	}
 	return ts, nil
 }
@@ -224,7 +224,7 @@ func columnSpec(c *schema.Column, t *schema.Table) (*sqlspec.Column, error) {
 		col.Extra.Attrs = append(col.Extra.Attrs, specutil.StrAttr("charset", c))
 	}
 	if c, ok := hasCollate(c.Attrs, t.Attrs); ok {
-		col.Extra.Attrs = append(col.Extra.Attrs, specutil.StrAttr("collation", c))
+		col.Extra.Attrs = append(col.Extra.Attrs, specutil.StrAttr("collate", c))
 	}
 	if o := (OnUpdate{}); sqlx.Has(c.Attrs, &o) {
 		col.Extra.Attrs = append(col.Extra.Attrs, specutil.RawAttr("on_update", o.A))
@@ -270,7 +270,12 @@ func convertCharset(spec specutil.Attrer, attrs *[]schema.Attr) error {
 		}
 		*attrs = append(*attrs, &schema.Charset{V: s})
 	}
-	if attr, ok := spec.Attr("collation"); ok {
+	// For backwards compatibility, accepts both "collate" and "collation".
+	attr, ok := spec.Attr("collate")
+	if !ok {
+		attr, ok = spec.Attr("collation")
+	}
+	if ok {
 		s, err := attr.String()
 		if err != nil {
 			return err
@@ -291,7 +296,7 @@ func hasCharset(attr []schema.Attr, parent []schema.Attr) (string, bool) {
 	return "", false
 }
 
-// hasCollate reports if the attribute contains the "collation" attribute,
+// hasCollate reports if the attribute contains the "collation"/"collate" attribute,
 // and it needs to be defined explicitly on the schema. This is true, in
 // case the element collation is different from its parent collation.
 func hasCollate(attr []schema.Attr, parent []schema.Attr) (string, bool) {

--- a/sql/mysql/sqlspec_test.go
+++ b/sql/mysql/sqlspec_test.go
@@ -334,10 +334,10 @@ func TestMarshalSpec_Charset(t *testing.T) {
 	const expected = `table "users" {
   schema = schema.test
   column "a" {
-    null      = false
-    type      = text
-    charset   = "latin1"
-    collation = "latin1_swedish_ci"
+    null    = false
+    type    = text
+    charset = "latin1"
+    collate = "latin1_swedish_ci"
   }
   column "b" {
     null = false
@@ -345,23 +345,23 @@ func TestMarshalSpec_Charset(t *testing.T) {
   }
 }
 table "posts" {
-  schema    = schema.test
-  charset   = "latin1"
-  collation = "latin1_swedish_ci"
+  schema  = schema.test
+  charset = "latin1"
+  collate = "latin1_swedish_ci"
   column "a" {
     null = false
     type = text
   }
   column "b" {
-    null      = false
-    type      = text
-    charset   = "utf8mb4"
-    collation = "utf8mb4_0900_ai_ci"
+    null    = false
+    type    = text
+    charset = "utf8mb4"
+    collate = "utf8mb4_0900_ai_ci"
   }
 }
 schema "test" {
-  charset   = "utf8mb4"
-  collation = "utf8mb4_0900_ai_ci"
+  charset = "utf8mb4"
+  collate = "utf8mb4_0900_ai_ci"
 }
 `
 	require.EqualValues(t, expected, string(buf))


### PR DESCRIPTION
`collate` is shorter and also used by MySQL/PostgreSQL