### PR TITLE
sql/sqlclient: use shared driver instance for different flavors

### DIFF
--- a/sql/sqlclient/client.go
+++ b/sql/sqlclient/client.go
@@ -325,15 +325,11 @@ func Register(name string, opener Opener, opts ...RegisterOption) {
 			return c, nil
 		})
 	}
+	drv := &driver{opener, name, opt.parser, opt.openDriver}
 	for _, f := range append(opt.flavours, name) {
 		if _, ok := drivers.Load(f); ok {
 			panic("sql/sqlclient: Register called twice for " + f)
 		}
-		drivers.Store(f, &driver{
-			name:       name,
-			parser:     opt.parser,
-			openDriver: opt.openDriver,
-			Opener:     opener,
-		})
+		drivers.Store(f, drv)
 	}
 }


### PR DESCRIPTION
Background: A driver registers its `Open` on the `driver`, but the current logic does this only for the first called flavor. The change in this PR ensure the same data, regardless of the flavor used to open an Atlas driver.