### PR TITLE
cmd/atlascmd/migrate: introduce SchemaChanger interface

### DIFF
--- a/cmd/atlascmd/migrate/migrate.go
+++ b/cmd/atlascmd/migrate/migrate.go
@@ -85,7 +85,7 @@ func (r *EntRevisions) Init(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	r.ec = ent.NewClient(ent.Driver(sql.OpenDB(sc.Name, sc.DB)))
+	r.ec = ent.NewClient(ent.Driver(sql.OpenDB(r.sc.Name, r.sc.DB)))
 	return r.ec.Schema.Create(ctx, entschema.WithAtlas(true))
 }
 

--- a/cmd/atlascmd/migrate/migrate_test.go
+++ b/cmd/atlascmd/migrate/migrate_test.go
@@ -23,6 +23,9 @@ func TestEntRevisions_Init(t *testing.T) {
 	)
 	require.NoError(t, err)
 	r, err := NewEntRevisions(c)
+	t.Cleanup(func() {
+		r.Close()
+	})
 	require.NoError(t, err)
 
 	require.NoError(t, r.Init(context.Background()))

--- a/internal/integration/cockroach_test.go
+++ b/internal/integration/cockroach_test.go
@@ -284,6 +284,10 @@ func TestCockroach_Enums(t *testing.T) {
 	})
 }
 
+func (t *crdbTest) url() string {
+	return t.dsn()
+}
+
 func (t *crdbTest) dsn() string {
 	return fmt.Sprintf("postgres://postgres:pass@localhost:%d/test?sslmode=disable", t.port)
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -475,6 +475,9 @@ func testEntRevisions(t T) {
 
 	r, err := entmigrate.NewEntRevisions(c, entmigrate.WithSchema(name))
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		r.Close()
+	})
 
 	require.NoError(t, r.Init(context.Background()))
 	t.dropSchemas(name)

--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -79,6 +79,12 @@ func myRun(t *testing.T, fn func(*myTest)) {
 	}
 }
 
