### PR TITLE
sql/migrate: refactor execution (in preparation for transactions)

### DIFF
--- a/cmd/atlascmd/migrate/migrate.go
+++ b/cmd/atlascmd/migrate/migrate.go
@@ -109,24 +109,18 @@ func (r *EntRevisions) ReadRevisions(ctx context.Context) (migrate.Revisions, er
 	return ret, nil
 }
 
-// WriteRevisions writes the revisions to the revisions table.
-func (r *EntRevisions) WriteRevisions(ctx context.Context, rs migrate.Revisions) error {
-	bulk := make([]*ent.RevisionCreate, len(rs))
-	for i, rev := range rs {
-		bulk[i] = r.ec.Revision.Create().
-			SetID(rev.Version).
-			SetDescription(rev.Description).
-			SetExecutionState(revision.ExecutionState(rev.ExecutionState)).
-			SetExecutedAt(rev.ExecutedAt).
-			SetExecutionTime(rev.ExecutionTime).
-			SetHash(rev.Hash).
-			SetOperatorVersion(rev.OperatorVersion).
-			SetMeta(rev.Meta)
-	}
-	return r.ec.Revision.CreateBulk(bulk...).
-		OnConflict(
-			sql.ConflictColumns(revision.FieldID),
-		).
+// WriteRevision writes a revision to the revisions table.
+func (r *EntRevisions) WriteRevision(ctx context.Context, rev *migrate.Revision) error {
+	return r.ec.Revision.Create().
+		SetID(rev.Version).
+		SetDescription(rev.Description).
+		SetExecutionState(revision.ExecutionState(rev.ExecutionState)).
+		SetExecutedAt(rev.ExecutedAt).
+		SetExecutionTime(rev.ExecutionTime).
+		SetHash(rev.Hash).
+		SetOperatorVersion(rev.OperatorVersion).
+		SetMeta(rev.Meta).
+		OnConflict(sql.ConflictColumns(revision.FieldID)).
 		UpdateNewValues().
 		Exec(ctx)
 }


### PR DESCRIPTION
This PR refactors the migration execution into two methods instead of one.

1. Compute the pending migration files
2. Execute a migration file onto a database

The above changes are needed to be able to wrap the execution of a migration file in a transaction. Splitting this into the two above methods also enables concurrent migration of multi-tenancy setups and keep them in sync before executing a new migration file.

Wrapping a migration execution in a transaction is should be controlled by the consumer instead of the executor itself. 