### PR TITLE
docs: update to use homebrew-core tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Atlas CLI is an open source tool that helps developers manage their database sch
 
 ## Quick Installation
 
-On macOS:
+On macOS via [Homebrew](https://brew.sh/):
 
 ```shell
-brew install ariga/tap/atlas
+brew install atlas
 ```
 
 Click [here](https://atlasgo.io/cli/getting-started/setting-up) to read instructions for other platforms.


### PR DESCRIPTION
I have [included the formula into the homebrew-core](https://github.com/Homebrew/homebrew-core/pull/93668), it would be better to use that one (it is also well maintained :) )

---

use stats in the past months:

```
$ brew info atlas
...
==> Analytics
install: 96 (30 days), 295 (90 days), 404 (365 days)
install-on-request: 97 (30 days), 296 (90 days), 405 (365 days)
build-error: 0 (30 days)
```