### PR TITLE
cmd/atlas: add atlas serve docs

### DIFF
--- a/cmd/atlas/doc.tmpl
+++ b/cmd/atlas/doc.tmpl
@@ -61,4 +61,26 @@ go get ariga.io/atlas/cmd/atlas
 ```
 {{ end }}
 {{ end }}
+## atlas serve
+
+Run Atlas web UI in a standalone mode
+
+#### Usage
+```
+atlas serve [flags]
+```
+
+#### Details
+'atlas serve' runs the Atlas web UI in a standalone mode with optional persistent storage.
+If you do not specify the storage, it will be stored in-memory.
+Atlas encrypts sensitive data such as passwords using the generated keyset.json.
+
+#### Flags
+```
+--addr string       listen address for atlas serve (default ":8080")
+--storage string    data store url using the dsn format:
+                    [driver://username:password@protocol(address)/dbname?param=value] (default "in-memory")
+-h, --help          help for serve
+```
+
 {{ end }}

--- a/doc/md/cli/reference.md
+++ b/doc/md/cli/reference.md
@@ -195,3 +195,25 @@ atlas version
 ```
 
 
+## atlas serve
+
+Run Atlas web UI in a standalone mode
+
+#### Usage
+```
+atlas serve [flags]
+```
+
+#### Details
+'atlas serve' runs the Atlas web UI in a standalone mode with optional persistent storage.
+If you do not specify the storage, it will be stored in-memory.
+Atlas encrypts sensitive data such as passwords using the generated keyset.json.
+
+#### Flags
+```
+--addr string       listen address for atlas serve (default ":8080")
+--storage string    data store url using the dsn format:
+                    [driver://username:password@protocol(address)/dbname?param=value] (default "in-memory")
+-h, --help          help for serve
+```
+

--- a/doc/package-lock.json
+++ b/doc/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "doc",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Adds documentation for atlas serve command.
