### PR TITLE
internal/integration: speed up test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         working-directory: cmd
 
   
-  integration_mysql56:
+  integration-mysql56:
     runs-on: ubuntu-latest
     services:
       mysql56:
@@ -101,9 +101,9 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql56
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=mysql56 go test -race -count=2 -v -run="MySQL.*/56" ./...
+        run: GO_TEST_ONLY_VERSION=mysql56 go test -race -count=2 -v -run="MySQL.*/mysql56" ./...
   
-  integration_mysql57:
+  integration-mysql57:
     runs-on: ubuntu-latest
     services:
       mysql57:
@@ -132,9 +132,9 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql57
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=mysql57 go test -race -count=2 -v -run="MySQL.*/57" ./...
+        run: GO_TEST_ONLY_VERSION=mysql57 go test -race -count=2 -v -run="MySQL.*/mysql57" ./...
   
-  integration_mysql8:
+  integration-mysql8:
     runs-on: ubuntu-latest
     services:
       mysql8:
@@ -163,9 +163,9 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql8
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=mysql8 go test -race -count=2 -v -run="MySQL.*/8" ./...
+        run: GO_TEST_ONLY_VERSION=mysql8 go test -race -count=2 -v -run="MySQL.*/mysql8" ./...
   
-  integration_maria107:
+  integration-maria107:
     runs-on: ubuntu-latest
     services:
       maria107:
@@ -194,9 +194,9 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria107
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=maria107 go test -race -count=2 -v -run="MySQL.*/Maria107" ./...
+        run: GO_TEST_ONLY_VERSION=maria107 go test -race -count=2 -v -run="MySQL.*/maria107" ./...
   
-  integration_maria102:
+  integration-maria102:
     runs-on: ubuntu-latest
     services:
       maria102:
@@ -225,9 +225,9 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria102
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=maria102 go test -race -count=2 -v -run="MySQL.*/Maria102" ./...
+        run: GO_TEST_ONLY_VERSION=maria102 go test -race -count=2 -v -run="MySQL.*/maria102" ./...
   
-  integration_maria103:
+  integration-maria103:
     runs-on: ubuntu-latest
     services:
       maria103:
@@ -256,9 +256,9 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria103
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=maria103 go test -race -count=2 -v -run="MySQL.*/Maria103" ./...
+        run: GO_TEST_ONLY_VERSION=maria103 go test -race -count=2 -v -run="MySQL.*/maria103" ./...
   
-  integration_postgres10:
+  integration-postgres10:
     runs-on: ubuntu-latest
     services:
       postgres10:
@@ -286,9 +286,9 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres10
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=postgres10 go test -race -count=2 -v -run="Postgres.*/10" ./...
+        run: GO_TEST_ONLY_VERSION=postgres10 go test -race -count=2 -v -run="Postgres.*/postgres10" ./...
   
-  integration_postgres11:
+  integration-postgres11:
     runs-on: ubuntu-latest
     services:
       postgres11:
@@ -316,9 +316,9 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres11
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=postgres11 go test -race -count=2 -v -run="Postgres.*/11" ./...
+        run: GO_TEST_ONLY_VERSION=postgres11 go test -race -count=2 -v -run="Postgres.*/postgres11" ./...
   
-  integration_postgres12:
+  integration-postgres12:
     runs-on: ubuntu-latest
     services:
       postgres12:
@@ -346,9 +346,9 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres12
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=postgres12 go test -race -count=2 -v -run="Postgres.*/12" ./...
+        run: GO_TEST_ONLY_VERSION=postgres12 go test -race -count=2 -v -run="Postgres.*/postgres12" ./...
   
-  integration_postgres13:
+  integration-postgres13:
     runs-on: ubuntu-latest
     services:
       postgres13:
@@ -376,9 +376,9 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres13
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=postgres13 go test -race -count=2 -v -run="Postgres.*/13" ./...
+        run: GO_TEST_ONLY_VERSION=postgres13 go test -race -count=2 -v -run="Postgres.*/postgres13" ./...
   
-  integration_postgres14:
+  integration-postgres14:
     runs-on: ubuntu-latest
     services:
       postgres14:
@@ -406,9 +406,9 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres14
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=postgres14 go test -race -count=2 -v -run="Postgres.*/14" ./...
+        run: GO_TEST_ONLY_VERSION=postgres14 go test -race -count=2 -v -run="Postgres.*/postgres14" ./...
   
-  integration_tidb5:
+  integration-tidb5:
     runs-on: ubuntu-latest
     services:
       tidb5:
@@ -430,9 +430,9 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for tidb5
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=tidb5 go test -race -count=2 -v -run="TiDB.*/5" ./...
+        run: GO_TEST_ONLY_VERSION=tidb5 go test -race -count=2 -v -run="TiDB.*/tidb5" ./...
   
-  integration_sqlite:
+  integration-sqlite:
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql56
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=mysql56 go test -race -count=2 -v -run="MySQL.*/mysql56" ./...
+        run: go test -race -count=2 -v -run="MySQL.*/mysql56" -service=mysql56 ./...
   
   integration-mysql57:
     runs-on: ubuntu-latest
@@ -132,7 +132,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql57
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=mysql57 go test -race -count=2 -v -run="MySQL.*/mysql57" ./...
+        run: go test -race -count=2 -v -run="MySQL.*/mysql57" -service=mysql57 ./...
   
   integration-mysql8:
     runs-on: ubuntu-latest
@@ -163,7 +163,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql8
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=mysql8 go test -race -count=2 -v -run="MySQL.*/mysql8" ./...
+        run: go test -race -count=2 -v -run="MySQL.*/mysql8" -service=mysql8 ./...
   
   integration-maria107:
     runs-on: ubuntu-latest
@@ -194,7 +194,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria107
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=maria107 go test -race -count=2 -v -run="MySQL.*/maria107" ./...
+        run: go test -race -count=2 -v -run="MySQL.*/maria107" -service=maria107 ./...
   
   integration-maria102:
     runs-on: ubuntu-latest
@@ -225,7 +225,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria102
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=maria102 go test -race -count=2 -v -run="MySQL.*/maria102" ./...
+        run: go test -race -count=2 -v -run="MySQL.*/maria102" -service=maria102 ./...
   
   integration-maria103:
     runs-on: ubuntu-latest
@@ -256,7 +256,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria103
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=maria103 go test -race -count=2 -v -run="MySQL.*/maria103" ./...
+        run: go test -race -count=2 -v -run="MySQL.*/maria103" -service=maria103 ./...
   
   integration-postgres10:
     runs-on: ubuntu-latest
@@ -286,7 +286,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres10
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=postgres10 go test -race -count=2 -v -run="Postgres.*/postgres10" ./...
+        run: go test -race -count=2 -v -run="Postgres.*/postgres10" -service=postgres10 ./...
   
   integration-postgres11:
     runs-on: ubuntu-latest
@@ -316,7 +316,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres11
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=postgres11 go test -race -count=2 -v -run="Postgres.*/postgres11" ./...
+        run: go test -race -count=2 -v -run="Postgres.*/postgres11" -service=postgres11 ./...
   
   integration-postgres12:
     runs-on: ubuntu-latest
@@ -346,7 +346,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres12
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=postgres12 go test -race -count=2 -v -run="Postgres.*/postgres12" ./...
+        run: go test -race -count=2 -v -run="Postgres.*/postgres12" -service=postgres12 ./...
   
   integration-postgres13:
     runs-on: ubuntu-latest
@@ -376,7 +376,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres13
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=postgres13 go test -race -count=2 -v -run="Postgres.*/postgres13" ./...
+        run: go test -race -count=2 -v -run="Postgres.*/postgres13" -service=postgres13 ./...
   
   integration-postgres14:
     runs-on: ubuntu-latest
@@ -406,7 +406,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres14
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=postgres14 go test -race -count=2 -v -run="Postgres.*/postgres14" ./...
+        run: go test -race -count=2 -v -run="Postgres.*/postgres14" -service=postgres14 ./...
   
   integration-tidb5:
     runs-on: ubuntu-latest
@@ -430,7 +430,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for tidb5
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=tidb5 go test -race -count=2 -v -run="TiDB.*/tidb5" ./...
+        run: go test -race -count=2 -v -run="TiDB.*/tidb5" -service=tidb5 ./...
   
   integration-sqlite:
     runs-on: ubuntu-latest
@@ -448,5 +448,5 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for sqlite
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION=sqlite go test -race -count=2 -v -run="SQLite.*" ./...
+        run: go test -race -count=2 -v -run="SQLite.*" -service=sqlite ./...
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql56
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/56" ./...
+        run: GO_TEST_ONLY_VERSION=mysql56 go test -race -count=2 -v -run="MySQL.*/56" ./...
   
   integration_mysql57:
     runs-on: ubuntu-latest
