### PR TITLE
cmd/action: add atlas migrate hash command to solve checksum mismatches

### DIFF
--- a/cmd/action/migrate.go
+++ b/cmd/action/migrate.go
@@ -81,11 +81,10 @@ the migration directory state to the desired schema. The desired state can be an
 	MigrateHashCmd = &cobra.Command{
 		Use:   "hash",
 		Short: "Hash creates an integrity hash file for the migration directories.",
-		Long: `'atlas migrate hash' computes the integrity hash sum of the migration directory andstores it in the atlas.sum file.
+		Long: `'atlas migrate hash' computes the integrity hash sum of the migration directory and stores it in the atlas.sum file.
 This command should be used whenever a manual change in the migration directory was made.`,
-		Example: `  atlas migrate validate
-  atlas migrate validate --dir /path/to/migration/directory`,
-		RunE: CmdMigrateHashRun,
+		Example: `  atlas migrate hash --force`,
+		RunE:    CmdMigrateHashRun,
 	}
 	// MigrateValidateCmd represents the migrate validate command.
 	MigrateValidateCmd = &cobra.Command{
@@ -162,7 +161,7 @@ func CmdMigrateDiffRun(cmd *cobra.Command, args []string) error {
 	// TODO(masseelch): clean up dev after reading the state from migration dir.
 }
 
-// CmdMigrateHashRun is the command executed when running the CLI with 'migrate diff' args.
+// CmdMigrateHashRun is the command executed when running the CLI with 'migrate hash' args.
 func CmdMigrateHashRun(*cobra.Command, []string) error {
 	// Open the migration directory.
 	dir, err := dir()

--- a/cmd/action/migrate.go
+++ b/cmd/action/migrate.go
@@ -77,6 +77,16 @@ the migration directory state to the desired schema. The desired state can be an
 		Args: cobra.MaximumNArgs(1),
 		RunE: CmdMigrateDiffRun,
 	}
+	// MigrateHashCmd represents the migrate hash command.
+	MigrateHashCmd = &cobra.Command{
+		Use:   "hash",
+		Short: "Hash creates an integrity hash file for the migration directories.",
+		Long: `'atlas migrate hash' computes the integrity hash sum of the migration directory andstores it in the atlas.sum file.
+This command should be used whenever a manual change in the migration directory was made.`,
+		Example: `  atlas migrate validate
+  atlas migrate validate --dir /path/to/migration/directory`,
+		RunE: CmdMigrateHashRun,
+	}
 	// MigrateValidateCmd represents the migrate validate command.
 	MigrateValidateCmd = &cobra.Command{
 		Use:   "validate",
@@ -94,6 +104,7 @@ func init() {
 	RootCmd.AddCommand(MigrateCmd)
 	MigrateCmd.AddCommand(MigrateDiffCmd)
 	MigrateCmd.AddCommand(MigrateValidateCmd)
+	MigrateCmd.AddCommand(MigrateHashCmd)
 	// Global flags.
 	MigrateCmd.PersistentFlags().StringVarP(&MigrateFlags.DirURL, migrateFlagDir, "", "file://migrations", "select migration directory using DSN format")
 	MigrateCmd.PersistentFlags().StringSliceVarP(&MigrateFlags.Schemas, migrateFlagSchema, "", nil, "set schema names")
@@ -118,7 +129,7 @@ func CmdMigrateDiffRun(cmd *cobra.Command, args []string) error {
 	if err := checkClean(cmd.Context(), dev); err != nil {
 		return err
 	}
-	// Open the migration directory. For now only local directories are supported.
+	// Open the migration directory.
 	dir, err := dir()
 	if err != nil {
 		return err
@@ -149,6 +160,20 @@ func CmdMigrateDiffRun(cmd *cobra.Command, args []string) error {
 	// Write the plan to a new file.
 	return pl.WritePlan(plan)
 	// TODO(masseelch): clean up dev after reading the state from migration dir.
+}
+
+// CmdMigrateHashRun is the command executed when running the CLI with 'migrate diff' args.
+func CmdMigrateHashRun(*cobra.Command, []string) error {
+	// Open the migration directory.
+	dir, err := dir()
+	if err != nil {
+		return err
+	}
+	sum, err := migrate.HashSum(dir)
+	if err != nil {
+		return err
+	}
+	return migrate.WriteSumFile(dir, sum)
 }
 
 // dir returns a migrate.Dir to use as migration directory. For now only local directories are supported.

--- a/doc/md/cli/reference.md
+++ b/doc/md/cli/reference.md
@@ -105,14 +105,13 @@ atlas migrate hash
 ```
 
 #### Details
-'atlas migrate hash' computes the integrity hash sum of the migration directory andstores it in the atlas.sum file.
+'atlas migrate hash' computes the integrity hash sum of the migration directory and stores it in the atlas.sum file.
 This command should be used whenever a manual change in the migration directory was made.
 
 #### Example
 
 ```
-  atlas migrate validate
-  atlas migrate validate --dir /path/to/migration/directory
+  atlas migrate hash --force
 ```
 
 ### atlas migrate validate

--- a/doc/md/cli/reference.md
+++ b/doc/md/cli/reference.md
@@ -95,6 +95,26 @@ the migration directory state to the desired schema. The desired state can be an
 ```
 
 
+### atlas migrate hash
+
+Hash creates an integrity hash file for the migration directories.
+
+#### Usage
+```
+atlas migrate hash
+```
+
+#### Details
+'atlas migrate hash' computes the integrity hash sum of the migration directory andstores it in the atlas.sum file.
+This command should be used whenever a manual change in the migration directory was made.
+
+#### Example
+
+```
+  atlas migrate validate
+  atlas migrate validate --dir /path/to/migration/directory
+```
+
 ### atlas migrate validate
 
 Validates the migration directories checksum.

--- a/sql/migrate/migrate.go
+++ b/sql/migrate/migrate.go
@@ -286,11 +286,7 @@ func (p *Planner) WritePlan(plan *Plan) error {
 		if err != nil {
 			return err
 		}
-		b, err := sum.MarshalText()
-		if err != nil {
-			return err
-		}
-		return p.dir.WriteFile(hashFile, b)
+		return WriteSumFile(p.dir, sum)
 	}
 	return nil
 }
@@ -490,6 +486,15 @@ func Validate(dir Dir) error {
 		return ErrChecksumMismatch
 	}
 	return nil
+}
+
+// WriteSumFile writes the given HashFile to the Dir. If the file does not exist, it is created.
+func WriteSumFile(dir Dir, sum HashFile) error {
+	b, err := sum.MarshalText()
+	if err != nil {
+		return err
+	}
+	return dir.WriteFile(hashFile, b)
 }
 
 // Sum returns the checksum of the represented hash file.

--- a/sql/migrate/migrate_test.go
+++ b/sql/migrate/migrate_test.go
@@ -87,7 +87,7 @@ func TestPlanner_Plan(t *testing.T) {
 	require.Equal(t, drv.plan, plan)
 }
 
-func TestHash(t *testing.T) {
+func TestHashSum(t *testing.T) {
 	p := t.TempDir()
 	d, err := migrate.NewLocalDir(p)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR adds the `atlas migrate hash` command that can be used to re-hash the migration directory. This is needed for when the user did any manual change to the migration directory to create a correct `atlas.sum` file.