### PR TITLE
schema/schemaspec: support defining resource names as attr

### DIFF
--- a/schema/schemaspec/extension.go
+++ b/schema/schemaspec/extension.go
@@ -93,7 +93,7 @@ func (r *Resource) As(target interface{}) error {
 	for _, ft := range specFields(target) {
 		field := v.FieldByName(ft.Name)
 		switch {
-		case ft.isName():
+		case ft.isName() && !hasAttr(r, ft.tag):
 			if seenName {
 				return errors.New("schemaspec: extension must have only one isName field")
 			}

--- a/schema/schemaspec/extension_test.go
+++ b/schema/schemaspec/extension_test.go
@@ -194,3 +194,20 @@ func TestListRef(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, resource, scan)
 }
+
+func TestNameAttr(t *testing.T) {
+	type Named struct {
+		Name string `spec:"name,name"`
+	}
+	schemaspec.Register("named", &Named{})
+	resource := &schemaspec.Resource{
+		Name: "id",
+		Attrs: []*schemaspec.Attr{
+			schemautil.StrLitAttr("name", "atlas"),
+		},
+	}
+	tgt := Named{}
+	err := resource.As(&tgt)
+	require.NoError(t, err)
+	require.EqualValues(t, "atlas", tgt.Name)
+}

--- a/schema/schemaspec/extension_test.go
+++ b/schema/schemaspec/extension_test.go
@@ -206,7 +206,7 @@ func TestNameAttr(t *testing.T) {
 			schemautil.StrLitAttr("name", "atlas"),
 		},
 	}
-	tgt := Named{}
+	var tgt Named
 	err := resource.As(&tgt)
 	require.NoError(t, err)
 	require.EqualValues(t, "atlas", tgt.Name)

--- a/schema/schemaspec/schemahcl/hcl_test.go
+++ b/schema/schemaspec/schemahcl/hcl_test.go
@@ -249,3 +249,25 @@ func TestQualified(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, h, string(out))
 }
+
+func TestNameAttr(t *testing.T) {
+	h := `
+named "block_id" {
+  name = "atlas"
+}
+ref = named.block_id.name
+`
+	type Named struct {
+		Name string `spec:"name,name"`
+	}
+	var test struct {
+		Named *Named `spec:"named"`
+		Ref   string `spec:"ref"`
+	}
+	err := Unmarshal([]byte(h), &test)
+	require.NoError(t, err)
+	require.EqualValues(t, &Named{
+		Name: "atlas",
+	}, test.Named)
+	require.EqualValues(t, "atlas", test.Ref)
+}


### PR DESCRIPTION
Needed in order to support input variables for schema names: 

```hcl
variable "tenant" {
   type = string
}

schema "tenant" {
  name = var.tenant
}

table "users" {
  schema = schema.tenant
}
```