+func TestMySQL_EntRevisions(t *testing.T) {
+	myRun(t, func(t *myTest) {
+		testEntRevisions(t)
+	})
+}
+
 func TestMySQL_Executor(t *testing.T) {
 	myRun(t, func(t *myTest) {
 		testExecutor(t)
@@ -661,7 +667,7 @@ func TestMySQL_CLI_MultiSchema(t *testing.T) {
 			}`
 	t.Run("SchemaInspect", func(t *testing.T) {
 		myRun(t, func(t *myTest) {
-			t.dropDB("test2")
+			t.dropSchemas("test2")
 			t.dropTables("users")
 			attrs := t.defaultAttrs()
 			charset, collate := attrs[0].(*schema.Charset), attrs[1].(*schema.Collation)
@@ -670,7 +676,7 @@ func TestMySQL_CLI_MultiSchema(t *testing.T) {
 	})
 	t.Run("SchemaApply", func(t *testing.T) {
 		myRun(t, func(t *myTest) {
-			t.dropDB("test2")
+			t.dropSchemas("test2")
 			t.dropTables("users")
 			attrs := t.defaultAttrs()
 			charset, collate := attrs[0].(*schema.Charset), attrs[1].(*schema.Collation)
@@ -681,7 +687,7 @@ func TestMySQL_CLI_MultiSchema(t *testing.T) {
 
 func TestMySQL_HCL_Realm(t *testing.T) {
 	myRun(t, func(t *myTest) {
-		t.dropDB("second")
+		t.dropSchemas("second")
 		realm := t.loadRealm()
 		hcl, err := mysql.MarshalHCL(realm)
 		require.NoError(t, err)
@@ -1178,6 +1184,10 @@ create table atlas_types_sanity
 	})
 }
 
+func (t *myTest) url() string {
+	return t.dsn("")
+}
+
 func (t *myTest) dsn(dbname string) string {
 	d := "mysql"
 	pass := ":pass"
@@ -1240,7 +1250,7 @@ func (t *myTest) dropTables(names ...string) {
 	})
 }
 
-func (t *myTest) dropDB(names ...string) {
+func (t *myTest) dropSchemas(names ...string) {
 	t.Cleanup(func() {
 		for _, n := range names {
 			_, err := t.db.Exec("DROP DATABASE IF EXISTS " + n)

--- a/internal/integration/postgres_test.go
+++ b/internal/integration/postgres_test.go
@@ -80,6 +80,12 @@ func pgRun(t *testing.T, fn func(*pgTest)) {
 	}
 }
 
+func TestPostgres_EntRevisions(t *testing.T) {
+	pgRun(t, func(t *pgTest) {
+		testEntRevisions(t)
+	})
+}
+
 func TestPostgres_Executor(t *testing.T) {
 	pgRun(t, func(t *pgTest) {
 		testExecutor(t)
@@ -1031,6 +1037,10 @@ create table atlas_types_sanity
 			testImplicitIndexes(t, t.db)
 		})
 	})
+}
+
+func (t *pgTest) url() string {
+	return t.dsn()
 }
 
 func (t *pgTest) dsn() string {

--- a/internal/integration/sqlite_test.go
+++ b/internal/integration/sqlite_test.go
@@ -57,6 +57,9 @@ func TestSQLite_EntRevisions(t *testing.T) {
 
 		r, err := entmigrate.NewEntRevisions(c)
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			r.Close()
+		})
 
 		require.NoError(t, r.Init(context.Background()))
 

--- a/internal/integration/sqlite_test.go
+++ b/internal/integration/sqlite_test.go
@@ -15,9 +15,12 @@ import (
 	"strings"
 	"testing"
 
+	entmigrate "ariga.io/atlas/cmd/atlascmd/migrate"
+	"ariga.io/atlas/cmd/atlascmd/migrate/ent/revision"
 	"ariga.io/atlas/sql/migrate"
 	"ariga.io/atlas/sql/postgres"
 	"ariga.io/atlas/sql/schema"
+	"ariga.io/atlas/sql/sqlclient"
 	"ariga.io/atlas/sql/sqlite"
 
 	"entgo.io/ent/dialect"
@@ -45,6 +48,23 @@ func liteRun(t *testing.T, fn func(test *liteTest)) {
 	require.NoError(t, err)
 	tt := &liteTest{T: t, db: db, drv: drv, file: f, rrw: &rrw{}}
 	fn(tt)
+}
+
+func TestSQLite_EntRevisions(t *testing.T) {
+	liteRun(t, func(t *liteTest) {
+		c, err := sqlclient.Open(context.Background(), t.url())
+		require.NoError(t, err)
+
+		r, err := entmigrate.NewEntRevisions(c)
+		require.NoError(t, err)
+
+		require.NoError(t, r.Init(context.Background()))
+
+		s, err := c.InspectSchema(context.Background(), "", nil)
+		require.NoError(t, err)
+		_, ok := s.Table(revision.Table)
+		require.True(t, ok)
+	})
 }
 
 func TestSQLite_Executor(t *testing.T) {
@@ -785,6 +805,8 @@ func (t *liteTest) revisionsStorage() migrate.RevisionReadWriter {
 	return t.rrw
 }
 
+func (t *liteTest) dropSchemas(...string) {}
+
 func (t *liteTest) applyHcl(spec string) {
 	realm := t.loadRealm()
 	var desired schema.Schema
@@ -934,6 +956,10 @@ func (t *liteTest) dropTables(names ...string) {
 
 func (t *liteTest) dsn() string {
 	return fmt.Sprintf("sqlite://file:%s?cache=shared&_fk=1", t.file)
+}
+
+func (t *liteTest) url() string {
+	return t.dsn()
 }
 
 func (t *liteTest) applyRealmHcl(spec string) {

--- a/internal/integration/tidb_test.go
+++ b/internal/integration/tidb_test.go
@@ -67,6 +67,12 @@ func tidbRun(t *testing.T, fn func(*myTest)) {
 	}
 }
 
+func TestTiDB_EntRevisions(t *testing.T) {
+	tidbRun(t, func(t *myTest) {
+		testEntRevisions(t)
+	})
+}
+
 func TestTiDB_AddDropTable(t *testing.T) {
 	tidbRun(t, func(t *myTest) {
 		testAddDrop(t)
@@ -471,7 +477,7 @@ func TestTiDB_ForeignKey(t *testing.T) {
 
 func TestTiDB_HCL_Realm(t *testing.T) {
 	tidbRun(t, func(t *myTest) {
-		t.dropDB("second")
+		t.dropSchemas("second")
 		realm := t.loadRealm()
 		hcl, err := mysql.MarshalHCL(realm)
 		require.NoError(t, err)
@@ -547,7 +553,7 @@ func TestTiDB_CLI_MultiSchema(t *testing.T) {
 			}`
 	t.Run("SchemaInspect", func(t *testing.T) {
 		tidbRun(t, func(t *myTest) {
-			t.dropDB("test2")
+			t.dropSchemas("test2")
 			t.dropTables("users")
 			attrs := t.defaultAttrs()
 			charset, collate := attrs[0].(*schema.Charset), attrs[1].(*schema.Collation)
@@ -556,7 +562,7 @@ func TestTiDB_CLI_MultiSchema(t *testing.T) {
 	})
 	t.Run("SchemaApply", func(t *testing.T) {
 		tidbRun(t, func(t *myTest) {
-			t.dropDB("test2")
+			t.dropSchemas("test2")
 			t.dropTables("users")
 			attrs := t.defaultAttrs()
 			charset, collate := attrs[0].(*schema.Charset), attrs[1].(*schema.Collation)

--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -247,11 +247,6 @@ func (parser) ChangeSchema(u *url.URL, s string) *url.URL {
 	return &nu
 }
 
-// parse returns an enriched sqlclient.URL from a url.URL.
-func parse(u *url.URL) *sqlclient.URL {
-	return &sqlclient.URL{URL: u, DSN: dsn(u), Schema: strings.TrimPrefix(u.Path, "/")}
-}
-
 // dsn returns the MySQL standard DSN for opening
 // the sql.DB from the user provided URL.
 func dsn(u *url.URL) string {

--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -44,9 +44,7 @@ func init() {
 		sqlclient.DriverOpener(Open),
 		sqlclient.RegisterCodec(MarshalHCL, EvalHCL),
 		sqlclient.RegisterFlavours("maria", "mariadb"),
-		sqlclient.RegisterURLParser(func(u *url.URL) *sqlclient.URL {
-			return &sqlclient.URL{URL: u, DSN: dsn(u), Schema: strings.TrimPrefix(u.Path, "/")}
-		}),
+		sqlclient.RegisterURLParser(parser{}),
 	)
 }
 
@@ -233,6 +231,25 @@ func unescape(s string) string {
 		}
 	}
 	return b.String()
+}
+
+type parser struct{}
+
+// ParseURL implements the sqlclient.URLParser interface.
+func (parser) ParseURL(u *url.URL) *sqlclient.URL {
+	return &sqlclient.URL{URL: u, DSN: dsn(u), Schema: strings.TrimPrefix(u.Path, "/")}
+}
+
+// ChangeSchema implements the sqlclient.SchemaChanger interface.
+func (parser) ChangeSchema(u *url.URL, s string) *url.URL {
+	nu := *u
+	nu.Path = "/" + s
+	return &nu
+}
+
+// parse returns an enriched sqlclient.URL from a url.URL.
+func parse(u *url.URL) *sqlclient.URL {
+	return &sqlclient.URL{URL: u, DSN: dsn(u), Schema: strings.TrimPrefix(u.Path, "/")}
 }
 
 // dsn returns the MySQL standard DSN for opening

--- a/sql/postgres/crdb.go
+++ b/sql/postgres/crdb.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"net/url"
 	"regexp"
 	"strings"
 
@@ -40,9 +39,7 @@ func init() {
 		sqlclient.DriverOpener(OpenCRDB),
 		sqlclient.RegisterCodec(MarshalHCL, EvalHCL),
 		sqlclient.RegisterFlavours("crdb"),
-		sqlclient.RegisterURLParser(func(u *url.URL) *sqlclient.URL {
-			return &sqlclient.URL{URL: u, DSN: u.String(), Schema: u.Query().Get("search_path")}
-		}),
+		sqlclient.RegisterURLParser(parser{}),
 	)
 }
 

--- a/sql/postgres/driver.go
+++ b/sql/postgres/driver.go
@@ -45,9 +45,7 @@ func init() {
 		"postgres",
 		sqlclient.DriverOpener(Open),
 		sqlclient.RegisterCodec(MarshalHCL, EvalHCL),
-		sqlclient.RegisterURLParser(func(u *url.URL) *sqlclient.URL {
-			return &sqlclient.URL{URL: u, DSN: u.String(), Schema: u.Query().Get("search_path")}
-		}),
+		sqlclient.RegisterURLParser(parser{}),
 	)
 }
 
@@ -161,6 +159,27 @@ func acquire(ctx context.Context, conn schema.ExecQuerier, id uint32, timeout ti
 		}
 		return nil
 	}
+}
+
+type parser struct{}
+
+// ParseURL implements the sqlclient.URLParser interface.
+func (parser) ParseURL(u *url.URL) *sqlclient.URL {
+	return &sqlclient.URL{URL: u, DSN: u.String(), Schema: u.Query().Get("search_path")}
+}
+
+// ChangeSchema implements the sqlclient.SchemaChanger interface.
+func (parser) ChangeSchema(u *url.URL, s string) *url.URL {
+	nu := *u
+	q := nu.Query()
+	q.Set("search_path", s)
+	nu.RawQuery = q.Encode()
+	return &nu
+}
+
+// parse returns an enriched sqlclient.URL from a url.URL.
+func parse(u *url.URL) *sqlclient.URL {
+	return &sqlclient.URL{URL: u, DSN: u.String(), Schema: u.Query().Get("search_path")}
 }
 
 // Standard column types (and their aliases) as defined in

--- a/sql/postgres/driver.go
+++ b/sql/postgres/driver.go
@@ -177,11 +177,6 @@ func (parser) ChangeSchema(u *url.URL, s string) *url.URL {
 	return &nu
 }
 
-// parse returns an enriched sqlclient.URL from a url.URL.
-func parse(u *url.URL) *sqlclient.URL {
-	return &sqlclient.URL{URL: u, DSN: u.String(), Schema: u.Query().Get("search_path")}
-}
-
 // Standard column types (and their aliases) as defined in
 // PostgreSQL codebase/website.
 const (

--- a/sql/sqlclient/client.go
+++ b/sql/sqlclient/client.go
@@ -128,6 +128,7 @@ type (
 	OpenOption func(*config) error
 )
 
+// ErrUnsupported is returned if a registered driver does not support changing the schema.
 var ErrUnsupported = errors.New("sql/sqlclient: driver does not support changing connected schema")
 
 // Open opens an Atlas client by its provided url string.

--- a/sql/sqlclient/client.go
+++ b/sql/sqlclient/client.go
@@ -119,13 +119,13 @@ func (f URLParserFunc) ParseURL(u *url.URL) *URL {
 var drivers sync.Map
 
 type (
-	// config holds additional configuration values for opening a Client.
-	config struct {
+	// openOptions holds additional configuration values for opening a Client.
+	openOptions struct {
 		schema string
 	}
 
-	// OpenOption allows to configure a config using functional arguments.
-	OpenOption func(*config) error
+	// OpenOption allows to configure a openOptions using functional arguments.
+	OpenOption func(*openOptions) error
 )
 
 // ErrUnsupported is returned if a registered driver does not support changing the schema.
@@ -142,7 +142,7 @@ func Open(ctx context.Context, s string, opts ...OpenOption) (*Client, error) {
 
 // OpenURL opens an Atlas client by its provided url.URL.
 func OpenURL(ctx context.Context, u *url.URL, opts ...OpenOption) (*Client, error) {
-	cfg := &config{}
+	cfg := &openOptions{}
 	for _, opt := range opts {
 		if err := opt(cfg); err != nil {
 			return nil, err
@@ -173,7 +173,7 @@ func OpenURL(ctx context.Context, u *url.URL, opts ...OpenOption) (*Client, erro
 // OpenSchema opens the connection to the given schema.
 // If the registered driver does not support this, ErrUnsupported is returned instead.
 func OpenSchema(s string) OpenOption {
-	return func(c *config) error {
+	return func(c *openOptions) error {
 		c.schema = s
 		return nil
 	}

--- a/sql/sqlclient/client_test.go
+++ b/sql/sqlclient/client_test.go
@@ -23,9 +23,9 @@ func TestRegisterOpen(t *testing.T) {
 			return c, nil
 		}),
 		sqlclient.RegisterFlavours("maria"),
-		sqlclient.RegisterURLParser(func(u *url.URL) *sqlclient.URL {
+		sqlclient.RegisterURLParser(sqlclient.URLParserFunc(func(u *url.URL) *sqlclient.URL {
 			return &sqlclient.URL{URL: u, DSN: "dsn", Schema: "schema"}
-		}),
+		})),
 	)
 	require.PanicsWithValue(
 		t,

--- a/sql/sqlite/driver.go
+++ b/sql/sqlite/driver.go
@@ -48,9 +48,9 @@ func init() {
 		sqlclient.DriverOpener(Open),
 		sqlclient.RegisterCodec(MarshalHCL, EvalHCL),
 		sqlclient.RegisterFlavours("sqlite"),
-		sqlclient.RegisterURLParser(func(u *url.URL) *sqlclient.URL {
+		sqlclient.RegisterURLParser(sqlclient.URLParserFunc(func(u *url.URL) *sqlclient.URL {
 			return &sqlclient.URL{URL: u, DSN: strings.TrimPrefix(u.String(), u.Scheme+"://"), Schema: mainFile}
-		}),
+		})),
 	)
 }
 


### PR DESCRIPTION
Ent based schema revisions are stored in its own database schema (except SQLite). The responsibility for parsing and editing connection URLs lay at the drivers. Ent based revisions introduce a new interface for the drivers to implement in order to alter the originally given connection URL to connect to another schema to store revisions table in.