### PR TITLE
sql: add support for renaming resources (tables, columns and indexes)

### DIFF
--- a/sql/internal/sqlx/sqlx.go
+++ b/sql/internal/sqlx/sqlx.go
@@ -314,7 +314,7 @@ func (b *Builder) Wrap(f func(b *Builder)) *Builder {
 func (b *Builder) Clone() *Builder {
 	return &Builder{
 		QuoteChar: b.QuoteChar,
-		Buffer:    *bytes.NewBufferString(b.String()),
+		Buffer:    *bytes.NewBufferString(b.Buffer.String()),
 	}
 }
 

--- a/sql/mysql/migrate.go
+++ b/sql/mysql/migrate.go
@@ -348,6 +348,9 @@ func (s *state) alterTable(t *schema.Table, changes []schema.Change) error {
 					To:     change.From,
 					Change: change.Change,
 				})
+			case *schema.RenameColumn:
+				b.P("RENAME COLUMN").Ident(change.From.Name).P("TO").Ident(change.To.Name)
+				reverse = append(reverse, &schema.RenameColumn{From: change.To, To: change.From})
 			case *schema.DropColumn:
 				b.P("DROP COLUMN").Ident(change.C.Name)
 				reverse = append(reverse, &schema.AddColumn{C: change.C})

--- a/sql/mysql/migrate.go
+++ b/sql/mysql/migrate.go
@@ -358,6 +358,9 @@ func (s *state) alterTable(t *schema.Table, changes []schema.Change) error {
 				b.P("ADD")
 				index(b, change.I)
 				reverse = append(reverse, &schema.DropIndex{I: change.I})
+			case *schema.RenameIndex:
+				b.P("RENAME INDEX").Ident(change.From.Name).P("TO").Ident(change.To.Name)
+				reverse = append(reverse, &schema.RenameIndex{From: change.To, To: change.From})
 			case *schema.DropIndex:
 				b.P("DROP INDEX").Ident(change.I.Name)
 				reverse = append(reverse, &schema.AddIndex{I: change.I})

--- a/sql/mysql/migrate_test.go
+++ b/sql/mysql/migrate_test.go
@@ -754,6 +754,28 @@ func TestPlanChanges(t *testing.T) {
 				},
 			},
 		},
+		{
+			input: []schema.Change{
+				&schema.ModifyTable{
+					T: schema.NewTable("t1").SetSchema(schema.New("s1")),
+					Changes: []schema.Change{
+						&schema.RenameColumn{
+							From: schema.NewColumn("a"),
+							To:   schema.NewColumn("b"),
+						},
+					},
+				},
+			},
+			wantPlan: &migrate.Plan{
+				Reversible: true,
+				Changes: []*migrate.Change{
+					{
+						Cmd:     "ALTER TABLE `s1`.`t1` RENAME COLUMN `a` TO `b`",
+						Reverse: "ALTER TABLE `s1`.`t1` RENAME COLUMN `b` TO `a`",
+					},
+				},
+			},
+		},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/sql/mysql/migrate_test.go
+++ b/sql/mysql/migrate_test.go
@@ -720,6 +720,40 @@ func TestPlanChanges(t *testing.T) {
 				},
 			},
 		},
+		{
+			input: []schema.Change{
+				&schema.RenameTable{
+					From: schema.NewTable("t1"),
+					To:   schema.NewTable("t2"),
+				},
+			},
+			wantPlan: &migrate.Plan{
+				Reversible: true,
+				Changes: []*migrate.Change{
+					{
+						Cmd:     "RENAME TABLE `t1` TO `t2`",
+						Reverse: "RENAME TABLE `t2` TO `t1`",
+					},
+				},
+			},
+		},
+		{
+			input: []schema.Change{
+				&schema.RenameTable{
+					From: schema.NewTable("t1").SetSchema(schema.New("s1")),
+					To:   schema.NewTable("t2").SetSchema(schema.New("s2")),
+				},
+			},
+			wantPlan: &migrate.Plan{
+				Reversible: true,
+				Changes: []*migrate.Change{
+					{
+						Cmd:     "RENAME TABLE `s1`.`t1` TO `s2`.`t2`",
+						Reverse: "RENAME TABLE `s2`.`t2` TO `s1`.`t1`",
+					},
+				},
+			},
+		},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/sql/mysql/migrate_test.go
+++ b/sql/mysql/migrate_test.go
@@ -776,6 +776,28 @@ func TestPlanChanges(t *testing.T) {
 				},
 			},
 		},
