### PR TITLE
sql/postgres: fixed invalid postgres DSN

### DIFF
--- a/cmd/action/mux.go
+++ b/cmd/action/mux.go
@@ -109,9 +109,6 @@ func SchemaNameFromURL(ctx context.Context, url string) (string, error) {
 		}
 		return cfg.DBName, err
 	case "postgres":
-		// Use `url` instead of `dsn` as dsn lacks the scheme part (postgres://).
-		// url.Parse pareses such URLs incorrectly or produce an
-		// error: first path segment in URL cannot contain colon
 		return postgresSchema(url)
 	case "sqlite":
 		return schemaName(ctx, dsn)

--- a/cmd/action/mux.go
+++ b/cmd/action/mux.go
@@ -109,7 +109,10 @@ func SchemaNameFromURL(ctx context.Context, url string) (string, error) {
 		}
 		return cfg.DBName, err
 	case "postgres":
-		return postgresSchema(dsn)
+		// Use `url` instead of `dsn` as dsn lacks the scheme part (postgres://).
+		// url.Parse pareses such URLs incorrectly or produce an
+		// error: first path segment in URL cannot contain colon
+		return postgresSchema(url)
 	case "sqlite":
 		return schemaName(ctx, dsn)
 	default:

--- a/cmd/action/mux_test.go
+++ b/cmd/action/mux_test.go
@@ -150,6 +150,10 @@ func Test_PostgresSchemaDSN(t *testing.T) {
 			url:      "postgres://localhost:5432/dbname?search_path=",
 			expected: "",
 		},
+		{
+			url:      "postgres://user_name:password@localhost:5432/dbname?sslmode=disable",
+			expected: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.url, func(t *testing.T) {


### PR DESCRIPTION
DSN for Postgres with underscore (_) in the username causes an error: first path segment in URL cannot contain colon. 

Reason: the provider (postgres://) got stripped from the DSN which is then parsed as an URL. If the DSN contains username:password url.Parse either misinterpret the url (if the username contains only letters) or otherwise produces an error "first path segment in URL cannot contain colon".