### PR TITLE
cmd/action: add --verbose flag to apply command and document docker driver

### DIFF
--- a/cmd/action/docker.go
+++ b/cmd/action/docker.go
@@ -166,13 +166,13 @@ func (c *DockerConfig) Run(ctx context.Context) (*Container, error) {
 	// Get a free host TCP port the container can bind its exposed service port on.
 	p, err := freePort()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting open port: %w", err)
 	}
 	// Make sure the image is up-to-date.
 	cmd := exec.CommandContext(ctx, "docker", "pull", c.Image) //nolint:gosec
 	cmd.Stdout = c.Out
 	if err := cmd.Run(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("pulling image: %w", err)
 	}
 	// Run the container.
 	args := []string{"docker", "run", "--rm", "--detach"}

--- a/cmd/action/mux_test.go
+++ b/cmd/action/mux_test.go
@@ -174,7 +174,7 @@ func TestMux_OpenAtlas(t *testing.T) {
 			require.NoError(t, mysqld.SetLogger(log.New(ioutil.Discard, "", 1)))
 			_, err := action.DefaultMux.OpenAtlas(context.Background(), fmt.Sprintf(u, l.Addr()))
 			require.Error(t, err, "mock server rejects all incoming connections")
-			require.NotZero(t, *calls)
+			require.NotZero(t, atomic.LoadInt64(calls))
 		}
 	})
 }

--- a/doc/md/cli/dev.md
+++ b/doc/md/cli/dev.md
@@ -7,8 +7,9 @@ slug: /cli/dev-database
 
 Various Atlas commands accept the `--dev-url` flag. This option uses the [URL](url.mdx) format, and allows passing
 a development database (a twin environment) to validate schemas, simulate migrations and calculate the state of the
-migration directory by replaying the historical changes. Let's go over a few examples to explain the benefits of using
-a dev/twin database.
+migration directory by replaying the historical changes. Let's go over a few examples to explain the benefits of using a
+dev/twin database. For a one-time use Atlas can spin up an ephemeral local docker container for you with a special
+[docker driver](url.mdx).
 
 ## Validation
 

--- a/doc/md/cli/reference.md
+++ b/doc/md/cli/reference.md
@@ -187,6 +187,7 @@ migration.
       --auto-approve     Auto approve. Apply the schema changes without prompting for approval.
   -w, --web              Open in a local Atlas UI.
       --addr string      used with -w, local address to bind the server to. (default ":5800")
+      --verbose          enable verbose logging
 
 ```
 

--- a/doc/md/cli/url.mdx
+++ b/doc/md/cli/url.mdx
@@ -25,6 +25,7 @@ values={[
 {label: 'MariaDB', value: 'maria'},
 {label: 'PostgreSQL', value: 'postgres'},
 {label: 'SQLite', value: 'sqlite'},
+{label: 'Docker', value: 'docker'},
 ]}>
 <TabItem value="mysql">
 
@@ -67,6 +68,22 @@ postgres://postgres:pass@0.0.0.0:5432/database?sslmode=disable
 sqlite://file.db
 
 sqlite://file?cache=shared&mode=memory
+```
+
+</TabItem>
+<TabItem value="docker">
+
+Atlas can spin up an ephemeral local docker container for you by specifying a special URL like below. This can be useful
+if you need a [dev database](dev.md) for schema validation or diffing. However, some images like `mysql` /
+`mariadb` take quite some time to "boot", before they are ready to be used. For a smoother developing experience
+consider spinning up a longer lived container by yourself.
+
+```
+docker://postgres
+
+docker://mysql:8
+
+docker://mariadb:10.8.2-rc-focal
 ```
 
 </TabItem>


### PR DESCRIPTION
1. Adds `--verbose` to `atlas schema apply` to increase output if using `--dev-url docker://...`
2. Document usage of `docker://...`