### PR TITLE
sql/mysql: RevisionReadWriter implementation for mysql

### DIFF
--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"ariga.io/atlas/sql/migrate"
 	"ariga.io/atlas/sql/mysql"
 	"ariga.io/atlas/sql/schema"
 
@@ -76,6 +77,12 @@ func myInit(dialect string) []io.Closer {
 		myTests.drivers[version] = &myTest{db: db, drv: drv, version: version, port: port}
 	}
 	return cs
+}
+
+func TestMySQL_Executor(t *testing.T) {
+	myRun(t, func(t *myTest) {
+		testExecutor(t)
+	})
 }
 
 func TestMySQL_AddDropTable(t *testing.T) {
@@ -1131,6 +1138,10 @@ func (t *myTest) dsn(dbname string) string {
 		d = "mariadb"
 	}
 	return fmt.Sprintf("%s://root%s@tcp(localhost:%d)/%s", d, pass, t.port, dbname)
+}
+
+func (t *myTest) driver() migrate.Driver {
+	return t.drv
 }
 
 func (t *myTest) applyHcl(spec string) {

--- a/internal/integration/postgres_test.go
+++ b/internal/integration/postgres_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"ariga.io/atlas/sql/migrate"
 	"ariga.io/atlas/sql/mysql"
 	"ariga.io/atlas/sql/postgres"
 	"ariga.io/atlas/sql/schema"
@@ -992,6 +993,10 @@ create table atlas_types_sanity
 
 func (t *pgTest) dsn() string {
 	return fmt.Sprintf("postgres://postgres:pass@localhost:%d/test?sslmode=disable", t.port)
+}
+
+func (t *pgTest) driver() migrate.Driver {
+	return t.drv
 }
 
 func (t *pgTest) applyHcl(spec string) {

--- a/internal/integration/sqlite_test.go
+++ b/internal/integration/sqlite_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"ariga.io/atlas/sql/migrate"
 	"ariga.io/atlas/sql/postgres"
 	"ariga.io/atlas/sql/schema"
 	"ariga.io/atlas/sql/sqlite"
@@ -711,6 +712,10 @@ create table atlas_types_sanity
 			testImplicitIndexes(t, t.db)
 		})
 	})
+}
+
+func (t *liteTest) driver() migrate.Driver {
+	return t.drv
 }
 
 func (t *liteTest) applyHcl(spec string) {

--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -25,6 +25,7 @@ type (
 		schema.Differ
 		schema.Inspector
 		migrate.PlanApplier
+		migrate.RevisionReadWriter
 	}
 
 	// database connection and its information.
@@ -56,10 +57,11 @@ func Open(db schema.ExecQuerier) (*Driver, error) {
 		}, nil
 	}
 	return &Driver{
-		conn:        c,
-		Differ:      &sqlx.Diff{DiffDriver: &diff{c}},
-		Inspector:   &inspect{c},
-		PlanApplier: &planApply{c},
+		conn:               c,
+		Differ:             &sqlx.Diff{DiffDriver: &diff{c}},
+		Inspector:          &inspect{c},
+		PlanApplier:        &planApply{c},
+		RevisionReadWriter: &revReadWrite{c},
 	}, nil
 }
 


### PR DESCRIPTION
This PR adds implementation for a revisions management table in SQL. Once the other drivers get their implementation parts of this code might be moved to sqlx since they can be shared.

Yet missing: In which schema to save the table. This requires some configuration options for drivers to pass in the table name (`schema`.`table`).