@@ -132,7 +132,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql57
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/57" ./...
+        run: GO_TEST_ONLY_VERSION=mysql57 go test -race -count=2 -v -run="MySQL.*/57" ./...
   
   integration_mysql8:
     runs-on: ubuntu-latest
@@ -163,7 +163,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql8
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/8" ./...
+        run: GO_TEST_ONLY_VERSION=mysql8 go test -race -count=2 -v -run="MySQL.*/8" ./...
   
   integration_maria107:
     runs-on: ubuntu-latest
@@ -194,7 +194,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria107
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/Maria107" ./...
+        run: GO_TEST_ONLY_VERSION=maria107 go test -race -count=2 -v -run="MySQL.*/Maria107" ./...
   
   integration_maria102:
     runs-on: ubuntu-latest
@@ -225,7 +225,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria102
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/Maria102" ./...
+        run: GO_TEST_ONLY_VERSION=maria102 go test -race -count=2 -v -run="MySQL.*/Maria102" ./...
   
   integration_maria103:
     runs-on: ubuntu-latest
@@ -256,7 +256,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria103
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/Maria103" ./...
+        run: GO_TEST_ONLY_VERSION=maria103 go test -race -count=2 -v -run="MySQL.*/Maria103" ./...
   
   integration_postgres10:
     runs-on: ubuntu-latest
@@ -286,7 +286,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres10
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/10" ./...
+        run: GO_TEST_ONLY_VERSION=postgres10 go test -race -count=2 -v -run="Postgres.*/10" ./...
   
   integration_postgres11:
     runs-on: ubuntu-latest
@@ -316,7 +316,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres11
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/11" ./...
+        run: GO_TEST_ONLY_VERSION=postgres11 go test -race -count=2 -v -run="Postgres.*/11" ./...
   
   integration_postgres12:
     runs-on: ubuntu-latest
@@ -346,7 +346,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres12
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/12" ./...
+        run: GO_TEST_ONLY_VERSION=postgres12 go test -race -count=2 -v -run="Postgres.*/12" ./...
   
   integration_postgres13:
     runs-on: ubuntu-latest
@@ -376,7 +376,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres13
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/13" ./...
+        run: GO_TEST_ONLY_VERSION=postgres13 go test -race -count=2 -v -run="Postgres.*/13" ./...
   
   integration_postgres14:
     runs-on: ubuntu-latest
@@ -406,7 +406,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres14
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/14" ./...
+        run: GO_TEST_ONLY_VERSION=postgres14 go test -race -count=2 -v -run="Postgres.*/14" ./...
   
   integration_tidb5:
     runs-on: ubuntu-latest
@@ -430,7 +430,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for tidb5
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="TiDB.*/5" ./...
+        run: GO_TEST_ONLY_VERSION=tidb5 go test -race -count=2 -v -run="TiDB.*/5" ./...
   
   integration_sqlite:
     runs-on: ubuntu-latest
@@ -448,5 +448,5 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for sqlite
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="SQLite.*" ./...
+        run: GO_TEST_ONLY_VERSION=sqlite go test -race -count=2 -v -run="SQLite.*" ./...
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - uses: actions/cache@v2.1.5
         with:
           path: ~/go/pkg/mod
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17', '1.16']
+        go: ['1.17', '1.18']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -217,7 +217,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - uses: actions/cache@v2.1.6
         with:
           path: ~/go/pkg/mod
@@ -227,3 +227,4 @@ jobs:
       - name: Run integration tests
         working-directory: internal/integration
         run: go test -race -count=2 -timeout=15m ./...
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
+# # # # # # # # # # # # # # # #
+# CODE GENERATED - DO NOT EDIT
+# # # # # # # # # # # # # # # #
 name: Continuous Integration
 on:
   pull_request:
   push:
     branches:
       - master
-      
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -31,7 +34,7 @@ jobs:
       - name: run "go generate ./..."
         run: go generate ./...
       - name: run "go generate internal/typedoc"
-        working-directory: internal/typedoc 
+        working-directory: internal/typedoc
         run: go generate ./...
       - name: Verify generated files are checked in properly
         run: |