+		{
+			input: []schema.Change{
+				&schema.ModifyTable{
+					T: schema.NewTable("t1").SetSchema(schema.New("s1")),
+					Changes: []schema.Change{
+						&schema.RenameIndex{
+							From: schema.NewIndex("a"),
+							To:   schema.NewIndex("b"),
+						},
+					},
+				},
+			},
+			wantPlan: &migrate.Plan{
+				Reversible: true,
+				Changes: []*migrate.Change{
+					{
+						Cmd:     "ALTER TABLE `s1`.`t1` RENAME INDEX `a` TO `b`",
+						Reverse: "ALTER TABLE `s1`.`t1` RENAME INDEX `b` TO `a`",
+					},
+				},
+			},
+		},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/sql/mysql/migrate_test.go
+++ b/sql/mysql/migrate_test.go
@@ -327,7 +327,7 @@ func TestPlanChanges(t *testing.T) {
 			},
 			wantPlan: &migrate.Plan{
 				Reversible: true,
-				Changes:    []*migrate.Change{{Cmd: "ALTER DATABASE `test` CHARSET latin1", Reverse: "ALTER DATABASE `test`CHARSET utf8"}},
+				Changes:    []*migrate.Change{{Cmd: "ALTER DATABASE `test` CHARSET latin1", Reverse: "ALTER DATABASE `test` CHARSET utf8"}},
 			},
 		},
 		// Modify charset.
