### PR TITLE
sql/migrate: local files can be created with read permissions for eve…

### DIFF
--- a/sql/migrate/migrate.go
+++ b/sql/migrate/migrate.go
@@ -381,7 +381,7 @@ func (d *LocalDir) Open(name string) (fs.File, error) {
 
 // WriteFile implements Dir.WriteFile.
 func (d *LocalDir) WriteFile(name string, b []byte) error {
-	return os.WriteFile(filepath.Join(d.dir, name), b, 0600)
+	return os.WriteFile(filepath.Join(d.dir, name), b, 0644) // nolint: gosec
 }
 
 var _ Dir = (*LocalDir)(nil)


### PR DESCRIPTION
…ryone, since they are meant to be read by other tools.