### PR TITLE
schema/schemaspec/schemahcl: patch references to blocks with variable names

### DIFF
--- a/schema/schemaspec/extension_test.go
+++ b/schema/schemaspec/extension_test.go
@@ -131,6 +131,9 @@ func TestNested(t *testing.T) {
 	err = scan.Scan(&pb)
 	require.NoError(t, err)
 	require.EqualValues(t, pet, scan)
+	name, err := pet.FinalName()
+	require.NoError(t, err)
+	require.EqualValues(t, "donut", name)
 }
 
 func TestRef(t *testing.T) {
@@ -202,6 +205,7 @@ func TestNameAttr(t *testing.T) {
 	schemaspec.Register("named", &Named{})
 	resource := &schemaspec.Resource{
 		Name: "id",
+		Type: "named",
 		Attrs: []*schemaspec.Attr{
 			schemautil.StrLitAttr("name", "atlas"),
 		},
@@ -210,4 +214,7 @@ func TestNameAttr(t *testing.T) {
 	err := resource.As(&tgt)
 	require.NoError(t, err)
 	require.EqualValues(t, "atlas", tgt.Name)
+	name, err := resource.FinalName()
+	require.NoError(t, err)
+	require.EqualValues(t, name, "atlas")
 }

--- a/schema/schemaspec/schemahcl/hcl.go
+++ b/schema/schemaspec/schemahcl/hcl.go
@@ -81,18 +81,18 @@ func (s *State) Eval(data []byte, v interface{}, input map[string]string) error 
 	return nil
 }
 
-// refMap maps addresses to their referenced resource.
-type refMap map[string]*schemaspec.Resource
+// addrRef maps addresses to their referenced resource.
+type addrRef map[string]*schemaspec.Resource
 
 // patchRefs recursively searches for schemaspec.Ref under the provided schemaspec.Resource
 // and patches any variables with their concrete names.
 func patchRefs(spec *schemaspec.Resource) error {
-	m := make(refMap)
+	m := make(addrRef)
 	m.load(spec, "")
 	return m.patch(spec)
 }
 
-func (r refMap) patch(resource *schemaspec.Resource) error {
+func (r addrRef) patch(resource *schemaspec.Resource) error {
 	for _, attr := range resource.Attrs {
 		if ref, ok := attr.V.(*schemaspec.Ref); ok {
 			referenced, ok := r[ref.V]
@@ -113,7 +113,7 @@ func (r refMap) patch(resource *schemaspec.Resource) error {
 }
 
 // load loads the references from the children of the resource.
-func (r refMap) load(res *schemaspec.Resource, track string) {
+func (r addrRef) load(res *schemaspec.Resource, track string) {
 	unlabeled := 0
 	for _, ch := range res.Children {
 		current := rep(ch)

--- a/schema/schemaspec/schemahcl/hcl.go
+++ b/schema/schemaspec/schemahcl/hcl.go
@@ -97,6 +97,7 @@ func (r addrRef) patch(resource *schemaspec.Resource) error {
 		if ref, ok := attr.V.(*schemaspec.Ref); ok {
 			referenced, ok := r[ref.V]
 			if !ok {
+				fmt.Println(r)
 				return fmt.Errorf("broken reference to %q", ref.V)
 			}
 			if name, err := referenced.FinalName(); err == nil {

--- a/sql/internal/spectest/spectest.go
+++ b/sql/internal/spectest/spectest.go
@@ -59,6 +59,7 @@ table "users" {
 	err := evaluator.Eval([]byte(h), &test, map[string]string{"tenant": "rotemtam"})
 	require.NoError(t, err)
 	require.EqualValues(t, "rotemtam", test.Schemas[0].Name)
+	require.Len(t, test.Schemas[0].Tables, 1)
 }
 
 func contains(s string, l []string) bool {

--- a/sql/internal/spectest/spectest.go
+++ b/sql/internal/spectest/spectest.go
@@ -53,6 +53,12 @@ table "users" {
 	column "id" {
 		type = int
 	}
+	index "user_name" {
+    on {
+      column = column.id
+      unique = true
+    }
+  }
 }
 `
 	var test schema.Realm


### PR DESCRIPTION
Fixes a bug in cases like:
```hcl
variable "tenant" {
	type = string
	default = "test"
}
schema "tenant" {
	name = var.tenant
}
table "users" {
	schema = schema.tenant
	column "id" {
		type = int
	}
}
```
When provided an input var such as `tenant=rotemtam`, the value of the reference to `schema.tenant` was `$schema.tenant` instead of `$schema.rotemtam`