@@ -342,7 +342,7 @@ func TestPlanChanges(t *testing.T) {
 			},
 			wantPlan: &migrate.Plan{
 				Reversible: true,
-				Changes:    []*migrate.Change{{Cmd: "ALTER DATABASE `test` CHARSET utf8", Reverse: "ALTER DATABASE `test`CHARSET latin1"}},
+				Changes:    []*migrate.Change{{Cmd: "ALTER DATABASE `test` CHARSET utf8", Reverse: "ALTER DATABASE `test` CHARSET latin1"}},
 			},
 		},
 		{

--- a/sql/postgres/migrate.go
+++ b/sql/postgres/migrate.go
@@ -301,9 +301,6 @@ func (s *state) alterTable(t *schema.Table, changes []schema.Change) error {
 					return err
 				}
 				reverse = append(reverse, &schema.DropColumn{C: change.C})
-			case *schema.DropColumn:
-				b.P("DROP COLUMN").Ident(change.C.Name)
-				reverse = append(reverse, &schema.AddColumn{C: change.C})
 			case *schema.ModifyColumn:
 				if err := s.alterColumn(b, change.Change, change.To); err != nil {
 					return err
@@ -316,6 +313,12 @@ func (s *state) alterTable(t *schema.Table, changes []schema.Change) error {
 					To:     change.From,
 					Change: change.Change & ^schema.ChangeGenerated,
 				})
+			case *schema.RenameColumn:
+				b.P("RENAME COLUMN").Ident(change.From.Name).P("TO").Ident(change.To.Name)
+				reverse = append(reverse, &schema.RenameColumn{From: change.To, To: change.From})
+			case *schema.DropColumn:
+				b.P("DROP COLUMN").Ident(change.C.Name)
+				reverse = append(reverse, &schema.AddColumn{C: change.C})
 			case *schema.AddForeignKey:
 				b.P("ADD")
 				s.fks(b, change.F)

--- a/sql/postgres/migrate.go
+++ b/sql/postgres/migrate.go
@@ -451,7 +451,7 @@ func (s *state) dropIndexes(t *schema.Table, indexes ...*schema.Index) {
 	for i, idx := range indexes {
 		s.append(&migrate.Change{
 			Cmd:     rs.Changes[i].Reverse,
-			Comment: fmt.Sprintf("Drop index %q from table: %q", idx.Name, t.Name),
+			Comment: fmt.Sprintf("drop index %q from table: %q", idx.Name, t.Name),
 			Reverse: rs.Changes[i].Cmd,
 		})
 	}
@@ -528,7 +528,7 @@ func (s *state) addIndexes(t *schema.Table, indexes ...*schema.Index) {
 		s.index(b, idx)
 		s.append(&migrate.Change{
 			Cmd:     b.String(),
-			Comment: fmt.Sprintf("Create index %q to table: %q", idx.Name, t.Name),
+			Comment: fmt.Sprintf("create index %q to table: %q", idx.Name, t.Name),
 			Reverse: func() string {
 				b := Build("DROP INDEX")
 				// Unlike MySQL, the DROP command is not attached to ALTER TABLE.

--- a/sql/postgres/migrate.go
+++ b/sql/postgres/migrate.go
@@ -221,6 +221,13 @@ func (s *state) modifyTable(ctx context.Context, modify *schema.ModifyTable) err
 			// Index modification requires rebuilding the index.
 			addI = append(addI, change.To)
 			dropI = append(dropI, change.From)
+		case *schema.RenameIndex:
+			s.append(&migrate.Change{
+				Source:  change,
+				Comment: fmt.Sprintf("rename an index from %q to %q", change.From.Name, change.To.Name),
+				Cmd:     Build("ALTER INDEX").Ident(change.From.Name).P("RENAME TO").Ident(change.To.Name).String(),
+				Reverse: Build("ALTER INDEX").Ident(change.To.Name).P("RENAME TO").Ident(change.From.Name).String(),
+			})
 		case *schema.ModifyForeignKey:
 			// Foreign-key modification is translated into 2 steps.
 			// Dropping the current foreign key and creating a new one.

--- a/sql/postgres/migrate_test.go
+++ b/sql/postgres/migrate_test.go
@@ -668,6 +668,24 @@ func TestPlanChanges(t *testing.T) {
 				},
 			},
 		},
+		{
+			changes: []schema.Change{
+				&schema.RenameTable{
+					From: schema.NewTable("t1").SetSchema(schema.New("s1")),
+					To:   schema.NewTable("t2").SetSchema(schema.New("s2")),
+				},
+			},
+			plan: &migrate.Plan{
+				Reversible:    true,
+				Transactional: true,
+				Changes: []*migrate.Change{
+					{
+						Cmd:     `ALTER TABLE "s1"."t1" RENAME TO "s2"."t2"`,
+						Reverse: `ALTER TABLE "s2"."t2" RENAME TO "s1"."t1"`,
+					},
+				},
+			},
+		},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/sql/postgres/migrate_test.go
+++ b/sql/postgres/migrate_test.go
@@ -686,6 +686,29 @@ func TestPlanChanges(t *testing.T) {
 				},
 			},
 		},
+		{
+			changes: []schema.Change{
+				&schema.ModifyTable{
+					T: schema.NewTable("t1").SetSchema(schema.New("s1")),
+					Changes: []schema.Change{
+						&schema.RenameColumn{
+							From: schema.NewColumn("a"),
+							To:   schema.NewColumn("b"),
+						},
+					},
+				},
+			},
+			plan: &migrate.Plan{
+				Reversible:    true,
+				Transactional: true,
+				Changes: []*migrate.Change{
+					{
+						Cmd:     `ALTER TABLE "s1"."t1" RENAME COLUMN "a" TO "b"`,
+						Reverse: `ALTER TABLE "s1"."t1" RENAME COLUMN "b" TO "a"`,
+					},
+				},
+			},
+		},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/sql/postgres/migrate_test.go
+++ b/sql/postgres/migrate_test.go
@@ -709,6 +709,29 @@ func TestPlanChanges(t *testing.T) {
 				},
 			},
 		},
