### PR TITLE
sql/mysql: Attempt a fix for RawExpr cases

### DIFF
--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -612,7 +612,7 @@ table "users" {
 }
 
 func TestMySQL_CLI_MultiSchema(t *testing.T) {
-	h := `	
+	h := `
 			schema "test" {
 				charset   = "%s"
 				collation = "%s"
@@ -844,7 +844,7 @@ create table atlas_types_sanity
 						Default: &schema.RawExpr{
 							X: func() string {
 								if t.mariadb() {
-									return "current_timestamp()"
+									return "(current_timestamp())"
 								}
 								return "CURRENT_TIMESTAMP"
 							}(),
@@ -857,7 +857,7 @@ create table atlas_types_sanity
 						Default: &schema.RawExpr{
 							X: func() string {
 								if t.mariadb() {
-									return "current_timestamp(6)"
+									return "(current_timestamp(6))"
 								}
 								return "CURRENT_TIMESTAMP(6)"
 							}(),
@@ -870,7 +870,7 @@ create table atlas_types_sanity
 						Default: &schema.RawExpr{
 							X: func() string {
 								if t.mariadb() {
-									return "current_timestamp()"
+									return "(current_timestamp())"
 								}
 								return "CURRENT_TIMESTAMP"
 							}(),
@@ -892,7 +892,7 @@ create table atlas_types_sanity
 						Default: &schema.RawExpr{
 							X: func() string {
 								if t.mariadb() {
-									return "current_timestamp(6)"
+									return "(current_timestamp(6))"
 								}
 								return "CURRENT_TIMESTAMP(6)"
 							}(),

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -542,7 +542,7 @@ var reCurrTimestamp = regexp.MustCompile(`(?i)^current_timestamp(?:\(\d?\))?$`)
 func (i *inspect) myDefaultExpr(c *schema.Column, x string, attr *extraAttr) schema.Expr {
 	// In MySQL, the DEFAULT_GENERATED indicates the column has an expression default value.
 	if i.supportsExprDefault() && attr.defaultGenerated {
-		return &schema.RawExpr{X: x}
+		return &schema.RawExpr{X: sqlx.MayWrap(x)}
 	}
 	switch c.Type.Type.(type) {
 	case *schema.BinaryType:
@@ -556,7 +556,7 @@ func (i *inspect) myDefaultExpr(c *schema.Column, x string, attr *extraAttr) sch
 		// "current_timestamp" is exceptional in old versions
 		// of MySQL for timestamp and datetime data types.
 		if reCurrTimestamp.MatchString(x) {
-			return &schema.RawExpr{X: x}
+			return &schema.RawExpr{X: sqlx.MayWrap(x)}
 		}
 	}
 	return &schema.Literal{V: quote(x)}

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -542,6 +542,10 @@ var reCurrTimestamp = regexp.MustCompile(`(?i)^current_timestamp(?:\(\d?\))?$`)
 func (i *inspect) myDefaultExpr(c *schema.Column, x string, attr *extraAttr) schema.Expr {
 	// In MySQL, the DEFAULT_GENERATED indicates the column has an expression default value.
 	if i.supportsExprDefault() && attr.defaultGenerated {
+		// CURRENT_TIMESTAMP is an exception for MySQL
+		if _, ok := c.Type.Type.(*schema.TimeType); ok && reCurrTimestamp.MatchString(x) {
+			return &schema.RawExpr{X: x}
+		}
 		return &schema.RawExpr{X: sqlx.MayWrap(x)}
 	}
 	switch c.Type.Type.(type) {
@@ -556,7 +560,7 @@ func (i *inspect) myDefaultExpr(c *schema.Column, x string, attr *extraAttr) sch
 		// "current_timestamp" is exceptional in old versions
 		// of MySQL for timestamp and datetime data types.
 		if reCurrTimestamp.MatchString(x) {
-			return &schema.RawExpr{X: sqlx.MayWrap(x)}
+			return &schema.RawExpr{X: x}
 		}
 	}
 	return &schema.Literal{V: quote(x)}
@@ -620,7 +624,7 @@ func (i *inspect) marDefaultExpr(c *schema.Column, x string) schema.Expr {
 		// "current_timestamp" is exceptional in old versions
 		// of MySQL (i.e. MariaDB in this case).
 		if strings.ToLower(x) == currentTS {
-			return &schema.RawExpr{X: sqlx.MayWrap(x)}
+			return &schema.RawExpr{X: x}
 		}
 	}
 	if !i.supportsExprDefault() {

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -542,7 +542,7 @@ var reCurrTimestamp = regexp.MustCompile(`(?i)^current_timestamp(?:\(\d?\))?$`)
 func (i *inspect) myDefaultExpr(c *schema.Column, x string, attr *extraAttr) schema.Expr {
 	// In MySQL, the DEFAULT_GENERATED indicates the column has an expression default value.
 	if i.supportsExprDefault() && attr.defaultGenerated {
-		// CURRENT_TIMESTAMP is an exception for MySQL
+		// Skip CURRENT_TIMESTAMP, because wrapping it with parens will translate it to now().
 		if _, ok := c.Type.Type.(*schema.TimeType); ok && reCurrTimestamp.MatchString(x) {
 			return &schema.RawExpr{X: x}
 		}

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -620,13 +620,13 @@ func (i *inspect) marDefaultExpr(c *schema.Column, x string) schema.Expr {
 		// "current_timestamp" is exceptional in old versions
 		// of MySQL (i.e. MariaDB in this case).
 		if strings.ToLower(x) == currentTS {
-			return &schema.RawExpr{X: x}
+			return &schema.RawExpr{X: sqlx.MayWrap(x)}
 		}
 	}
 	if !i.supportsExprDefault() {
 		return &schema.Literal{V: quote(x)}
 	}
-	return &schema.RawExpr{X: x}
+	return &schema.RawExpr{X: sqlx.MayWrap(x)}
 }
 
 func (i *inspect) querySchema(ctx context.Context, query string, s *schema.Schema) (*sql.Rows, error) {


### PR DESCRIPTION
This is an optimistic attempt at a fix for expressions/functions in schema. Feel free to correct and guide me towards a better solve. :)

The wrapping is somewhat redundant when we already have `sql()` but [going by the comments in code](https://github.com/ariga/atlas/blob/60c0ed8bff94979c621c3453426a46c3ad44ee46/sql/mysql/migrate.go#L676-L677), backwards compatibility has made the situation a little messy.

Fixes #795 

Note: Initially, MySQL looked like it was working fine without this change.
But if we tried to inspect -> drop database -> create. We ended up with string default instead of an expression.