### PR TITLE
sql/migrate: StateReader if Dir has precedence

### DIFF
--- a/cmd/atlascmd/migrate/migrate.go
+++ b/cmd/atlascmd/migrate/migrate.go
@@ -66,11 +66,11 @@ func (r *EntRevisions) Init(ctx context.Context) error {
 		return r.ec.Schema.Create(ctx, entschema.WithAtlas(true))
 	}
 	// Driver does support changing schemas. Make sure the schema does exist before proceeding.
-	_, err2 := r.ac.InspectSchema(ctx, r.schema, &schema.InspectOptions{Mode: schema.InspectSchemas})
-	if err2 != nil && !schema.IsNotExistError(err2) {
-		return err2
+	_, err = r.ac.InspectSchema(ctx, r.schema, &schema.InspectOptions{Mode: schema.InspectSchemas})
+	if err != nil && !schema.IsNotExistError(err) {
+		return err
 	}
-	if schema.IsNotExistError(err2) {
+	if schema.IsNotExistError(err) {
 		if err := r.ac.ApplyChanges(ctx, []schema.Change{
 			&schema.AddSchema{S: &schema.Schema{Name: r.schema}},
 		}); err != nil {

--- a/sql/sqlite/driver.go
+++ b/sql/sqlite/driver.go
@@ -95,7 +95,7 @@ func (d *Driver) IsClean(ctx context.Context) (bool, error) {
 	return r == nil || len(r.Schemas) == 1 && r.Schemas[0].Name == mainFile && len(r.Schemas[0].Tables) == 0, nil
 }
 
-// Clean implements the inlined migrate.Clean interface to override the "emptying" behavior.
+// Clean implements the inlined Clean interface to override the "emptying" behavior.
 func (d *Driver) Clean(ctx context.Context) error {
 	for _, stmt := range []string{
 		"PRAGMA writable_schema = 1;",


### PR DESCRIPTION
This change is the first one in a series of PR's to gradually make the migration directory the source of truth for all migration related logic (scanning, formatting, reading state, ...)

In the future one migration directory will be configured for exactly one dialect, migration tool, etc.