+		{
+			changes: []schema.Change{
+				&schema.ModifyTable{
+					T: schema.NewTable("t1").SetSchema(schema.New("s1")),
+					Changes: []schema.Change{
+						&schema.RenameIndex{
+							From: schema.NewIndex("a"),
+							To:   schema.NewIndex("b"),
+						},
+					},
+				},
+			},
+			plan: &migrate.Plan{
+				Reversible:    true,
+				Transactional: true,
+				Changes: []*migrate.Change{
+					{
+						Cmd:     `ALTER INDEX "a" RENAME TO "b"`,
+						Reverse: `ALTER INDEX "b" RENAME TO "a"`,
+					},
+				},
+			},
+		},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/sql/schema/migrate.go
+++ b/sql/schema/migrate.go
@@ -81,6 +81,11 @@ type (
 		Changes []Change
 	}
 
+	// RenameTable describes a table rename change.
+	RenameTable struct {
+		From, To *Table
+	}
+
 	// AddColumn describes a column creation change.
 	AddColumn struct {
 		C *Column
@@ -278,6 +283,7 @@ func (*ModifySchema) change()     {}
 func (*AddTable) change()         {}
 func (*DropTable) change()        {}
 func (*ModifyTable) change()      {}
+func (*RenameTable) change()      {}
 func (*AddIndex) change()         {}
 func (*DropIndex) change()        {}
 func (*ModifyIndex) change()      {}

--- a/sql/schema/migrate.go
+++ b/sql/schema/migrate.go
@@ -123,6 +123,11 @@ type (
 		Change   ChangeKind
 	}
 
+	// RenameIndex describes an index rename change.
+	RenameIndex struct {
+		From, To *Index
+	}
+
 	// AddForeignKey describes a foreign-key creation change.
 	AddForeignKey struct {
 		F *ForeignKey
@@ -292,6 +297,7 @@ func (*RenameTable) change()      {}
 func (*AddIndex) change()         {}
 func (*DropIndex) change()        {}
 func (*ModifyIndex) change()      {}
+func (*RenameIndex) change()      {}
 func (*AddCheck) change()         {}
 func (*DropCheck) change()        {}
 func (*ModifyCheck) change()      {}

--- a/sql/schema/migrate.go
+++ b/sql/schema/migrate.go
@@ -102,6 +102,11 @@ type (
 		Change   ChangeKind
 	}
 
+	// RenameColumn describes a column rename change.
+	RenameColumn struct {
+		From, To *Column
+	}
+
 	// AddIndex describes an index creation change.
 	AddIndex struct {
 		I *Index
@@ -293,6 +298,7 @@ func (*ModifyCheck) change()      {}
 func (*AddColumn) change()        {}
 func (*DropColumn) change()       {}
 func (*ModifyColumn) change()     {}
+func (*RenameColumn) change()     {}
 func (*AddForeignKey) change()    {}
 func (*DropForeignKey) change()   {}
 func (*ModifyForeignKey) change() {}

--- a/sql/sqlite/migrate_test.go
+++ b/sql/sqlite/migrate_test.go
@@ -259,7 +259,34 @@ func TestPlanChanges(t *testing.T) {
 				Changes: []*migrate.Change{
 					{
 						Cmd:     "ALTER TABLE `t1` RENAME COLUMN `a` TO `b`",
-						Reverse: "ALTER TABLE `t1` RENAME COLUMN`b` TO `a`",
+						Reverse: "ALTER TABLE `t1` RENAME COLUMN `b` TO `a`",
+					},
+				},
+			},
+		},
+		{
+			changes: []schema.Change{
+				&schema.ModifyTable{
+					T: schema.NewTable("t1"),
+					Changes: []schema.Change{
+						&schema.RenameIndex{
+							From: schema.NewIndex("a").AddColumns(schema.NewColumn("a")),
+							To:   schema.NewIndex("b").AddColumns(schema.NewColumn("a")),
+						},
+					},
+				},
+			},
+			plan: &migrate.Plan{
+				Reversible:    true,
+				Transactional: true,
+				Changes: []*migrate.Change{
+					{
+						Cmd:     "CREATE INDEX `b` ON `t1` (`a`)",
+						Reverse: "DROP INDEX `b`",
+					},
+					{
+						Cmd:     "DROP INDEX `a`",
+						Reverse: "CREATE INDEX `a` ON `t1` (`a`)",
 					},
 				},
 			},

--- a/sql/sqlite/migrate_test.go
+++ b/sql/sqlite/migrate_test.go
@@ -221,6 +221,24 @@ func TestPlanChanges(t *testing.T) {
 				},
 			},
 		},
+		{
+			changes: []schema.Change{
+				&schema.RenameTable{
+					From: schema.NewTable("t1"),
+					To:   schema.NewTable("t2"),
+				},
+			},
+			plan: &migrate.Plan{
+				Reversible:    true,
+				Transactional: true,
+				Changes: []*migrate.Change{
+					{
+						Cmd:     "ALTER TABLE `t1` RENAME TO `t2`",
+						Reverse: "ALTER TABLE `t2` RENAME TO `t1`",
+					},
+				},
+			},
+		},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/sql/sqlite/migrate_test.go
+++ b/sql/sqlite/migrate_test.go
@@ -121,9 +121,10 @@ func TestPlanChanges(t *testing.T) {
 				}(),
 			},
 			plan: &migrate.Plan{
+				Reversible:    true,
 				Transactional: true,
 				Changes: []*migrate.Change{
-					{Cmd: "ALTER TABLE `users` ADD COLUMN `name` varchar(255) NOT NULL"},
+					{Cmd: "ALTER TABLE `users` ADD COLUMN `name` varchar(255) NOT NULL", Reverse: "ALTER TABLE `users` DROP COLUMN `name`"},
 					{Cmd: "CREATE INDEX `id_key` ON `users` (`id`)", Reverse: "DROP INDEX `id_key`"},
 				},
 			},
