### PR TITLE
sql/mysql: can inspect indexes which are not support comment

### DIFF
--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -193,10 +193,10 @@ func (d *conn) supportsRenameColumn() bool {
 
 // supportsIndexComment reports if the connected database
 // supports comments on indexes.
-func (d *conn) supportsIndexComment() bool {
+func (c *conn) supportsIndexComment() bool {
 	// According to Oracle release notes, comments on
 	// indexes were added in version 5.5.3.
-	return d.mariadb() || d.gteV("5.5.3")
+	return c.mariadb() || c.gteV("5.5.3")
 }
 
 // mariadb reports if the Driver is connected to a MariaDB database.

--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -195,7 +195,7 @@ func (d *conn) supportsRenameColumn() bool {
 // supports the index comment.
 func (d *conn) supportsIndexComment() bool {
 	// According to release notes
-	// MySQL 5.5.3 starts supprinting the index comment
+	// MySQL 5.5.3 starts supporting the index comment
 	return d.mariadb() || d.gteV("5.5.3")
 }
 

--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -194,7 +194,9 @@ func (d *conn) supportsRenameColumn() bool {
 // supportsIndexComment reports if the connected database
 // supports the index comment.
 func (d *conn) supportsIndexComment() bool {
-	return d.mariadb() || d.gteV("5.5.0")
+	// According to release notes
+	// MySQL 5.5.3 starts supprinting the index comment
+	return d.mariadb() || d.gteV("5.5.3")
 }
 
 // mariadb reports if the Driver is connected to a MariaDB database.

--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -191,6 +191,12 @@ func (d *conn) supportsRenameColumn() bool {
 	return d.gteV(v)
 }
 
+// supportsIndexComment reports if the connected database
+// supports the index comment.
+func (d *conn) supportsIndexComment() bool {
+	return d.mariadb() || d.gteV("5.5.0")
+}
+
 // mariadb reports if the Driver is connected to a MariaDB database.
 func (d *conn) mariadb() bool {
 	return strings.Index(d.version, "MariaDB") > 0

--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -192,10 +192,10 @@ func (d *conn) supportsRenameColumn() bool {
 }
 
 // supportsIndexComment reports if the connected database
-// supports the index comment.
+// supports comments on indexes.
 func (d *conn) supportsIndexComment() bool {
-	// According to release notes
-	// MySQL 5.5.3 starts supporting the index comment
+	// According to Oracle release notes, comments on
+	// indexes were added in version 5.5.3.
 	return d.mariadb() || d.gteV("5.5.3")
 }
 

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -293,14 +293,7 @@ func (i *inspect) addColumn(s *schema.Schema, rows *sql.Rows) error {
 
 // indexes queries and appends the indexes of the given table.
 func (i *inspect) indexes(ctx context.Context, s *schema.Schema) error {
-	query := indexesNoCommentQuery
-	if i.supportsIndexComment() {
-		query = indexesQuery
-	}
-
-	if i.supportsIndexExpr() {
-		query = indexesExprQuery
-	}
+	query := i.indexQuery()
 	rows, err := i.querySchema(ctx, query, s)
 	if err != nil {
 		return fmt.Errorf("mysql: query schema %q indexes: %w", s.Name, err)
@@ -444,6 +437,20 @@ func (i *inspect) checks(ctx context.Context, s *schema.Schema) error {
 		t.Attrs = append(t.Attrs, check)
 	}
 	return rows.Err()
+}
+
+// indexQuery returns the query to retrieve the indexes of the given table.
+func (i *inspect) indexQuery() string {
+	query := indexesNoCommentQuery
+	if i.supportsIndexComment() {
+		query = indexesQuery
+	}
+
+	if i.supportsIndexExpr() {
+		query = indexesExprQuery
+	}
+
+	return query
 }
 
 // extraAttr is a parsed version of the information_schema EXTRA column.

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -445,11 +445,9 @@ func (i *inspect) indexQuery() string {
 	if i.supportsIndexComment() {
 		query = indexesQuery
 	}
-
 	if i.supportsIndexExpr() {
 		query = indexesExprQuery
 	}
-
 	return query
 }
 

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -293,7 +293,11 @@ func (i *inspect) addColumn(s *schema.Schema, rows *sql.Rows) error {
 
 // indexes queries and appends the indexes of the given table.
 func (i *inspect) indexes(ctx context.Context, s *schema.Schema) error {
-	query := indexesQuery
+	query := indexesNoCommentQuery
+	if i.supportsIndexComment() {
+		query = indexesQuery
+	}
+
 	if i.supportsIndexExpr() {
 		query = indexesExprQuery
 	}
@@ -658,8 +662,9 @@ const (
 	columnsExprQuery = "SELECT `TABLE_NAME`, `COLUMN_NAME`, `COLUMN_TYPE`, `COLUMN_COMMENT`, `IS_NULLABLE`, `COLUMN_KEY`, `COLUMN_DEFAULT`, `EXTRA`, `CHARACTER_SET_NAME`, `COLLATION_NAME`, `GENERATION_EXPRESSION` FROM `INFORMATION_SCHEMA`.`COLUMNS` WHERE `TABLE_SCHEMA` = ? AND `TABLE_NAME` IN (%s) ORDER BY `ORDINAL_POSITION`"
 
 	// Query to list table indexes.
-	indexesQuery     = "SELECT `TABLE_NAME`, `INDEX_NAME`, `COLUMN_NAME`, `NON_UNIQUE`, `SEQ_IN_INDEX`, `INDEX_TYPE`, UPPER(`COLLATION`) = 'D' AS `DESC`, `INDEX_COMMENT`, `SUB_PART`, NULL AS `EXPRESSION` FROM `INFORMATION_SCHEMA`.`STATISTICS` WHERE `TABLE_SCHEMA` = ? AND `TABLE_NAME` IN (%s) ORDER BY `index_name`, `seq_in_index`"
-	indexesExprQuery = "SELECT `TABLE_NAME`, `INDEX_NAME`, `COLUMN_NAME`, `NON_UNIQUE`, `SEQ_IN_INDEX`, `INDEX_TYPE`, UPPER(`COLLATION`) = 'D' AS `DESC`, `INDEX_COMMENT`, `SUB_PART`, `EXPRESSION` FROM `INFORMATION_SCHEMA`.`STATISTICS` WHERE `TABLE_SCHEMA` = ? AND `TABLE_NAME` IN (%s) ORDER BY `index_name`, `seq_in_index`"
+	indexesQuery          = "SELECT `TABLE_NAME`, `INDEX_NAME`, `COLUMN_NAME`, `NON_UNIQUE`, `SEQ_IN_INDEX`, `INDEX_TYPE`, UPPER(`COLLATION`) = 'D' AS `DESC`, `INDEX_COMMENT`, `SUB_PART`, NULL AS `EXPRESSION` FROM `INFORMATION_SCHEMA`.`STATISTICS` WHERE `TABLE_SCHEMA` = ? AND `TABLE_NAME` IN (%s) ORDER BY `index_name`, `seq_in_index`"
+	indexesExprQuery      = "SELECT `TABLE_NAME`, `INDEX_NAME`, `COLUMN_NAME`, `NON_UNIQUE`, `SEQ_IN_INDEX`, `INDEX_TYPE`, UPPER(`COLLATION`) = 'D' AS `DESC`, `INDEX_COMMENT`, `SUB_PART`, `EXPRESSION` FROM `INFORMATION_SCHEMA`.`STATISTICS` WHERE `TABLE_SCHEMA` = ? AND `TABLE_NAME` IN (%s) ORDER BY `index_name`, `seq_in_index`"
+	indexesNoCommentQuery = "SELECT `TABLE_NAME`, `INDEX_NAME`, `COLUMN_NAME`, `NON_UNIQUE`, `SEQ_IN_INDEX`, `INDEX_TYPE`, UPPER(`COLLATION`) = 'D' AS `DESC`, NULL AS `INDEX_COMMENT`, `SUB_PART`, NULL AS `EXPRESSION` FROM `INFORMATION_SCHEMA`.`STATISTICS` WHERE `TABLE_SCHEMA` = ? AND `TABLE_NAME` IN (%s) ORDER BY `index_name`, `seq_in_index`"
 
 	tablesQuery = `
 SELECT

--- a/sql/mysql/inspect_test.go
+++ b/sql/mysql/inspect_test.go
@@ -19,13 +19,15 @@ import (
 
 // Single table queries used by the different tests.
 var (
-	queryFKs         = sqltest.Escape(fmt.Sprintf(fksQuery, "?"))
-	queryTable       = sqltest.Escape(fmt.Sprintf(tablesQuery, "?"))
-	queryColumns     = sqltest.Escape(fmt.Sprintf(columnsExprQuery, "?"))
-	queryIndexes     = sqltest.Escape(fmt.Sprintf(indexesQuery, "?"))
-	queryIndexesExpr = sqltest.Escape(fmt.Sprintf(indexesExprQuery, "?"))
-	queryMyChecks    = sqltest.Escape(fmt.Sprintf(myChecksQuery, "?"))
-	queryMarChecks   = sqltest.Escape(fmt.Sprintf(marChecksQuery, "?"))
+	queryFKs              = sqltest.Escape(fmt.Sprintf(fksQuery, "?"))
+	queryTable            = sqltest.Escape(fmt.Sprintf(tablesQuery, "?"))
+	queryColumns          = sqltest.Escape(fmt.Sprintf(columnsExprQuery, "?"))
+	queryColumnsNoExpr    = sqltest.Escape(fmt.Sprintf(columnsQuery, "?"))
+	queryIndexes          = sqltest.Escape(fmt.Sprintf(indexesQuery, "?"))
+	queryIndexesNoComment = sqltest.Escape(fmt.Sprintf(indexesNoCommentQuery, "?"))
+	queryIndexesExpr      = sqltest.Escape(fmt.Sprintf(indexesExprQuery, "?"))
+	queryMyChecks         = sqltest.Escape(fmt.Sprintf(myChecksQuery, "?"))
+	queryMarChecks        = sqltest.Escape(fmt.Sprintf(marChecksQuery, "?"))
 )
 
 func TestDriver_InspectTable(t *testing.T) {
@@ -234,14 +236,14 @@ func TestDriver_InspectTable(t *testing.T) {
 				m.ExpectQuery(queryColumns).
 					WithArgs("public", "users").
 					WillReturnRows(sqltest.Rows(`
-+------------+-------------------+--------------------+----------------+-------------+------------+----------------+-------+--------------------+----------------+---------------------------+ 
-| table_name |    column_name    | column_type        | column_comment | is_nullable | column_key | column_default | extra | character_set_name | collation_name | generation_expression     | 
-+------------+-------------------+--------------------+----------------+-------------+------------+----------------+-------+--------------------+----------------+---------------------------+ 
-| users      |  float            | float              |                | NO          |            |                |       | NULL               | NULL           | NULL                      | 
-| users      |  double           | double             |                | NO          |            |                |       | NULL               | NULL           | NULL                      | 
-| users      |  float_unsigned   | float unsigned     |                | NO          |            |                |       | NULL               | NULL           | NULL                      | 
-| users      |  double_unsigned  | double unsigned    |                | NO          |            |                |       | NULL               | NULL           | NULL                      | 
-| users      |  float_unsigned_p | float(10) unsigned |                | NO          |            |                |       | NULL               | NULL           | NULL                      | 
++------------+-------------------+--------------------+----------------+-------------+------------+----------------+-------+--------------------+----------------+---------------------------+
+| table_name |    column_name    | column_type        | column_comment | is_nullable | column_key | column_default | extra | character_set_name | collation_name | generation_expression     |
++------------+-------------------+--------------------+----------------+-------------+------------+----------------+-------+--------------------+----------------+---------------------------+
+| users      |  float            | float              |                | NO          |            |                |       | NULL               | NULL           | NULL                      |
+| users      |  double           | double             |                | NO          |            |                |       | NULL               | NULL           | NULL                      |
+| users      |  float_unsigned   | float unsigned     |                | NO          |            |                |       | NULL               | NULL           | NULL                      |
+| users      |  double_unsigned  | double unsigned    |                | NO          |            |                |       | NULL               | NULL           | NULL                      |
+| users      |  float_unsigned_p | float(10) unsigned |                | NO          |            |                |       | NULL               | NULL           | NULL                      |
 +------------+-------------------+--------------------+----------------+-------------+------------+----------------+-------+--------------------+----------------+---------------------------+
 `))
 				m.noIndexes()
@@ -421,18 +423,18 @@ func TestDriver_InspectTable(t *testing.T) {
 				m.ExpectQuery(queryColumns).
 					WithArgs("public", "users").
 					WillReturnRows(sqltest.Rows(`
-+------------+-------------+--------------------+----------------+-------------+------------+----------------+-------+--------------------+----------------+---------------------------+ 
-| table_name | column_name | column_type        | column_comment | is_nullable | column_key | column_default | extra | character_set_name | collation_name | GENERATION_EXPRESSION     | 
-+------------+-------------+--------------------+----------------+-------------+------------+----------------+-------+--------------------+----------------+---------------------------+ 
-| users      | c1          | point              |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      | 
-| users      | c2          | multipoint         |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      | 
-| users      | c3          | linestring         |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      | 
-| users      | c4          | multilinestring    |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      | 
-| users      | c5          | polygon            |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |  
-| users      | c6          | multipolygon       |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |  
-| users      | c7          | geometry           |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |  
-| users      | c8          | geometrycollection |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |  
-| users      | c9          | geomcollection     |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |  
++------------+-------------+--------------------+----------------+-------------+------------+----------------+-------+--------------------+----------------+---------------------------+
+| table_name | column_name | column_type        | column_comment | is_nullable | column_key | column_default | extra | character_set_name | collation_name | GENERATION_EXPRESSION     |
++------------+-------------+--------------------+----------------+-------------+------------+----------------+-------+--------------------+----------------+---------------------------+
+| users      | c1          | point              |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |
+| users      | c2          | multipoint         |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |
+| users      | c3          | linestring         |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |
+| users      | c4          | multilinestring    |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |
+| users      | c5          | polygon            |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |
+| users      | c6          | multipolygon       |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |
+| users      | c7          | geometry           |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |
+| users      | c8          | geometrycollection |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |
+| users      | c9          | geomcollection     |                | NO          |            | NULL           |       | NULL               | NULL           | NULL                      |
 +------------+-------------+--------------------+----------------+-------------+------------+----------------+-------+--------------------+----------------+---------------------------+
 `))
 				m.noIndexes()
@@ -562,19 +564,99 @@ func TestDriver_InspectTable(t *testing.T) {
 			},
 		},
 		{
+			name:    "indexes/not_support_comment",
+			version: "5.1.60",
+			before: func(m mock) {
+				m.tableExists("public", "users", true)
+				m.ExpectQuery(queryColumnsNoExpr).
+					WithArgs("public", "users").
+					WillReturnRows(sqltest.Rows(`
++------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+
+| TABLE_NAME | COLUMN_NAME | COLUMN_TYPE  | COLUMN_COMMENT | IS_NULLABLE | COLUMN_KEY | COLUMN_DEFAULT | EXTRA          | CHARACTER_SET_NAME | COLLATION_NAME     | GENERATION_EXPRESSION     |
++------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+
+| users      | id          | int          |                | NO          | PRI        | NULL           |                | NULL               | NULL               | NULL                      |
+| users      | nickname    | varchar(255) |                | NO          | UNI        | NULL           |                | utf8mb4            | utf8mb4_0900_ai_ci | NULL                      |
+| users      | oid         | int          |                | NO          | MUL        | NULL           |                | NULL               | NULL               | NULL                      |
+| users      | uid         | int          |                | NO          | MUL        | NULL           |                | NULL               | NULL               | NULL                      |
++------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+
+`))
+				m.ExpectQuery(queryIndexesNoComment).
+					WithArgs("public", "users").
+					WillReturnRows(sqltest.Rows(`
++--------------+--------------+-------------+------------+--------------+--------------+---------+--------------+------------+------------------+
+| TABLE_NAME   | INDEX_NAME   | COLUMN_NAME | NON_UNIQUE | SEQ_IN_INDEX | INDEX_TYPE   | DESC    | COMMENT      | SUB_PART   | EXPRESSION       |
++--------------+--------------+-------------+------------+--------------+--------------+---------+--------------+------------+------------------+
+| users        | nickname     | nickname    |          0 |            1 | BTREE        | nil     | NULL         |        255 |      NULL        |
+| users        | lower_nick   | NULL        |          1 |            1 | HASH         | 0       | NULL         |       NULL | lower(nickname)  |
+| users        | non_unique   | oid         |          1 |            1 | BTREE        | 0       | NULL         |       NULL |      NULL        |
+| users        | non_unique   | uid         |          1 |            2 | BTREE        | 0       | NULL         |       NULL |      NULL        |
+| users        | PRIMARY      | id          |          0 |            1 | BTREE        | 0       | NULL         |       NULL |      NULL        |
+| users        | unique_index | uid         |          0 |            1 | BTREE        | 1       | NULL         |       NULL |      NULL        |
+| users        | unique_index | oid         |          0 |            2 | BTREE        | 1       | NULL         |       NULL |      NULL        |
++--------------+--------------+-------------+------------+--------------+--------------+---------+--------------+------------+------------------+
+`))
+				m.noFKs()
+				m.ExpectQuery(sqltest.Escape("SHOW CREATE TABLE `public`.`users`")).
+					WillReturnRows(sqltest.Rows(`
++-------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| Table | Create Table                                                                                                                                |
++-------+---------------------------------------------------------------------------------------------------------------------------------------------+
++-------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| users | CREATE TABLE users (id bigint NOT NULL AUTO_INCREMENT) ENGINE=InnoDB AUTO_INCREMENT=55834574848 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
++-------+---------------------------------------------------------------------------------------------------------------------------------------------+
+`))
+			},
+			expect: func(require *require.Assertions, t *schema.Table, err error) {
+				require.NoError(err)
+				require.Equal("users", t.Name)
+				indexes := []*schema.Index{
+					{Name: "nickname", Unique: true, Table: t, Attrs: []schema.Attr{&IndexType{T: "BTREE"}}}, // Implicitly created by the UNIQUE clause.
+					{Name: "lower_nick", Table: t, Attrs: []schema.Attr{&IndexType{T: "HASH"}}},
+					{Name: "non_unique", Table: t, Attrs: []schema.Attr{&IndexType{T: "BTREE"}}},
+					{Name: "unique_index", Unique: true, Table: t, Attrs: []schema.Attr{&IndexType{T: "BTREE"}}},
+				}
+				columns := []*schema.Column{
+					{Name: "id", Type: &schema.ColumnType{Raw: "int", Type: &schema.IntegerType{T: "int"}}},
+					{Name: "nickname", Type: &schema.ColumnType{Raw: "varchar(255)", Type: &schema.StringType{T: "varchar", Size: 255}}, Indexes: indexes[0:1], Attrs: []schema.Attr{&schema.Charset{V: "utf8mb4"}, &schema.Collation{V: "utf8mb4_0900_ai_ci"}}},
+					{Name: "oid", Type: &schema.ColumnType{Raw: "int", Type: &schema.IntegerType{T: "int"}}, Indexes: indexes[2:]},
+					{Name: "uid", Type: &schema.ColumnType{Raw: "int", Type: &schema.IntegerType{T: "int"}}, Indexes: indexes[2:]},
+				}
+				// nickname
+				indexes[0].Parts = []*schema.IndexPart{
+					{SeqNo: 1, C: columns[1], Attrs: []schema.Attr{&SubPart{Len: 255}}},
+				}
+				// lower(nickname)
+				indexes[1].Parts = []*schema.IndexPart{
+					{SeqNo: 1, X: &schema.RawExpr{X: "lower(nickname)"}},
+				}
+				// oid, uid
+				indexes[2].Parts = []*schema.IndexPart{
+					{SeqNo: 1, C: columns[2]},
+					{SeqNo: 2, C: columns[3]},
+				}
+				// uid, oid
+				indexes[3].Parts = []*schema.IndexPart{
+					{SeqNo: 1, C: columns[3], Desc: true},
+					{SeqNo: 2, C: columns[2], Desc: true},
+				}
+				require.EqualValues(columns, t.Columns)
+				require.EqualValues(indexes, t.Indexes)
+			},
+		},
+		{
 			name: "fks",
 			before: func(m mock) {
 				m.tableExists("public", "users", true)
 				m.ExpectQuery(queryColumns).
 					WithArgs("public", "users").
 					WillReturnRows(sqltest.Rows(`
-+------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+ 
-| TABLE_NAME | COLUMN_NAME | COLUMN_TYPE  | COLUMN_COMMENT | IS_NULLABLE | COLUMN_KEY | COLUMN_DEFAULT | EXTRA          | CHARACTER_SET_NAME | COLLATION_NAME     | GENERATION_EXPRESSION     | 
-+------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+ 
-| users      | id          | int          |                | NO          | PRI        | NULL           |                | NULL               | NULL               | NULL                      | 
-| users      | oid         | int          |                | NO          | MUL        | NULL           |                | NULL               | NULL               | NULL                      | 
-| users      | uid         | int          |                | NO          | MUL        | NULL           |                | NULL               | NULL               | NULL                      | 
-+------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+ 
++------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+
+| TABLE_NAME | COLUMN_NAME | COLUMN_TYPE  | COLUMN_COMMENT | IS_NULLABLE | COLUMN_KEY | COLUMN_DEFAULT | EXTRA          | CHARACTER_SET_NAME | COLLATION_NAME     | GENERATION_EXPRESSION     |
++------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+
+| users      | id          | int          |                | NO          | PRI        | NULL           |                | NULL               | NULL               | NULL                      |
+| users      | oid         | int          |                | NO          | MUL        | NULL           |                | NULL               | NULL               | NULL                      |
+| users      | uid         | int          |                | NO          | MUL        | NULL           |                | NULL               | NULL               | NULL                      |
++------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+
 `))
 				m.noIndexes()
 				m.ExpectQuery(queryFKs).
@@ -617,12 +699,12 @@ func TestDriver_InspectTable(t *testing.T) {
 				m.ExpectQuery(queryColumns).
 					WithArgs("public", "users").
 					WillReturnRows(sqltest.Rows(`
-+-------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+ 
-| TABLE_NAME  | COLUMN_NAME | COLUMN_TYPE  | COLUMN_COMMENT | IS_NULLABLE | COLUMN_KEY | COLUMN_DEFAULT | EXTRA          | CHARACTER_SET_NAME | COLLATION_NAME     | GENERATION_EXPRESSION     | 
-+-------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+ 
-| users       | id          | int          |                | NO          | PRI        | NULL           |                | NULL               | NULL               | NULL                      | 
-| users       | c1          | int          |                | NO          | MUL        | NULL           |                | NULL               | NULL               | NULL                      | 
-+-------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+ 
++-------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+
+| TABLE_NAME  | COLUMN_NAME | COLUMN_TYPE  | COLUMN_COMMENT | IS_NULLABLE | COLUMN_KEY | COLUMN_DEFAULT | EXTRA          | CHARACTER_SET_NAME | COLLATION_NAME     | GENERATION_EXPRESSION     |
++-------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+
+| users       | id          | int          |                | NO          | PRI        | NULL           |                | NULL               | NULL               | NULL                      |
+| users       | c1          | int          |                | NO          | MUL        | NULL           |                | NULL               | NULL               | NULL                      |
++-------------+-------------+--------------+----------------+-------------+------------+----------------+----------------+--------------------+--------------------+---------------------------+
 `))
 				m.noIndexes()
 				m.noFKs()


### PR DESCRIPTION
Unfortunately, I'm using MySQL 5.1 which is not support comments on indexes.
The schema inspection for an older version of MySQL seems to be working with this PR.

I know MySQL 5.1 is too old to support. However, this PR will be helpful for unlucky people like me.