### PR TITLE
sql/sqlite: simple file lock to implement schema.Locker for SQLite

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,8 +12,16 @@ issues:
       linters:
         - gosec
 
+linters-settings:
+  goheader:
+    template: |-
+      Copyright 2021-present The Atlas Authors. All rights reserved.
+      This source code is licensed under the Apache 2.0 license found
+      in the LICENSE file in the root directory of this source tree.
+
 linters:
   disable-all: true
   enable:
     - gosec
     - revive
+    - goheader

--- a/cmd/atlas/doc.go
+++ b/cmd/atlas/doc.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 //go:build ignore
 // +build ignore
 

--- a/cmd/atlas/generate.go
+++ b/cmd/atlas/generate.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package main
 
 //go:generate go run -mod=mod doc.go

--- a/cmd/atlas/main.go
+++ b/cmd/atlas/main.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package main
 
 import (

--- a/cmd/atlascmd/migrate/ent/schema/revision.go
+++ b/cmd/atlascmd/migrate/ent/schema/revision.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package schema
 
 import (

--- a/cmd/atlascmd/update/update_test.go
+++ b/cmd/atlascmd/update/update_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package update
 
 import (

--- a/internal/ci/main.go
+++ b/internal/ci/main.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package main
 
 import (

--- a/internal/integration/hclsqlspec/hclsqlspec_test.go
+++ b/internal/integration/hclsqlspec/hclsqlspec_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package hclsqlspec
 
 import (

--- a/internal/integration/hclsqlspec/migrate_test.go
+++ b/internal/integration/hclsqlspec/migrate_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package hclsqlspec
 
 import (

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package integration
 
 import (

--- a/internal/typedoc/main.go
+++ b/internal/typedoc/main.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package main
 
 import (

--- a/schema/schemaspec/doc.go
+++ b/schema/schemaspec/doc.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 // Package schemaspec provides types designed to capture atlas schema elements, and create
 // type-safe extensions to the configuration language. This package is designed to provide
 // an intermediate representation between a serialized configuration language representation

--- a/schema/schemaspec/extension.go
+++ b/schema/schemaspec/extension.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package schemaspec
 
 import (

--- a/schema/schemaspec/extension_test.go
+++ b/schema/schemaspec/extension_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package schemaspec_test
 
 import (

--- a/schema/schemaspec/internal/schemautil/schemautil.go
+++ b/schema/schemaspec/internal/schemautil/schemautil.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package schemautil
 
 import (

--- a/schema/schemaspec/schemahcl/hcl.go
+++ b/schema/schemaspec/schemahcl/hcl.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package schemahcl
 
 import (

--- a/schema/schemaspec/schemahcl/hcl_test.go
+++ b/schema/schemaspec/schemahcl/hcl_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package schemahcl
 
 import (

--- a/schema/schemaspec/schemahcl/opts.go
+++ b/schema/schemaspec/schemahcl/opts.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package schemahcl
 
 import (

--- a/schema/schemaspec/schemahcl/types.go
+++ b/schema/schemaspec/schemahcl/types.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package schemahcl
 
 import (

--- a/schema/schemaspec/schemahcl/types_test.go
+++ b/schema/schemaspec/schemahcl/types_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package schemahcl
 
 import (

--- a/schema/schemaspec/spec.go
+++ b/schema/schemaspec/spec.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package schemaspec
 
 import (

--- a/schema/schemaspec/spec_test.go
+++ b/schema/schemaspec/spec_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package schemaspec
 
 import (

--- a/sql/internal/specutil/convert_test.go
+++ b/sql/internal/specutil/convert_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package specutil
 
 import (

--- a/sql/internal/specutil/spec.go
+++ b/sql/internal/specutil/spec.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package specutil
 
 import (

--- a/sql/mysql/sqlspec.go
+++ b/sql/mysql/sqlspec.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package mysql
 
 import (

--- a/sql/mysql/sqlspec_test.go
+++ b/sql/mysql/sqlspec_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package mysql
 
 import (

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package postgres
 
 import (

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package postgres
 
 import (

--- a/sql/sqlite/driver.go
+++ b/sql/sqlite/driver.go
@@ -107,11 +107,7 @@ func (d *Driver) Clean(ctx context.Context) error {
 
 // Lock implements the schema.Locker interface.
 func (d *Driver) Lock(_ context.Context, name string, timeout time.Duration) (schema.UnlockFunc, error) {
-	dir, err := os.UserCacheDir()
-	if err != nil {
-		return nil, fmt.Errorf("sql/sqlite: determining lock dir: %w", err)
-	}
-	path := filepath.Join(dir, name+".lock")
+	path := filepath.Join(os.TempDir(), name+".lock")
 	c, err := ioutil.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return acquireLock(path, timeout)
@@ -136,7 +132,7 @@ func acquireLock(path string, timeout time.Duration) (schema.UnlockFunc, error) 
 		return nil, fmt.Errorf("sql/sqlite: creating lockfile %q: %w", path, err)
 	}
 	if _, err := lock.Write([]byte(strconv.FormatInt(time.Now().Add(timeout).UnixNano(), 10))); err != nil {
-		return nil, fmt.Errorf("sql/sqlite: writing zo lockfile %q: %w", path, err)
+		return nil, fmt.Errorf("sql/sqlite: writing to lockfile %q: %w", path, err)
 	}
 	defer lock.Close()
 	return func() error { return os.Remove(path) }, nil

--- a/sql/sqlite/driver_test.go
+++ b/sql/sqlite/driver_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package sqlite
 
 import (

--- a/sql/sqlite/driver_test.go
+++ b/sql/sqlite/driver_test.go
@@ -1,0 +1,44 @@
+package sqlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDriver_LockAcquired(t *testing.T) {
+	drv := &Driver{}
+
+	// Acquiring a lock does work.
+	unlock, err := drv.Lock(context.Background(), "lock", time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, unlock)
+
+	// Acquiring a lock on the same value will fail.
+	_, err = drv.Lock(context.Background(), "lock", time.Second)
+	require.Error(t, err)
+
+	// After unlock it will succeed again.
+	require.NoError(t, unlock())
+	_, err = drv.Lock(context.Background(), "lock", time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, unlock)
+
+	// Acquiring a lock on a value that has been expired works.
+	dir, err := os.UserCacheDir()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "lock.lock"),
+		[]byte(strconv.FormatInt(time.Now().Add(-time.Second).UnixNano(), 10)),
+		0666,
+	))
+	_, err = drv.Lock(context.Background(), "lock", time.Second)
+
+	// Acquiring a lock on another value works as well.
+	_, err = drv.Lock(context.Background(), "another", time.Second)
+}

--- a/sql/sqlite/sqlspec.go
+++ b/sql/sqlite/sqlspec.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package sqlite
 
 import (

--- a/sql/sqlspec/migratespec.go
+++ b/sql/sqlspec/migratespec.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package sqlspec
 
 import (

--- a/sql/sqlspec/sqlspec.go
+++ b/sql/sqlspec/sqlspec.go
@@ -1,3 +1,7 @@
+// Copyright 2021-present The Atlas Authors. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
 package sqlspec
 
 import (


### PR DESCRIPTION
This PR assumes, that SQLite files will most likely be run locally (which means never be accessed remotely) and therefore this implementation works for that cases. It aims to provide consistency with the other drivers.