@@ -146,9 +147,10 @@ func TestPlanChanges(t *testing.T) {
 				}(),
 			},
 			plan: &migrate.Plan{
+				Reversible:    true,
 				Transactional: true,
 				Changes: []*migrate.Change{
-					{Cmd: "ALTER TABLE `users` ADD COLUMN `nid` bigint NOT NULL AS (1)"},
+					{Cmd: "ALTER TABLE `users` ADD COLUMN `nid` bigint NOT NULL AS (1)", Reverse: "ALTER TABLE `users` DROP COLUMN `nid`"},
 				},
 			},
 		},
@@ -235,6 +237,29 @@ func TestPlanChanges(t *testing.T) {
 					{
 						Cmd:     "ALTER TABLE `t1` RENAME TO `t2`",
 						Reverse: "ALTER TABLE `t2` RENAME TO `t1`",
+					},
+				},
+			},
+		},
+		{
+			changes: []schema.Change{
+				&schema.ModifyTable{
+					T: schema.NewTable("t1"),
+					Changes: []schema.Change{
+						&schema.RenameColumn{
+							From: schema.NewColumn("a"),
+							To:   schema.NewColumn("b"),
+						},
+					},
+				},
+			},
+			plan: &migrate.Plan{
+				Reversible:    true,
+				Transactional: true,
+				Changes: []*migrate.Change{
+					{
+						Cmd:     "ALTER TABLE `t1` RENAME COLUMN `a` TO `b`",
+						Reverse: "ALTER TABLE `t1` RENAME COLUMN`b` TO `a`",
 					},
 				},
 			},


### PR DESCRIPTION
<strike>The only thing left is to support renaming indexes in SQLite, which requires recreation of the index. </strike>