### PR TITLE
cmd/atlas: do not error on empty migration plan

### DIFF
--- a/doc/md/cli/projects.md
+++ b/doc/md/cli/projects.md
@@ -13,7 +13,7 @@ environments when working with Atlas. A project file is a file named
 // Define an environment named "local"
 env "local" {
   // Declare where the schema definition file resides.
-  src = "./schema/project.hcl"
+  src = "./project/schema.hcl"
   
   // Define the URL of the database which is managed in
   // this environment.
@@ -75,7 +75,7 @@ to the environment block:
 ```hcl
 env "local" {
   url = "sqlite://test?mode=memory&_fk=1"
-  src = "./schema.hcl"
+  src = "schema.hcl"
   
   // Other attributes are passed as input values to "schema.hcl":
   tenant = "rotemtam"
@@ -105,7 +105,7 @@ variable "tenant" {
 
 env "local" {
   url = "sqlite://test?mode=memory&_fk=1"
-  src = "./schema.hcl"
+  src = "schema.hcl"
   
   // The value for "tenant" is determined by the user at runtime.
   tenant = var.tenant


### PR DESCRIPTION
Continue my manual testing on `atlas` today. Something I find weird and inconsistent with `atlas schema apply` is to fail in case the migration directory is synced with the desired state. See before and after:

<img width="760" alt="image" src="https://user-images.githubusercontent.com/7413593/177770570-fdb9438d-17cb-4c20-920a-c488115aca42.png">
