### PR TITLE
sql/migrate: harden atlas.sum file integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      steps:
+      - uses: actions/setup-go@v2
       - uses: actions/checkout@v2
       - name: Run linters
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.42.1
           args: --verbose
   generate-cmp:
     runs-on: ubuntu-latest

--- a/cmd/action/migrations/atlas.sum
+++ b/cmd/action/migrations/atlas.sum
@@ -1,2 +1,2 @@
-sum h1:CZFyP06wsoDt78We3f3kGuRqhMnVBe/8mHINP2hE4ik=
-20220318104614_initial.sql h1:X9aVoWzuxCUrcS3tWoxPBUEh5aDeCwAelvo73hca1Ys=
+h1:CuXS3DZEf7JpEt4+3+YB0nDZtOK6mSZDnajdwfY1COM=
+20220318104614_initial.sql h1:EoDHPlX7fTGn5qiCdR5xhwFh+DrOi3cQ7Y49BsIy97k=

--- a/internal/ci/ci.tmpl
+++ b/internal/ci/ci.tmpl
@@ -12,11 +12,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      steps:
+      - uses: actions/setup-go@v2
       - uses: actions/checkout@v2
       - name: Run linters
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.42.1
           args: --verbose
   generate-cmp:
     runs-on: ubuntu-latest

--- a/schema/schemaspec/schemahcl/opts.go
+++ b/schema/schemaspec/schemahcl/opts.go
@@ -23,8 +23,8 @@ type (
 	Option func(*Config)
 )
 
-// New returns a state configured with options.
-func New(opts ...Option) *state {
+// New returns a State configured with options.
+func New(opts ...Option) *State {
 	cfg := &Config{
 		pathVars: make(map[string]map[string]cty.Value),
 		newCtx: func() *hcl.EvalContext {
@@ -37,7 +37,7 @@ func New(opts ...Option) *state {
 	for _, opt := range opts {
 		opt(cfg)
 	}
-	return &state{config: cfg}
+	return &State{config: cfg}
 }
 
 // WithScopedEnums configured a list of allowed ENUMs to be used in

--- a/sql/migrate/testdata/atlas.sum
+++ b/sql/migrate/testdata/atlas.sum
@@ -1,4 +1,4 @@
-sum h1:DPwupu/FZJZYDnpuzD/l7aOg0jW2vhZxnajKPqhtKXI=
-1_initial.down.sql h1:EZiUHYOg5uOulzAVoV3ASKISA07Yh1ssDovA9hFGm1g=
-1_initial.up.sql h1:jDnx3o9bPJxVl9R0zpqnB+ETv1uyHR8JmvDw2G+kJEk=
-sub/1.a_sub.up.sql h1:XTo+9ZV78c5t2cuZCqcvTSwkQEf0B2L9Didd8p8N2gc=
+h1:DCXCNGIZS22tT+MwN4xlx80g3Pz2ePVWIu5YqR/Qiuc=
+1_initial.down.sql h1:0zypK43rgPbgvVUgVJABGN25VgM1QSeU+LJDBb8cEQI=
+1_initial.up.sql h1:hFhs5XhRml4KTWGF5td6h1s7xNqAFnaEBbC5Y/NF7i4=
+sub/1.a_sub.up.sql h1:37EywUcuf8yZJsQiQFn6I1NXRaqtSnCTB4svZAg0OQ8=


### PR DESCRIPTION
This PR fixes one bug, where a raised error from `UnmarshalText()` was not propagated up and hardens the integrity of the file by taking the filename of the migrations into the hash as well. 