### PR TITLE
sql/migrate: (BC) read from state from migration directory instead of an extra state reader

### DIFF
--- a/sql/migrate/migrate.go
+++ b/sql/migrate/migrate.go
@@ -158,8 +158,8 @@ type (
 	}
 )
 
-// New creates a new Planner.
-func New(drv Driver, dir Dir, fmt Formatter) *Planner {
+// NewPlanner creates a new Planner.
+func NewPlanner(drv Driver, dir Dir, fmt Formatter) *Planner {
 	return &Planner{
 		drv: drv,
 		dir: dir,
@@ -214,7 +214,11 @@ type LocalDir struct {
 // NewLocalDir returns a new the Dir used by a Planner to work on the given local path.
 func NewLocalDir(path string) (*LocalDir, error) {
 	fi, err := os.Stat(path)
-	if err != nil {
+	if err == os.ErrNotExist {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			return nil, err
+		}
+	} else if err != nil {
 		return nil, err
 	}
 	if !fi.IsDir() {

--- a/sql/migrate/migrate.go
+++ b/sql/migrate/migrate.go
@@ -184,6 +184,13 @@ func WithFormatter(fmt Formatter) PlannerOption {
 	}
 }
 
+// WithStateReader sets the StateReader of a Planner.
+func WithStateReader(dsr StateReader) PlannerOption {
+	return func(p *Planner) {
+		p.dsr = dsr
+	}
+}
+
 // Plan calculates the migration Plan required for moving the current state (from) state to
 // the next state (to). A StateReader can be a directory, static schema elements or a Driver connection.
 func (p *Planner) Plan(ctx context.Context, name string, to StateReader) (*Plan, error) {

--- a/sql/migrate/migrate_test.go
+++ b/sql/migrate/migrate_test.go
@@ -33,7 +33,7 @@ func TestPlanner_WritePlan(t *testing.T) {
 	}
 
 	// DefaultFormatter
-	pl := migrate.NewPlanner(nil, mfs, migrate.DefaultFormatter)
+	pl := migrate.NewPlanner(nil, mfs)
 	require.NotNil(t, pl)
 	require.NoError(t, pl.WritePlan(plan))
 	v := strconv.FormatInt(time.Now().Unix(), 10)
@@ -53,7 +53,7 @@ func TestPlanner_WritePlan(t *testing.T) {
 		template.Must(template.New("").Parse("{{range .Changes}}{{println .Cmd}}{{end}}")),
 	)
 	require.NoError(t, err)
-	pl = migrate.NewPlanner(nil, mfs, fmt)
+	pl = migrate.NewPlanner(nil, mfs, migrate.WithFormatter(fmt))
 	require.NotNil(t, pl)
 	require.NoError(t, pl.WritePlan(plan))
 	require.Len(t, mfs.files, 3)
@@ -71,8 +71,8 @@ func TestPlanner_Plan(t *testing.T) {
 	)
 
 	// nothing to do
-	pl := migrate.NewPlanner(drv, mfs, migrate.DefaultFormatter)
-	plan, err := pl.Plan(ctx, "empty", migrate.Realm(nil), migrate.Realm(nil))
+	pl := migrate.NewPlanner(drv, mfs)
+	plan, err := pl.Plan(ctx, "empty", migrate.Realm(nil))
 	require.ErrorIs(t, err, migrate.ErrNoPlan)
 	require.Nil(t, plan)
 
@@ -87,7 +87,7 @@ func TestPlanner_Plan(t *testing.T) {
 			{Cmd: "CREATE TABLE t2(c int);"},
 		},
 	}
-	plan, err = pl.Plan(ctx, "", migrate.Realm(nil), migrate.Realm(nil))
+	plan, err = pl.Plan(ctx, "", migrate.Realm(nil))
 	require.NoError(t, err)
 	require.Equal(t, drv.plan, plan)
 }
@@ -100,11 +100,11 @@ func TestGlobStateReader(t *testing.T) {
 	localFS, err := migrate.NewLocalDir("testdata")
 	require.NoError(t, err)
 
-	_, err = localFS.GlobStateReader(drv, "*.up.sql").ReadState(ctx)
+	_, err = migrate.GlobStateReader(localFS, drv, "*.up.sql").ReadState(ctx)
 	require.NoError(t, err)
 	require.Equal(t, drv.executed, []string{"CREATE TABLE t(c int);"})
 
-	_, err = localFS.GlobStateReader(drv, "*.down.sql").ReadState(ctx)
+	_, err = migrate.GlobStateReader(localFS, drv, "*.down.sql").ReadState(ctx)
 	require.NoError(t, err)
 	require.Equal(t, drv.executed, []string{"CREATE TABLE t(c int);", "DROP TABLE IF EXISTS t;"})
 }

--- a/sql/migrate/migrate_test.go
+++ b/sql/migrate/migrate_test.go
@@ -33,7 +33,7 @@ func TestPlanner_WritePlan(t *testing.T) {
 	}
 
 	// DefaultFormatter
-	pl := migrate.New(nil, mfs, migrate.DefaultFormatter)
+	pl := migrate.NewPlanner(nil, mfs, migrate.DefaultFormatter)
 	require.NotNil(t, pl)
 	require.NoError(t, pl.WritePlan(plan))
 	v := strconv.FormatInt(time.Now().Unix(), 10)
@@ -53,7 +53,7 @@ func TestPlanner_WritePlan(t *testing.T) {
 		template.Must(template.New("").Parse("{{range .Changes}}{{println .Cmd}}{{end}}")),
 	)
 	require.NoError(t, err)
-	pl = migrate.New(nil, mfs, fmt)
+	pl = migrate.NewPlanner(nil, mfs, fmt)
 	require.NotNil(t, pl)
 	require.NoError(t, pl.WritePlan(plan))
 	require.Len(t, mfs.files, 3)
@@ -71,7 +71,7 @@ func TestPlanner_Plan(t *testing.T) {
 	)
 
 	// nothing to do
-	pl := migrate.New(drv, mfs, migrate.DefaultFormatter)
+	pl := migrate.NewPlanner(drv, mfs, migrate.DefaultFormatter)
 	plan, err := pl.Plan(ctx, "empty", migrate.Realm(nil), migrate.Realm(nil))
 	require.ErrorIs(t, err, migrate.ErrNoPlan)
 	require.Nil(t, plan)


### PR DESCRIPTION
This is the first PR of several to add the `atlas migrate` commands.