### PR TITLE
sql/postgres: marshal spec duplicate enum entries

### DIFF
--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -290,14 +290,20 @@ func schemaSpec(schem *schema.Schema) (*doc, error) {
 	}
 	d.Schemas = []*sqlspec.Schema{s}
 	d.Tables = tbls
+
+	added := make(map[string]struct{})
+
 	for _, t := range schem.Tables {
 		for _, c := range t.Columns {
 			if t, ok := c.Type.Type.(*schema.EnumType); ok {
-				d.Enums = append(d.Enums, &Enum{
-					Name:   t.T,
-					Schema: specutil.SchemaRef(s.Name),
-					Values: t.Values,
-				})
+				if _, ok := added[t.T]; !ok {
+					d.Enums = append(d.Enums, &Enum{
+						Name:   t.T,
+						Schema: specutil.SchemaRef(s.Name),
+						Values: t.Values,
+					})
+					added[t.T] = struct{}{}
+				}
 			}
 		}
 	}

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -291,18 +291,17 @@ func schemaSpec(schem *schema.Schema) (*doc, error) {
 	d.Schemas = []*sqlspec.Schema{s}
 	d.Tables = tbls
 
-	added := make(map[string]struct{})
-
+	enums := make(map[string]struct{})
 	for _, t := range schem.Tables {
 		for _, c := range t.Columns {
 			if t, ok := c.Type.Type.(*schema.EnumType); ok {
-				if _, ok := added[t.T]; !ok {
+				if _, ok := enums[t.T]; !ok {
 					d.Enums = append(d.Enums, &Enum{
 						Name:   t.T,
 						Schema: specutil.SchemaRef(s.Name),
 						Values: t.Values,
 					})
-					added[t.T] = struct{}{}
+					enums[t.T] = struct{}{}
 				}
 			}
 		}

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -378,10 +378,24 @@ func TestMarshalSpec_Enum(t *testing.T) {
 						schema.EnumValues("private", "business"),
 					),
 				),
+			schema.NewTable("table2").
+				AddColumns(
+					schema.NewEnumColumn("account_type",
+						schema.EnumName("account_type"),
+						schema.EnumValues("private", "business"),
+					),
+				),
 		)
 	buf, err := MarshalSpec(s, hclState)
 	require.NoError(t, err)
 	const expected = `table "account" {
+  schema = schema.test
+  column "account_type" {
+    null = false
+    type = enum.account_type
+  }
+}
+table "table2" {
   schema = schema.test
   column "account_type" {
     null = false


### PR DESCRIPTION
When marshalling 2 or more columns that reference the same enum type the generated Atlas DDL document contains duplicate entries for this enum (one entry per column). 