### PR TITLE
cmd/action: add user explanation when checksum mismatch occur

### DIFF
--- a/cmd/action/migrate.go
+++ b/cmd/action/migrate.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 	"text/template"
 	"time"
@@ -49,7 +50,17 @@ var (
 				if err != nil {
 					return err
 				}
-				return migrate.Validate(dir) // TODO(masseelch): tell the user what's wrong
+				if err := migrate.Validate(dir); err != nil {
+					fmt.Fprintf(
+						os.Stderr,
+						"Error: %s\n\nYou have a checksum error in your migration directory.\n"+
+							"This usually happens if you manually create or edit a migration file.\n"+
+							"Please check your migration files and run\n\n"+
+							"'atlas migrate hash --force'\n\nto re-hash the contents and resolve the error.\n\n",
+						err,
+					)
+					os.Exit(1)
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
More clear message if there is an checksum mismatch on the CLI.

![image](https://user-images.githubusercontent.com/12862103/158980710-52b34781-cd86-44db-9dc4-8e44b8230bd1.png)