@@ -46,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17', '1.18']
+        go: [ '1.17', '1.18' ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -68,7 +71,8 @@ jobs:
         run: go test -race ./...
         working-directory: cmd
 
-  integration:
+  
+  integration_mysql56:
     runs-on: ubuntu-latest
     services:
       mysql56:
@@ -84,6 +88,24 @@ jobs:
           --health-start-period 10s
           --health-timeout 5s
           --health-retries 10
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests for mysql56
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="MySQL.*/56" ./...
+  
+  integration_mysql57:
+    runs-on: ubuntu-latest
+    services:
       mysql57:
         image: mysql:5.7.26
         env:
@@ -97,6 +119,24 @@ jobs:
           --health-start-period 10s
           --health-timeout 5s
           --health-retries 10
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests for mysql57
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="MySQL.*/57" ./...
+  
+  integration_mysql8:
+    runs-on: ubuntu-latest
+    services:
       mysql8:
         image: mysql:8
         env:
@@ -110,8 +150,26 @@ jobs:
           --health-start-period 10s
           --health-timeout 5s
           --health-retries 10
-      maria:
-        image: mariadb
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests for mysql8
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="MySQL.*/8" ./...
+  
+  integration_maria107:
+    runs-on: ubuntu-latest
+    services:
+      maria107:
+        image: mariadb:10.7
         env:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: pass
@@ -123,6 +181,24 @@ jobs:
           --health-start-period 10s
           --health-timeout 5s
           --health-retries 10
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests for maria107
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="MySQL.*/Maria107" ./...
+  
+  integration_maria102:
+    runs-on: ubuntu-latest
+    services:
       maria102:
         image: mariadb:10.2.32
         env:
@@ -136,6 +212,24 @@ jobs:
           --health-start-period 10s
           --health-timeout 5s
           --health-retries 10
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests for maria102
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="MySQL.*/Maria102" ./...
+  
+  integration_maria103:
+    runs-on: ubuntu-latest
+    services:
       maria103:
         image: mariadb:10.3.13
         env:
@@ -149,6 +243,24 @@ jobs:
           --health-start-period 10s
           --health-timeout 5s
           --health-retries 10
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests for maria103
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="MySQL.*/Maria103" ./...
+  
+  integration_postgres10:
+    runs-on: ubuntu-latest
+    services:
       postgres10:
         image: postgres:10
         env:
@@ -161,6 +273,24 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests for postgres10
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="Postgres.*/10" ./...
+  
+  integration_postgres11:
+    runs-on: ubuntu-latest
+    services:
       postgres11:
         image: postgres:11
         env:
@@ -173,6 +303,24 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests for postgres11
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="Postgres.*/11" ./...
+  
+  integration_postgres12:
+    runs-on: ubuntu-latest
+    services:
       postgres12:
         image: postgres:12.3
         env:
@@ -185,6 +333,24 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests for postgres12
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="Postgres.*/12" ./...
+  
+  integration_postgres13:
+    runs-on: ubuntu-latest
+    services:
       postgres13:
         image: postgres:13.1
         env:
@@ -197,6 +363,24 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests for postgres13
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="Postgres.*/13" ./...
+  
+  integration_postgres14:
+    runs-on: ubuntu-latest
+    services:
       postgres14:
         image: postgres:14
         env:
@@ -209,10 +393,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-      tidb5:
-        image: pingcap/tidb:v5.4.0
-        ports:
-          - 4309:4000
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/setup-go@v2
@@ -224,7 +404,49 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Run integration tests
+      - name: Run integration tests for postgres14
         working-directory: internal/integration
-        run: go test -race -count=2 -timeout=15m ./...
-
+        run: go test -race -count=2 -v -run="Postgres.*/14" ./...
+  
+  integration_tidb5:
+    runs-on: ubuntu-latest
+    services:
+      tidb5:
+        image: pingcap/tidb:v5.4.0
+        
+        ports:
+          - 4309:4000
+        
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests for tidb5
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="TiDB.*/5" ./...
+  
+  integration_sqlite:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests for sqlite
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="SQLite.*" ./...
+  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql56
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/mysql56" -service=mysql56 ./...
+        run: go test -race -count=2 -v -run="MySQL.*/mysql56" -dialect=mysql56 ./...
   
   integration-mysql57:
     runs-on: ubuntu-latest
@@ -132,7 +132,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql57
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/mysql57" -service=mysql57 ./...
+        run: go test -race -count=2 -v -run="MySQL.*/mysql57" -dialect=mysql57 ./...
   
   integration-mysql8:
     runs-on: ubuntu-latest
@@ -163,7 +163,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql8
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/mysql8" -service=mysql8 ./...
+        run: go test -race -count=2 -v -run="MySQL.*/mysql8" -dialect=mysql8 ./...
   
   integration-maria107:
     runs-on: ubuntu-latest
@@ -194,7 +194,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria107
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/maria107" -service=maria107 ./...
+        run: go test -race -count=2 -v -run="MySQL.*/maria107" -dialect=maria107 ./...
   
   integration-maria102:
     runs-on: ubuntu-latest
@@ -225,7 +225,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria102
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/maria102" -service=maria102 ./...
+        run: go test -race -count=2 -v -run="MySQL.*/maria102" -dialect=maria102 ./...
   
   integration-maria103:
     runs-on: ubuntu-latest
@@ -256,7 +256,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria103
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/maria103" -service=maria103 ./...
+        run: go test -race -count=2 -v -run="MySQL.*/maria103" -dialect=maria103 ./...
   
   integration-postgres10:
     runs-on: ubuntu-latest
@@ -286,7 +286,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres10
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/postgres10" -service=postgres10 ./...
+        run: go test -race -count=2 -v -run="Postgres.*/postgres10" -dialect=postgres10 ./...
   
   integration-postgres11:
     runs-on: ubuntu-latest
@@ -316,7 +316,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres11
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/postgres11" -service=postgres11 ./...
+        run: go test -race -count=2 -v -run="Postgres.*/postgres11" -dialect=postgres11 ./...
   
   integration-postgres12:
     runs-on: ubuntu-latest
@@ -346,7 +346,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres12
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/postgres12" -service=postgres12 ./...
+        run: go test -race -count=2 -v -run="Postgres.*/postgres12" -dialect=postgres12 ./...
   
   integration-postgres13:
     runs-on: ubuntu-latest
@@ -376,7 +376,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres13
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/postgres13" -service=postgres13 ./...
+        run: go test -race -count=2 -v -run="Postgres.*/postgres13" -dialect=postgres13 ./...
   
   integration-postgres14:
     runs-on: ubuntu-latest
@@ -406,7 +406,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres14
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/postgres14" -service=postgres14 ./...
+        run: go test -race -count=2 -v -run="Postgres.*/postgres14" -dialect=postgres14 ./...
   
   integration-tidb5:
     runs-on: ubuntu-latest
@@ -430,7 +430,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for tidb5
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="TiDB.*/tidb5" -service=tidb5 ./...
+        run: go test -race -count=2 -v -run="TiDB.*/tidb5" -dialect=tidb5 ./...
   
   integration-sqlite:
     runs-on: ubuntu-latest
@@ -448,5 +448,5 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for sqlite
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="SQLite.*" -service=sqlite ./...
+        run: go test -race -count=2 -v -run="SQLite.*" -dialect=sqlite ./...
   

--- a/cmd/action/migrate.go
+++ b/cmd/action/migrate.go
@@ -220,7 +220,7 @@ var (
 		},
 	}
 	nameTmpl = template.Must(template.New("name").Funcs(funcMap).Parse(
-		"{{ now }}{{ with .Version }}_{{ . }}{{ end }}.sql",
+		"{{ now }}{{ with .Name }}_{{ . }}{{ end }}.sql",
 	))
 	contentTmpl = template.Must(template.New("content").Funcs(funcMap).Parse(
 		"{{ range .Changes }}{{ with .Comment }}-- {{ println . }}{{ end }}{{ println (sem .Cmd) }}{{ end }}",

--- a/cmd/action/migrate.go
+++ b/cmd/action/migrate.go
@@ -220,7 +220,7 @@ var (
 		},
 	}
 	nameTmpl = template.Must(template.New("name").Funcs(funcMap).Parse(
-		"{{ now }}{{ with .Name }}_{{ . }}{{ end }}.sql",
+		"{{ now }}{{ with .Version }}_{{ . }}{{ end }}.sql",
 	))
 	contentTmpl = template.Must(template.New("content").Funcs(funcMap).Parse(
 		"{{ range .Changes }}{{ with .Comment }}-- {{ println . }}{{ end }}{{ println (sem .Cmd) }}{{ end }}",

--- a/cmd/action/provider.go
+++ b/cmd/action/provider.go
@@ -18,7 +18,6 @@ func init() {
 	DefaultMux.RegisterProvider("mariadb", mysqlProvider)
 	DefaultMux.RegisterProvider("postgres", postgresProvider)
 	DefaultMux.RegisterProvider("sqlite", sqliteProvider)
-	DefaultMux.RegisterProvider("docker", dockerProvider)
 }
 
 func mysqlProvider(dsn string) (*Driver, error) {
@@ -75,8 +74,4 @@ func sqliteProvider(dsn string) (*Driver, error) {
 		Unmarshaler: sqlite.UnmarshalHCL,
 		Closer:      db,
 	}, nil
-}
-
-func dockerProvider(dsn string) (*Driver, error) {
-	return nil, nil
 }

--- a/cmd/action/provider.go
+++ b/cmd/action/provider.go
@@ -18,6 +18,7 @@ func init() {
 	DefaultMux.RegisterProvider("mariadb", mysqlProvider)
 	DefaultMux.RegisterProvider("postgres", postgresProvider)
 	DefaultMux.RegisterProvider("sqlite", sqliteProvider)
+	DefaultMux.RegisterProvider("docker", dockerProvider)
 }
 
 func mysqlProvider(dsn string) (*Driver, error) {
@@ -74,4 +75,8 @@ func sqliteProvider(dsn string) (*Driver, error) {
 		Unmarshaler: sqlite.UnmarshalHCL,
 		Closer:      db,
 	}, nil
+}
+
+func dockerProvider(dsn string) (*Driver, error) {
+	return nil, nil
 }

--- a/internal/ci/ci.tmpl
+++ b/internal/ci/ci.tmpl
@@ -99,5 +99,5 @@ jobs:
             {{ "${{ runner.os }}-go-" }}
       - name: Run integration tests for {{ .Version }}
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="{{ .Regex }}" -service={{ .Version }} ./...
+        run: go test -race -count=2 -v -run="{{ .Regex }}" -dialect={{ .Version }} ./...
   {{ end }}

--- a/internal/ci/ci.tmpl
+++ b/internal/ci/ci.tmpl
@@ -72,10 +72,10 @@ jobs:
         working-directory: cmd
 
   {{ range $ }}
-  integration_{{ .Name }}:
+  integration_{{ .Version }}:
     runs-on: ubuntu-latest
     {{ if .Image }}services:
-      {{ .Name }}:
+      {{ .Version }}:
         image: {{ .Image }}
         {{ with .Env }}env:{{ range . }}
           {{ . }}{{ end }}
@@ -97,7 +97,7 @@ jobs:
           key: {{ "${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}" }}
           restore-keys: |
             {{ "${{ runner.os }}-go-" }}
-      - name: Run integration tests for {{ .Name }}
+      - name: Run integration tests for {{ .Version }}
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="{{ .Regex }}" ./...
+        run: GO_TEST_ONLY_VERSION={{ .Version }} go test -race -count=2 -v -run="{{ .Regex }}" ./...
   {{ end }}

--- a/internal/ci/ci.tmpl
+++ b/internal/ci/ci.tmpl
@@ -99,5 +99,5 @@ jobs:
             {{ "${{ runner.os }}-go-" }}
       - name: Run integration tests for {{ .Version }}
         working-directory: internal/integration
-        run: GO_TEST_ONLY_VERSION={{ .Version }} go test -race -count=2 -v -run="{{ .Regex }}" ./...
+        run: go test -race -count=2 -v -run="{{ .Regex }}" -service={{ .Version }} ./...
   {{ end }}

--- a/internal/ci/ci.tmpl
+++ b/internal/ci/ci.tmpl
@@ -1,0 +1,103 @@
+# # # # # # # # # # # # # # # #
+# CODE GENERATED - DO NOT EDIT
+# # # # # # # # # # # # # # # #
+name: Continuous Integration
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run linters
+        uses: golangci/golangci-lint-action@v2.5.2
+        with:
+          version: v1.42.1
+          args: --verbose
+  generate-cmp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.18'
+      - uses: actions/cache@v2.1.5
+        with:
+          path: ~/go/pkg/mod
+          key: {{ "${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}" }}
+          restore-keys: |
+            {{ "${{ runner.os }}-go-" }}
+      - name: run "go generate ./..."
+        run: go generate ./...
+      - name: run "go generate internal/typedoc"
+        working-directory: internal/typedoc
+        run: go generate ./...
+      - name: Verify generated files are checked in properly
+        run: |
+          status=$(git status --porcelain)
+          if [ -n "$status" ]; then
+            echo "you need to run 'go generate ./...' and commit the changes"
+            echo "$status"
+            exit 1
+          fi
+
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.17', '1.18' ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: {{ "${{ matrix.go }}" }}
+      - uses: actions/cache@v2.1.5
+        with:
+          path: ~/go/pkg/mod
+          key: {{ "${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}" }}
+          restore-keys: |
+            {{ "${{ runner.os }}-go-" }}
+      - name: Run sql tests
+        run: go test -race ./...
+        working-directory: sql
+      - name: Run schema tests
+        run: go test -race ./...
+        working-directory: schema
+      - name: Run cli tests
+        run: go test -race ./...
+        working-directory: cmd
+
+  {{ range $ }}
+  integration_{{ .Name }}:
+    runs-on: ubuntu-latest
+    {{ if .Image }}services:
+      {{ .Name }}:
+        image: {{ .Image }}
+        {{ with .Env }}env:{{ range . }}
+          {{ . }}{{ end }}
+        {{- end }}
+        {{ with .Ports }}ports:{{ range . }}
+          - {{ . }}{{ end }}
+        {{- end }}
+        {{ with .Options }}options: >-{{ range . }}
+          {{ . }}{{ end }}
+        {{- end }}{{ end }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/go/pkg/mod
+          key: {{ "${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}" }}
+          restore-keys: |
+            {{ "${{ runner.os }}-go-" }}
+      - name: Run integration tests for {{ .Name }}
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="{{ .Regex }}" ./...
+  {{ end }}

--- a/internal/ci/ci.tmpl
+++ b/internal/ci/ci.tmpl
@@ -72,7 +72,7 @@ jobs:
         working-directory: cmd
 
   {{ range $ }}
-  integration_{{ .Version }}:
+  integration-{{ .Version }}:
     runs-on: ubuntu-latest
     {{ if .Image }}services:
       {{ .Version }}:

--- a/internal/ci/main.go
+++ b/internal/ci/main.go
@@ -49,7 +49,7 @@ var (
 		{
 			Version: "mysql56",
 			Image:   "mysql:5.6.35",
-			Regex:   "MySQL.*/56",
+			Regex:   "MySQL.*/mysql56",
 			Env:     mysqlEnv,
 			Ports:   []string{"3306:3306"},
 			Options: mysqlOptions,
@@ -57,7 +57,7 @@ var (
 		{
 			Version: "mysql57",
 			Image:   "mysql:5.7.26",
-			Regex:   "MySQL.*/57",
+			Regex:   "MySQL.*/mysql57",
 			Env:     mysqlEnv,
 			Ports:   []string{"3307:3306"},
 			Options: mysqlOptions,
@@ -65,7 +65,7 @@ var (
 		{
 			Version: "mysql8",
 			Image:   "mysql:8",
-			Regex:   "MySQL.*/8",
+			Regex:   "MySQL.*/mysql8",
 			Env:     mysqlEnv,
 			Ports:   []string{"3308:3306"},
 			Options: mysqlOptions,
@@ -73,7 +73,7 @@ var (
 		{
 			Version: "maria107",
 			Image:   "mariadb:10.7",
-			Regex:   "MySQL.*/Maria107",
+			Regex:   "MySQL.*/maria107",
 			Env:     mysqlEnv,
 			Ports:   []string{"4306:3306"},
 			Options: mysqlOptions,
@@ -81,7 +81,7 @@ var (
 		{
 			Version: "maria102",
 			Image:   "mariadb:10.2.32",
-			Regex:   "MySQL.*/Maria102",
+			Regex:   "MySQL.*/maria102",
 			Env:     mysqlEnv,
 			Ports:   []string{"4307:3306"},
 			Options: mysqlOptions,
@@ -89,7 +89,7 @@ var (
 		{
 			Version: "maria103",
 			Image:   "mariadb:10.3.13",
-			Regex:   "MySQL.*/Maria103",
+			Regex:   "MySQL.*/maria103",
 			Env:     mysqlEnv,
 			Ports:   []string{"4308:3306"},
 			Options: mysqlOptions,
@@ -97,7 +97,7 @@ var (
 		{
 			Version: "postgres10",
 			Image:   "postgres:10",
-			Regex:   "Postgres.*/10",
+			Regex:   "Postgres.*/postgres10",
 			Env:     pgEnv,
 			Ports:   []string{"5430:5432"},
 			Options: pgOptions,
@@ -105,7 +105,7 @@ var (
 		{
 			Version: "postgres11",
 			Image:   "postgres:11",
-			Regex:   "Postgres.*/11",
+			Regex:   "Postgres.*/postgres11",
 			Env:     pgEnv,
 			Ports:   []string{"5431:5432"},
 			Options: pgOptions,
@@ -113,7 +113,7 @@ var (
 		{
 			Version: "postgres12",
 			Image:   "postgres:12.3",
-			Regex:   "Postgres.*/12",
+			Regex:   "Postgres.*/postgres12",
 			Env:     pgEnv,
 			Ports:   []string{"5432:5432"},
 			Options: pgOptions,
@@ -121,7 +121,7 @@ var (
 		{
 			Version: "postgres13",
 			Image:   "postgres:13.1",
-			Regex:   "Postgres.*/13",
+			Regex:   "Postgres.*/postgres13",
 			Env:     pgEnv,
 			Ports:   []string{"5433:5432"},
 			Options: pgOptions,
@@ -129,7 +129,7 @@ var (
 		{
 			Version: "postgres14",
 			Image:   "postgres:14",
-			Regex:   "Postgres.*/14",
+			Regex:   "Postgres.*/postgres14",
 			Env:     pgEnv,
 			Ports:   []string{"5434:5432"},
 			Options: pgOptions,
@@ -137,7 +137,7 @@ var (
 		{
 			Version: "tidb5",
 			Image:   "pingcap/tidb:v5.4.0",
-			Regex:   "TiDB.*/5",
+			Regex:   "TiDB.*/tidb5",
 			Ports:   []string{"4309:4000"},
 		},
 		{

--- a/internal/ci/main.go
+++ b/internal/ci/main.go
@@ -12,7 +12,7 @@ import (
 
 // Job defines an integration job to run.
 type Job struct {
-	Version string   // version to test (used as GO_TEST_ONLY_VERSION env)
+	Version string   // version to test (passed to go test as flag which database dialect/version)
 	Image   string   // name of service
 	Regex   string   // run regex
 	Env     []string // env of service

--- a/internal/ci/main.go
+++ b/internal/ci/main.go
@@ -12,7 +12,7 @@ import (
 
 // Job defines an integration job to run.
 type Job struct {
-	Name    string   // name of job
+	Version string   // version to test (used as GO_TEST_ONLY_VERSION env)
 	Image   string   // name of service
 	Regex   string   // run regex
 	Env     []string // env of service
@@ -47,7 +47,7 @@ var (
 	}
 	jobs = []Job{
 		{
-			Name:    "mysql56",
+			Version: "mysql56",
 			Image:   "mysql:5.6.35",
 			Regex:   "MySQL.*/56",
 			Env:     mysqlEnv,
@@ -55,7 +55,7 @@ var (
 			Options: mysqlOptions,
 		},
 		{
-			Name:    "mysql57",
+			Version: "mysql57",
 			Image:   "mysql:5.7.26",
 			Regex:   "MySQL.*/57",
 			Env:     mysqlEnv,
@@ -63,7 +63,7 @@ var (
 			Options: mysqlOptions,
 		},
 		{
-			Name:    "mysql8",
+			Version: "mysql8",
 			Image:   "mysql:8",
 			Regex:   "MySQL.*/8",
 			Env:     mysqlEnv,
@@ -71,7 +71,7 @@ var (
 			Options: mysqlOptions,
 		},
 		{
-			Name:    "maria107",
+			Version: "maria107",
 			Image:   "mariadb:10.7",
 			Regex:   "MySQL.*/Maria107",
 			Env:     mysqlEnv,
@@ -79,7 +79,7 @@ var (
 			Options: mysqlOptions,
 		},
 		{
-			Name:    "maria102",
+			Version: "maria102",
 			Image:   "mariadb:10.2.32",
 			Regex:   "MySQL.*/Maria102",
 			Env:     mysqlEnv,
@@ -87,7 +87,7 @@ var (
 			Options: mysqlOptions,
 		},
 		{
-			Name:    "maria103",
+			Version: "maria103",
 			Image:   "mariadb:10.3.13",
 			Regex:   "MySQL.*/Maria103",
 			Env:     mysqlEnv,
@@ -95,7 +95,7 @@ var (
 			Options: mysqlOptions,
 		},
 		{
-			Name:    "postgres10",
+			Version: "postgres10",
 			Image:   "postgres:10",
 			Regex:   "Postgres.*/10",
 			Env:     pgEnv,
@@ -103,7 +103,7 @@ var (
 			Options: pgOptions,
 		},
 		{
-			Name:    "postgres11",
+			Version: "postgres11",
 			Image:   "postgres:11",
 			Regex:   "Postgres.*/11",
 			Env:     pgEnv,
@@ -111,7 +111,7 @@ var (
 			Options: pgOptions,
 		},
 		{
-			Name:    "postgres12",
+			Version: "postgres12",
 			Image:   "postgres:12.3",
 			Regex:   "Postgres.*/12",
 			Env:     pgEnv,
@@ -119,7 +119,7 @@ var (
 			Options: pgOptions,
 		},
 		{
-			Name:    "postgres13",
+			Version: "postgres13",
 			Image:   "postgres:13.1",
 			Regex:   "Postgres.*/13",
 			Env:     pgEnv,
@@ -127,7 +127,7 @@ var (
 			Options: pgOptions,
 		},
 		{
-			Name:    "postgres14",
+			Version: "postgres14",
 			Image:   "postgres:14",
 			Regex:   "Postgres.*/14",
 			Env:     pgEnv,
@@ -135,14 +135,14 @@ var (
 			Options: pgOptions,
 		},
 		{
-			Name:  "tidb5",
-			Image: "pingcap/tidb:v5.4.0",
-			Regex: "TiDB.*/5",
-			Ports: []string{"4309:4000"},
+			Version: "tidb5",
+			Image:   "pingcap/tidb:v5.4.0",
+			Regex:   "TiDB.*/5",
+			Ports:   []string{"4309:4000"},
 		},
 		{
-			Name:  "sqlite",
-			Regex: "SQLite.*",
+			Version: "sqlite",
+			Regex:   "SQLite.*",
 		},
 	}
 )

--- a/internal/ci/main.go
+++ b/internal/ci/main.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	_ "embed"
+	"log"
+	"os"
+	"text/template"
+)
+
+//go:generate go run main.go
+
+// Job defines an integration job to run.
+type Job struct {
+	Name    string   // name of job
+	Image   string   // name of service
+	Regex   string   // run regex
+	Env     []string // env of service
+	Ports   []string // port mappings
+	Options []string // other options
+}
+
+var (
+	//go:embed ci.tmpl
+	t string
+
+	mysqlOptions = []string{
+		`--health-cmd "mysqladmin ping -ppass"`,
+		`--health-interval 10s`,
+		`--health-start-period 10s`,
+		`--health-timeout 5s`,
+		`--health-retries 10`,
+	}
+	mysqlEnv = []string{
+		"MYSQL_DATABASE: test",
+		"MYSQL_ROOT_PASSWORD: pass",
+	}
+	pgOptions = []string{
+		"--health-cmd pg_isready",
+		"--health-interval 10s",
+		"--health-timeout 5s",
+		"--health-retries 5",
+	}
+	pgEnv = []string{
+		"POSTGRES_DB: test",
+		"POSTGRES_PASSWORD: pass",
+	}
+	jobs = []Job{
+		{
+			Name:    "mysql56",
+			Image:   "mysql:5.6.35",
+			Regex:   "MySQL.*/56",
+			Env:     mysqlEnv,
+			Ports:   []string{"3306:3306"},
+			Options: mysqlOptions,
+		},
+		{
+			Name:    "mysql57",
+			Image:   "mysql:5.7.26",
+			Regex:   "MySQL.*/57",
+			Env:     mysqlEnv,
+			Ports:   []string{"3307:3306"},
+			Options: mysqlOptions,
+		},
+		{
+			Name:    "mysql8",
+			Image:   "mysql:8",
+			Regex:   "MySQL.*/8",
+			Env:     mysqlEnv,
+			Ports:   []string{"3308:3306"},
+			Options: mysqlOptions,
+		},
+		{
+			Name:    "maria107",
+			Image:   "mariadb:10.7",
+			Regex:   "MySQL.*/Maria107",
+			Env:     mysqlEnv,
+			Ports:   []string{"4306:3306"},
+			Options: mysqlOptions,
+		},
+		{
+			Name:    "maria102",
+			Image:   "mariadb:10.2.32",
+			Regex:   "MySQL.*/Maria102",
+			Env:     mysqlEnv,
+			Ports:   []string{"4307:3306"},
+			Options: mysqlOptions,
+		},
+		{
+			Name:    "maria103",
+			Image:   "mariadb:10.3.13",
+			Regex:   "MySQL.*/Maria103",
+			Env:     mysqlEnv,
+			Ports:   []string{"4308:3306"},
+			Options: mysqlOptions,
+		},
+		{
+			Name:    "postgres10",
+			Image:   "postgres:10",
+			Regex:   "Postgres.*/10",
+			Env:     pgEnv,
+			Ports:   []string{"5430:5432"},
+			Options: pgOptions,
+		},
+		{
+			Name:    "postgres11",
+			Image:   "postgres:11",
+			Regex:   "Postgres.*/11",
+			Env:     pgEnv,
+			Ports:   []string{"5431:5432"},
+			Options: pgOptions,
+		},
+		{
+			Name:    "postgres12",
+			Image:   "postgres:12.3",
+			Regex:   "Postgres.*/12",
+			Env:     pgEnv,
+			Ports:   []string{"5432:5432"},
+			Options: pgOptions,
+		},
+		{
+			Name:    "postgres13",
+			Image:   "postgres:13.1",
+			Regex:   "Postgres.*/13",
+			Env:     pgEnv,
+			Ports:   []string{"5433:5432"},
+			Options: pgOptions,
+		},
+		{
+			Name:    "postgres14",
+			Image:   "postgres:14",
+			Regex:   "Postgres.*/14",
+			Env:     pgEnv,
+			Ports:   []string{"5434:5432"},
+			Options: pgOptions,
+		},
+		{
+			Name:  "tidb5",
+			Image: "pingcap/tidb:v5.4.0",
+			Regex: "TiDB.*/5",
+			Ports: []string{"4309:4000"},
+		},
+		{
+			Name:  "sqlite",
+			Regex: "SQLite.*",
+		},
+	}
+)
+
+func main() {
+	var buf bytes.Buffer
+	if err := template.Must(template.New("").Parse(t)).Execute(&buf, jobs); err != nil {
+		log.Fatalln(err)
+	}
+	if err := os.WriteFile("../../.github/workflows/ci.yml", buf.Bytes(), 0600); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/internal/integration/docker-compose.yaml
+++ b/internal/integration/docker-compose.yaml
@@ -122,7 +122,7 @@ services:
     ports:
       - 4308:3306
 
-# Default DB test, No Password
+  # Default DB test, No Password
   tidb5:
     platform: linux/amd64
     image: pingcap/tidb:v5.4.0

--- a/internal/integration/go.sum
+++ b/internal/integration/go.sum
@@ -82,6 +82,7 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
@@ -277,6 +278,7 @@ github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
 github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
+github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -297,6 +299,7 @@ github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
@@ -352,9 +355,11 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cobra v1.3.0 h1:R7cSvGu+Vv+qX0gW5R/85dx2kmmJT5z5NM8ifdYjdn0=
 github.com/spf13/cobra v1.3.0/go.mod h1:BrRVncBjOJa/eUcVVm9CE+oC6as8k+VYr4NY7WCi9V4=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.10.0/go.mod h1:SoyBPwAtKDzypXNDFKN5kzH7ppppbGZtls1UpIy5AsM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -24,13 +24,13 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	var service string
-	flag.StringVar(&service, "service", "", "[mysql56, postgres10, tidb5, ...] what version to test")
+	var dialect string
+	flag.StringVar(&dialect, "dialect", "", "[mysql56, postgres10, tidb5, ...] what dialect (version) to test")
 	flag.Parse()
 	var dbs []io.Closer
-	dbs = append(dbs, myInit(service)...)
-	dbs = append(dbs, pgInit(service)...)
-	dbs = append(dbs, tidbInit(service)...)
+	dbs = append(dbs, myInit(dialect)...)
+	dbs = append(dbs, pgInit(dialect)...)
+	dbs = append(dbs, tidbInit(dialect)...)
 	defer func() {
 		for _, db := range dbs {
 			db.Close()

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"flag"
 	"io"
 	"io/ioutil"
 	"os"
@@ -23,10 +24,13 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	var service string
+	flag.StringVar(&service, "service", "", "[mysql56, postgres10, tidb5, ...] what version to test")
+	flag.Parse()
 	var dbs []io.Closer
-	dbs = append(dbs, myInit()...)
-	dbs = append(dbs, pgInit()...)
-	dbs = append(dbs, tidbInit()...)
+	dbs = append(dbs, myInit(service)...)
+	dbs = append(dbs, pgInit(service)...)
+	dbs = append(dbs, tidbInit(service)...)
 	defer func() {
 		for _, db := range dbs {
 			db.Close()

--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -29,19 +29,19 @@ type myTest struct {
 	port    int
 }
 
-var (
-	myTests struct {
-		drivers map[string]*myTest
-	}
-	myPorts = map[string]int{
-		"mysql56":  3306,
+var myTests = struct {
+	drivers map[string]*myTest
+	ports   map[string]int
+}{
+	drivers: make(map[string]*myTest),
+	ports: map[string]int{"mysql56": 3306,
 		"mysql57":  3307,
 		"mysql8":   3308,
 		"maria107": 4306,
 		"maria102": 4307,
 		"maria103": 4308,
-	}
-)
+	},
+}
 
 func myRun(t *testing.T, fn func(*myTest)) {
 	for version, tt := range myTests.drivers {
@@ -52,18 +52,17 @@ func myRun(t *testing.T, fn func(*myTest)) {
 	}
 }
 
-func myInit(service string) []io.Closer {
+func myInit(dialect string) []io.Closer {
 	var cs []io.Closer
-	myTests.drivers = make(map[string]*myTest)
-	if service != "" {
-		p, ok := myPorts[service]
+	if dialect != "" {
+		p, ok := myTests.ports[dialect]
 		if ok {
-			myPorts = map[string]int{service: p}
+			myTests.ports = map[string]int{dialect: p}
 		} else {
-			myPorts = make(map[string]int)
+			myTests.ports = make(map[string]int)
 		}
 	}
-	for version, port := range myPorts {
+	for version, port := range myTests.ports {
 		db, err := sql.Open("mysql", fmt.Sprintf("root:pass@tcp(localhost:%d)/test?parseTime=True", port))
 		if err != nil {
 			log.Fatalln(err)

--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -756,31 +756,31 @@ create table atlas_types_sanity
 					{
 						Name: "tInt",
 						Type: &schema.ColumnType{Type: &schema.IntegerType{T: "int", Unsigned: false},
-							Raw: t.valueByVersion(map[string]string{"8": "int"}, "int(10)"), Null: false},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "int"}, "int(10)"), Null: false},
 						Default: &schema.Literal{V: "4"},
 					},
 					{
 						Name: "tTinyInt",
 						Type: &schema.ColumnType{Type: &schema.IntegerType{T: "tinyint", Unsigned: false},
-							Raw: t.valueByVersion(map[string]string{"8": "tinyint"}, "tinyint(10)"), Null: true},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "tinyint"}, "tinyint(10)"), Null: true},
 						Default: &schema.Literal{V: "8"},
 					},
 					{
 						Name: "tSmallInt",
 						Type: &schema.ColumnType{Type: &schema.IntegerType{T: "smallint", Unsigned: false},
-							Raw: t.valueByVersion(map[string]string{"8": "smallint"}, "smallint(10)"), Null: true},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "smallint"}, "smallint(10)"), Null: true},
 						Default: &schema.Literal{V: "2"},
 					},
 					{
 						Name: "tMediumInt",
 						Type: &schema.ColumnType{Type: &schema.IntegerType{T: "mediumint", Unsigned: false},
-							Raw: t.valueByVersion(map[string]string{"8": "mediumint"}, "mediumint(10)"), Null: true},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "mediumint"}, "mediumint(10)"), Null: true},
 						Default: &schema.Literal{V: "11"},
 					},
 					{
 						Name: "tBigInt",
 						Type: &schema.ColumnType{Type: &schema.IntegerType{T: "bigint", Unsigned: false},
-							Raw: t.valueByVersion(map[string]string{"8": "bigint"}, "bigint(10)"), Null: true},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "bigint"}, "bigint(10)"), Null: true},
 						Default: &schema.Literal{V: "4"},
 					},
 					{
@@ -902,8 +902,8 @@ create table atlas_types_sanity
 					},
 					{
 						Name: "tYear",
-						Type: &schema.ColumnType{Type: &schema.TimeType{T: "year", Precision: t.intByVersion(map[string]int{"8": 0}, 4)},
-							Raw: t.valueByVersion(map[string]string{"8": "year"}, "year(4)"), Null: true},
+						Type: &schema.ColumnType{Type: &schema.TimeType{T: "year", Precision: t.intByVersion(map[string]int{"mysql8": 0}, 4)},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "year"}, "year(4)"), Null: true},
 					},
 					{
 						Name: "tVarchar",
@@ -929,13 +929,13 @@ create table atlas_types_sanity
 						Name: "tVarBinary",
 						Type: &schema.ColumnType{Type: &schema.BinaryType{T: "varbinary", Size: 30},
 							Raw: "varbinary(30)", Null: true},
-						Default: &schema.Literal{V: t.valueByVersion(map[string]string{"8": "0x546974616E"}, t.quoted("Titan"))},
+						Default: &schema.Literal{V: t.valueByVersion(map[string]string{"mysql8": "0x546974616E"}, t.quoted("Titan"))},
 					},
 					{
 						Name: "tBinary",
 						Type: &schema.ColumnType{Type: &schema.BinaryType{T: "binary", Size: 5},
 							Raw: "binary(5)", Null: true},
-						Default: &schema.Literal{V: t.valueByVersion(map[string]string{"8": "0x546974616E"}, t.quoted("Titan"))},
+						Default: &schema.Literal{V: t.valueByVersion(map[string]string{"mysql8": "0x546974616E"}, t.quoted("Titan"))},
 					},
 					{
 						Name: "tBlob",
@@ -1049,8 +1049,8 @@ create table atlas_types_sanity
 					{
 						Name: "tGeometryCollection",
 						Type: &schema.ColumnType{Type: &schema.SpatialType{T: t.valueByVersion(
-							map[string]string{"8": "geomcollection"}, "geometrycollection")},
-							Raw: t.valueByVersion(map[string]string{"8": "geomcollection"},
+							map[string]string{"mysql8": "geomcollection"}, "geometrycollection")},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "geomcollection"},
 								"geometrycollection"), Null: true},
 					},
 				},
@@ -1068,7 +1068,7 @@ create table atlas_types_sanity
 ) CHARSET = latin1 COLLATE latin1_swedish_ci;
 `
 		myRun(t, func(t *myTest) {
-			if t.version == "56" {
+			if t.version == "mysql56" {
 				return
 			}
 			t.dropTables(n)
@@ -1081,7 +1081,7 @@ create table atlas_types_sanity
 			expected := schema.Table{
 				Name: n,
 				Attrs: func() []schema.Attr {
-					if t.version == "Maria107" {
+					if t.version == "maria107" {
 						return []schema.Attr{
 							&schema.Charset{V: "latin1"},
 							&schema.Collation{V: "latin1_swedish_ci"},
@@ -1098,9 +1098,9 @@ create table atlas_types_sanity
 					func() *schema.Column {
 						c := &schema.Column{Name: "tJSON", Type: &schema.ColumnType{Type: &schema.JSONType{T: "json"}, Raw: "json", Null: true}}
 						switch t.version {
-						case "Maria107":
+						case "maria107":
 							c.Attrs = []schema.Attr{}
-						case "Maria102", "Maria103":
+						case "maria102", "maria103":
 							c.Type.Raw = "longtext"
 							c.Type.Type = &schema.StringType{T: "longtext"}
 							c.Attrs = []schema.Attr{
@@ -1310,8 +1310,8 @@ func (t *myTest) loadTable(name string) *schema.Table {
 	return table
 }
 
-func (t *myTest) mariadb() bool { return strings.HasPrefix(t.version, "Maria") }
-func (t *myTest) tidb() bool    { return strings.HasPrefix(t.version, "TiDB") }
+func (t *myTest) mariadb() bool { return strings.HasPrefix(t.version, "maria") }
+func (t *myTest) tidb() bool    { return strings.HasPrefix(t.version, "tidb") }
 
 // defaultConfig returns the default charset and
 // collation configuration based on the MySQL version.
@@ -1321,13 +1321,13 @@ func (t *myTest) defaultAttrs() []schema.Attr {
 		collation = "latin1_swedish_ci"
 	)
 	switch {
-	case strings.Contains(t.version, "TiDB"):
+	case strings.Contains(t.version, "tidb"):
 		charset = "utf8mb4"
 		collation = "utf8mb4_bin"
-	case t.version == "8":
+	case t.version == "mysql8":
 		charset = "utf8mb4"
 		collation = "utf8mb4_0900_ai_ci"
-	case t.version == "Maria107":
+	case t.version == "maria107":
 		charset = "utf8mb4"
 		collation = "utf8mb4_general_ci"
 	}

--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"strings"
 	"testing"
 
@@ -53,14 +52,13 @@ func myRun(t *testing.T, fn func(*myTest)) {
 	}
 }
 
-func myInit() []io.Closer {
+func myInit(service string) []io.Closer {
 	var cs []io.Closer
 	myTests.drivers = make(map[string]*myTest)
-	// If the env var GO_TEST_ONLY_VERSION set only run test for that service.
-	if v, ok := os.LookupEnv("GO_TEST_ONLY_VERSION"); ok {
-		p, ok := myPorts[v]
+	if service != "" {
+		p, ok := myPorts[service]
 		if ok {
-			myPorts = map[string]int{v: p}
+			myPorts = map[string]int{service: p}
 		} else {
 			myPorts = make(map[string]int)
 		}

--- a/internal/integration/postgres_test.go
+++ b/internal/integration/postgres_test.go
@@ -30,18 +30,19 @@ type pgTest struct {
 	port    int
 }
 
-var (
-	pgTests struct {
-		drivers map[string]*pgTest
-	}
-	pgPorts = map[string]int{
+var pgTests = struct {
+	drivers map[string]*pgTest
+	ports   map[string]int
+}{
+	drivers: make(map[string]*pgTest),
+	ports: map[string]int{
 		"postgres10": 5430,
 		"postgres11": 5431,
 		"postgres12": 5432,
 		"postgres13": 5433,
 		"postgres14": 5434,
-	}
-)
+	},
+}
 
 func pgRun(t *testing.T, fn func(*pgTest)) {
 	for version, tt := range pgTests.drivers {
@@ -52,18 +53,17 @@ func pgRun(t *testing.T, fn func(*pgTest)) {
 	}
 }
 
-func pgInit(service string) []io.Closer {
+func pgInit(dialect string) []io.Closer {
 	var cs []io.Closer
-	pgTests.drivers = make(map[string]*pgTest)
-	if service != "" {
-		p, ok := pgPorts[service]
+	if dialect != "" {
+		p, ok := pgTests.ports[dialect]
 		if ok {
-			pgPorts = map[string]int{service: p}
+			pgTests.ports = map[string]int{dialect: p}
 		} else {
-			pgPorts = make(map[string]int)
+			pgTests.ports = make(map[string]int)
 		}
 	}
-	for version, port := range pgPorts {
+	for version, port := range pgTests.ports {
 		db, err := sql.Open("postgres", fmt.Sprintf("host=localhost port=%d user=postgres dbname=test password=pass sslmode=disable", port))
 		if err != nil {
 			log.Fatalln(err)

--- a/internal/integration/postgres_test.go
+++ b/internal/integration/postgres_test.go
@@ -667,12 +667,12 @@ create table atlas_types_sanity
 				{
 					Name:    "tBit",
 					Type:    &schema.ColumnType{Type: &postgres.BitType{T: "bit", Len: 10}, Raw: "bit", Null: true},
-					Default: &schema.RawExpr{X: t.valueByVersion(map[string]string{"10": "B'100'::\"bit\""}, "'100'::\"bit\"")},
+					Default: &schema.RawExpr{X: t.valueByVersion(map[string]string{"postgres10": "B'100'::\"bit\""}, "'100'::\"bit\"")},
 				},
 				{
 					Name:    "tBitVar",
 					Type:    &schema.ColumnType{Type: &postgres.BitType{T: "bit varying", Len: 10}, Raw: "bit varying", Null: true},
-					Default: &schema.RawExpr{X: t.valueByVersion(map[string]string{"10": "B'100'::\"bit\""}, "'100'::\"bit\"")},
+					Default: &schema.RawExpr{X: t.valueByVersion(map[string]string{"postgres10": "B'100'::\"bit\""}, "'100'::\"bit\"")},
 				},
 				{
 					Name:    "tBoolean",

--- a/internal/integration/postgres_test.go
+++ b/internal/integration/postgres_test.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log"
 	"strings"
-	"sync"
 	"testing"
 
 	"ariga.io/atlas/sql/mysql"
@@ -32,7 +31,6 @@ type pgTest struct {
 }
 
 var pgTests struct {
-	sync.Once
 	drivers map[string]*pgTest
 }
 

--- a/internal/integration/postgres_test.go
+++ b/internal/integration/postgres_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"strings"
 	"testing"
 
@@ -53,14 +52,13 @@ func pgRun(t *testing.T, fn func(*pgTest)) {
 	}
 }
 
-func pgInit() []io.Closer {
+func pgInit(service string) []io.Closer {
 	var cs []io.Closer
 	pgTests.drivers = make(map[string]*pgTest)
-	// If the env var GO_TEST_ONLY_VERSION set only run test for that service.
-	if v, ok := os.LookupEnv("GO_TEST_ONLY_VERSION"); ok {
-		p, ok := pgPorts[v]
+	if service != "" {
+		p, ok := pgPorts[service]
 		if ok {
-			pgPorts = map[string]int{v: p}
+			pgPorts = map[string]int{service: p}
 		} else {
 			pgPorts = make(map[string]int)
 		}

--- a/internal/integration/sqlite_test.go
+++ b/internal/integration/sqlite_test.go
@@ -30,6 +30,7 @@ type liteTest struct {
 }
 
 func liteRun(t *testing.T, fn func(test *liteTest)) {
+	t.Parallel()
 	f := path.Join(t.TempDir(), strings.ReplaceAll(t.Name(), "/", "_"))
 	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?cache=shared&_fk=1", f))
 	require.NoError(t, err)
@@ -455,6 +456,11 @@ func TestSQLite_CLI(t *testing.T) {
 	t.Run("SchemaDiffRun", func(t *testing.T) {
 		liteRun(t, func(t *liteTest) {
 			testCLISchemaDiff(t, t.dsn())
+		})
+	})
+	t.Run("SchemaApplyAutoApprove", func(t *testing.T) {
+		liteRun(t, func(t *liteTest) {
+			testCLISchemaApplyAutoApprove(t, h, t.dsn())
 		})
 	})
 }

--- a/internal/integration/testdata/mysql/autoincrement.txt
+++ b/internal/integration/testdata/mysql/autoincrement.txt
@@ -30,7 +30,7 @@ CREATE TABLE `users` (
   PRIMARY KEY (`id`)
 )
 
--- 8/1.sql --
+-- mysql8/1.sql --
 CREATE TABLE `users` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
@@ -58,7 +58,7 @@ CREATE TABLE `users` (
   PRIMARY KEY (`id`)
 ) AUTO_INCREMENT=1000
 
--- 8/2.sql --
+-- mysql8/2.sql --
 CREATE TABLE `users` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
@@ -86,7 +86,7 @@ CREATE TABLE `users` (
   PRIMARY KEY (`id`)
 ) AUTO_INCREMENT=2000
 
--- 8/3.sql --
+-- mysql8/3.sql --
 CREATE TABLE `users` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)

--- a/internal/integration/testdata/mysql/column-add-drop.txt
+++ b/internal/integration/testdata/mysql/column-add-drop.txt
@@ -50,7 +50,7 @@ CREATE TABLE `users` (
   PRIMARY KEY (`id`)
 )
 
--- 8/1.sql --
+-- mysql8/1.sql --
 CREATE TABLE `users` (
   `id` int NOT NULL,
   PRIMARY KEY (`id`)
@@ -82,7 +82,7 @@ CREATE TABLE `users` (
   PRIMARY KEY (`id`)
 )
 
--- 8/2.sql --
+-- mysql8/2.sql --
 CREATE TABLE `users` (
   `id` int NOT NULL,
   `name` text NOT NULL,

--- a/internal/integration/testdata/mysql/column-bool.txt
+++ b/internal/integration/testdata/mysql/column-bool.txt
@@ -82,7 +82,7 @@ CREATE TABLE `users` (
   `c` tinyint(1) NOT NULL
 )
 
--- 8/3.sql --
+-- mysql8/3.sql --
 CREATE TABLE `users` (
   `a` tinyint(1) NOT NULL,
   `b` tinyint NOT NULL,

--- a/internal/integration/testdata/mysql/column-time-precision-mysql.txt
+++ b/internal/integration/testdata/mysql/column-time-precision-mysql.txt
@@ -1,5 +1,5 @@
 # Each test runs on a clean database.
-only 56 57 8
+only mysql56 mysql57 mysql8
 
 # Apply schema "1.hcl" on fresh database.
 apply 1.hcl

--- a/internal/integration/testdata/mysql/foreign-key-add.txt
+++ b/internal/integration/testdata/mysql/foreign-key-add.txt
@@ -149,7 +149,7 @@ CREATE TABLE `posts` (
   CONSTRAINT `owner_id` FOREIGN KEY (`author_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
 )
 
--- 8/2.sql --
+-- mysql8/2.sql --
 CREATE TABLE `users` (
   `id` int NOT NULL,
   PRIMARY KEY (`id`)

--- a/internal/integration/testdata/mysql/foreign-key-modify-action.txt
+++ b/internal/integration/testdata/mysql/foreign-key-modify-action.txt
@@ -57,7 +57,7 @@ CREATE TABLE `posts` (
   CONSTRAINT `owner_id` FOREIGN KEY (`author_id`) REFERENCES `users` (`id`) ON UPDATE SET NULL
 )
 
--- 8/1.sql --
+-- mysql8/1.sql --
 CREATE TABLE `users` (
   `id` int NOT NULL,
   PRIMARY KEY (`id`)
@@ -119,7 +119,7 @@ CREATE TABLE `posts` (
   CONSTRAINT `owner_id` FOREIGN KEY (`author_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 )
 
--- 8/2.sql --
+-- mysql8/2.sql --
 CREATE TABLE `users` (
   `id` int NOT NULL,
   PRIMARY KEY (`id`)

--- a/internal/integration/testdata/mysql/index-add-drop.txt
+++ b/internal/integration/testdata/mysql/index-add-drop.txt
@@ -36,7 +36,7 @@ CREATE TABLE `users` (
   `rank` bigint(20) NOT NULL
 )
 
--- 8/1.sql --
+-- mysql8/1.sql --
 CREATE TABLE `users` (
   `rank` bigint NOT NULL
 )
@@ -64,7 +64,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `rank_idx` (`rank`)
 )
 
--- 8/2.sql --
+-- mysql8/2.sql --
 CREATE TABLE `users` (
   `rank` bigint NOT NULL,
   UNIQUE KEY `rank_idx` (`rank`)
@@ -93,7 +93,7 @@ CREATE TABLE `users` (
   KEY `rank_idx` (`rank`)
 )
 
--- 8/3.sql --
+-- mysql8/3.sql --
 CREATE TABLE `users` (
   `rank` bigint NOT NULL,
   KEY `rank_idx` (`rank`)

--- a/internal/integration/testdata/mysql/index-desc.txt
+++ b/internal/integration/testdata/mysql/index-desc.txt
@@ -1,7 +1,7 @@
 # Each test runs on a clean database.
 
 # Run this test only on MySQL 8 as it is not supported by other versions.
-only 8
+only mysql8
 
 # Apply schema "1.hcl" on fresh database.
 apply 1.hcl

--- a/internal/integration/testdata/mysql/index-expr.txt
+++ b/internal/integration/testdata/mysql/index-expr.txt
@@ -1,5 +1,5 @@
 # Run this test only on MySQL 8 as it is not supported by other versions.
-only 8
+only mysql8
 
 apply 1.hcl
 cmpshow users 1.sql

--- a/internal/integration/tidb_test.go
+++ b/internal/integration/tidb_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"testing"
 
 	"ariga.io/atlas/sql/mysql"
@@ -35,14 +34,13 @@ var (
 	}
 )
 
-func tidbInit() []io.Closer {
+func tidbInit(service string) []io.Closer {
 	var cs []io.Closer
 	tidbTests.drivers = make(map[string]*myTest)
-	// If the env var GO_TEST_ONLY_VERSION set only run test for that service.
-	if v, ok := os.LookupEnv("GO_TEST_ONLY_VERSION"); ok {
-		p, ok := tidbPorts[v]
+	if service != "" {
+		p, ok := tidbPorts[service]
 		if ok {
-			tidbPorts = map[string]int{v: p}
+			tidbPorts = map[string]int{service: p}
 		} else {
 			tidbPorts = make(map[string]int)
 		}

--- a/internal/integration/tidb_test.go
+++ b/internal/integration/tidb_test.go
@@ -40,7 +40,7 @@ func tidbInit() []io.Closer {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	tidbTests.drivers["TiDB5"] = &myTest{db: db, drv: drv, version: "TiDB5", port: port}
+	tidbTests.drivers["5"] = &myTest{db: db, drv: drv, version: "5", port: port}
 	return []io.Closer{db}
 }
 

--- a/internal/integration/tidb_test.go
+++ b/internal/integration/tidb_test.go
@@ -25,27 +25,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	tidbTests struct {
-		drivers map[string]*myTest
-	}
-	tidbPorts = map[string]int{
-		"tidb5": 4309,
-	}
-)
+var tidbTests = struct {
+	drivers map[string]*myTest
+	ports   map[string]int
+}{
+	drivers: make(map[string]*myTest),
+	ports:   map[string]int{"tidb5": 4309},
+}
 
-func tidbInit(service string) []io.Closer {
+func tidbInit(dialect string) []io.Closer {
 	var cs []io.Closer
-	tidbTests.drivers = make(map[string]*myTest)
-	if service != "" {
-		p, ok := tidbPorts[service]
+	if dialect != "" {
+		p, ok := tidbTests.ports[dialect]
 		if ok {
-			tidbPorts = map[string]int{service: p}
+			tidbTests.ports = map[string]int{dialect: p}
 		} else {
-			tidbPorts = make(map[string]int)
+			tidbTests.ports = make(map[string]int)
 		}
 	}
-	for version, port := range tidbPorts {
+	for version, port := range tidbTests.ports {
 		db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(localhost:%d)/test?parseTime=True", port))
 		if err != nil {
 			log.Fatalln(err)

--- a/internal/integration/tidb_test.go
+++ b/internal/integration/tidb_test.go
@@ -759,31 +759,31 @@ create table atlas_types_sanity
 					{
 						Name: "tInt",
 						Type: &schema.ColumnType{Type: &schema.IntegerType{T: "int", Unsigned: false},
-							Raw: t.valueByVersion(map[string]string{"8": "int"}, "int(10)"), Null: false},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "int"}, "int(10)"), Null: false},
 						Default: &schema.Literal{V: "4"},
 					},
 					{
 						Name: "tTinyInt",
 						Type: &schema.ColumnType{Type: &schema.IntegerType{T: "tinyint", Unsigned: false},
-							Raw: t.valueByVersion(map[string]string{"8": "tinyint"}, "tinyint(10)"), Null: true},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "tinyint"}, "tinyint(10)"), Null: true},
 						Default: &schema.Literal{V: "8"},
 					},
 					{
 						Name: "tSmallInt",
 						Type: &schema.ColumnType{Type: &schema.IntegerType{T: "smallint", Unsigned: false},
-							Raw: t.valueByVersion(map[string]string{"8": "smallint"}, "smallint(10)"), Null: true},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "smallint"}, "smallint(10)"), Null: true},
 						Default: &schema.Literal{V: "2"},
 					},
 					{
 						Name: "tMediumInt",
 						Type: &schema.ColumnType{Type: &schema.IntegerType{T: "mediumint", Unsigned: false},
-							Raw: t.valueByVersion(map[string]string{"8": "mediumint"}, "mediumint(10)"), Null: true},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "mediumint"}, "mediumint(10)"), Null: true},
 						Default: &schema.Literal{V: "11"},
 					},
 					{
 						Name: "tBigInt",
 						Type: &schema.ColumnType{Type: &schema.IntegerType{T: "bigint", Unsigned: false},
-							Raw: t.valueByVersion(map[string]string{"8": "bigint"}, "bigint(10)"), Null: true},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "bigint"}, "bigint(10)"), Null: true},
 						Default: &schema.Literal{V: "4"},
 					},
 					{
@@ -875,8 +875,8 @@ create table atlas_types_sanity
 					},
 					{
 						Name: "tYear",
-						Type: &schema.ColumnType{Type: &schema.TimeType{T: "year", Precision: t.intByVersion(map[string]int{"8": 0}, 4)},
-							Raw: t.valueByVersion(map[string]string{"8": "year"}, "year(4) unsigned"), Null: true},
+						Type: &schema.ColumnType{Type: &schema.TimeType{T: "year", Precision: t.intByVersion(map[string]int{"mysql8": 0}, 4)},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "year"}, "year(4) unsigned"), Null: true},
 					},
 					{
 						Name: "tVarchar",
@@ -902,13 +902,13 @@ create table atlas_types_sanity
 						Name: "tVarBinary",
 						Type: &schema.ColumnType{Type: &schema.BinaryType{T: "varbinary", Size: 30},
 							Raw: "varbinary(30)", Null: true},
-						Default: &schema.Literal{V: t.valueByVersion(map[string]string{"8": "0x546974616E"}, t.quoted("Titan"))},
+						Default: &schema.Literal{V: t.valueByVersion(map[string]string{"mysql8": "0x546974616E"}, t.quoted("Titan"))},
 					},
 					{
 						Name: "tBinary",
 						Type: &schema.ColumnType{Type: &schema.BinaryType{T: "binary", Size: 5},
 							Raw: "binary(5)", Null: true},
-						Default: &schema.Literal{V: t.valueByVersion(map[string]string{"8": "0x546974616E"}, t.quoted("Titan"))},
+						Default: &schema.Literal{V: t.valueByVersion(map[string]string{"mysql8": "0x546974616E"}, t.quoted("Titan"))},
 					},
 					{
 						Name: "tBlob",
@@ -1055,7 +1055,7 @@ create table atlas_types_sanity
 					&schema.Column{
 						Name: "tBigInt2",
 						Type: &schema.ColumnType{Type: &schema.IntegerType{T: "bigint", Unsigned: false},
-							Raw: t.valueByVersion(map[string]string{"8": "bigint"}, "bigint(10)"), Null: true},
+							Raw: t.valueByVersion(map[string]string{"mysql8": "bigint"}, "bigint(10)"), Null: true},
 						Default: &schema.Literal{V: "4"},
 					},
 				},


### PR DESCRIPTION
Integration tests are now run each in its own job.

I had to do some kind of "hacky" solution, so it working correctly in the CI by using an env var when running the test. This does not affect local running.