### PR TITLE
Default value of string like field can be empty string `""` or `"null"`

### DIFF
--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -237,7 +237,7 @@ func (i *inspect) addColumn(s *schema.Schema, rows *sql.Rows) error {
 	if err := i.extraAttr(t, c, extra.String); err != nil {
 		return err
 	}
-	if sqlx.ValidString(defaults) {
+	if defaults.Valid {
 		if i.mariadb() {
 			c.Default = i.marDefaultExpr(c, defaults.String)
 		} else {

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -573,6 +573,10 @@ func isHex(x string) bool { return len(x) > 2 && strings.ToLower(x[:2]) == "0x" 
 
 // marDefaultExpr returns the correct schema.Expr based on the column attributes for MariaDB.
 func (i *inspect) marDefaultExpr(c *schema.Column, x string) schema.Expr {
+	// Unlike MySQL, NULL means default to NULL or no default.
+	if x == "NULL" {
+		return nil
+	}
 	// From MariaDB 10.2.7, string-based literals are quoted to distinguish them from expressions.
 	if i.gteV("10.2.7") && sqlx.IsQuoted(x, '\'') {
 		return &schema.Literal{V: x}

--- a/sql/postgres/inspect.go
+++ b/sql/postgres/inspect.go
@@ -178,7 +178,7 @@ func (i *inspect) addColumn(s *schema.Schema, rows *sql.Rows) error {
 		typtype:       typtype.String,
 		typid:         typid.Int64,
 	})
-	if sqlx.ValidString(defaults) {
+	if defaults.Valid {
 		c.Default = defaultExpr(c, defaults.String)
 	}
 	if identity.String == "YES" {

--- a/sql/sqlite/inspect.go
+++ b/sql/sqlite/inspect.go
@@ -138,7 +138,7 @@ func (i *inspect) addColumn(t *schema.Table, rows *sql.Rows) error {
 	if err != nil {
 		return err
 	}
-	if sqlx.ValidString(defaults) {
+	if defaults.Valid {
 		c.Default = defaultExpr(defaults.String)
 	}
 	// TODO(a8m): extract collation from 'CREATE TABLE' statement.


### PR DESCRIPTION
fix issue #625 