### PR TITLE
schema/schemaspec/schemahcl: state eval with input vars

### DIFF
--- a/schema/schemaspec/schemahcl/context_test.go
+++ b/schema/schemaspec/schemahcl/context_test.go
@@ -485,26 +485,23 @@ variable "bool" {
   type = bool
 }
 
-
 name = var.name
 default = var.default
 int = var.int
 bool = var.bool
 `
-	state := New(
-		WithInputValues(map[string]interface{}{
-			"name": "rotemtam",
-			"int":  42,
-			"bool": true,
-		}),
-	)
+	state := New()
 	var test struct {
 		Name    string `spec:"name"`
 		Default string `spec:"default"`
 		Int     int    `spec:"int"`
 		Bool    bool   `spec:"bool"`
 	}
-	err := state.UnmarshalSpec([]byte(h), &test)
+	err := state.Eval([]byte(h), &test, map[string]string{
+		"name": "rotemtam",
+		"int":  "42",
+		"bool": "true",
+	})
 	require.NoError(t, err)
 	require.EqualValues(t, "rotemtam", test.Name)
 	require.EqualValues(t, "hello", test.Default)

--- a/schema/schemaspec/schemahcl/opts.go
+++ b/schema/schemaspec/schemahcl/opts.go
@@ -14,10 +14,9 @@ import (
 type (
 	// Config configures an unmarshaling.
 	Config struct {
-		types       []*schemaspec.TypeSpec
-		newCtx      func() *hcl.EvalContext
-		pathVars    map[string]map[string]cty.Value
-		inputValues map[string]cty.Value
+		types    []*schemaspec.TypeSpec
+		newCtx   func() *hcl.EvalContext
+		pathVars map[string]map[string]cty.Value
 	}
 
 	// Option configures a Config.
@@ -92,26 +91,6 @@ func WithTypes(typeSpecs []*schemaspec.TypeSpec) Option {
 	return func(config *Config) {
 		config.newCtx = newCtx
 		config.types = append(config.types, typeSpecs...)
-	}
-}
-
-// WithInputValues configures the input values available to the Unmarshaler.
-func WithInputValues(vals map[string]interface{}) Option {
-	inputs := make(map[string]cty.Value)
-	for k, v := range vals {
-		switch v := v.(type) {
-		case string:
-			inputs[k] = cty.StringVal(v)
-		case bool:
-			inputs[k] = cty.BoolVal(v)
-		case int:
-			inputs[k] = cty.NumberIntVal(int64(v))
-		default:
-			panic("unsupported type for input value " + k)
-		}
-	}
-	return func(config *Config) {
-		config.inputValues = inputs
 	}
 }
 


### PR DESCRIPTION
Changing direction a bit on the API for evaluating atlas DDL documents that contain input variable definitions. 