### PR TITLE
cmd/atlas/internal/ci: harden change loader

### DIFF
--- a/cmd/atlas/internal/ci/ci.go
+++ b/cmd/atlas/internal/ci/ci.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"ariga.io/atlas/sql/migrate"
+	"ariga.io/atlas/sql/schema"
 	"ariga.io/atlas/sql/sqlcheck"
 	"ariga.io/atlas/sql/sqlclient"
 )
@@ -169,7 +170,43 @@ type DevLoader struct {
 }
 
 // LoadChanges implements the ChangesLoader interface.
-func (d *DevLoader) LoadChanges(ctx context.Context, files []migrate.File) ([]*sqlcheck.File, error) {
+func (d *DevLoader) LoadChanges(ctx context.Context, base, files []migrate.File) (_ []*sqlcheck.File, err error) {
+	// Lock database so no one else interferes with our change detection.
+	l, ok := d.Dev.Driver.(schema.Locker)
+	if !ok {
+		return nil, errors.New("driver does not support locking")
+	}
+	unlock, err := l.Lock(ctx, "atlas_ci_change_detection", 0)
+	if err != nil {
+		return nil, fmt.Errorf("acquiring database lock: %w", err)
+	}
+	defer unlock()
+	// We need an empty database state to reliably replay the migration directory.
+	if err := migrate.IsClean(d.Dev.Driver, ctx); err != nil {
+		return nil, err
+	}
+	// Clean up after ourselves.
+	defer func() {
+		if err2 := migrate.Clean(d.Dev.Driver, ctx); err2 != nil {
+			if err != nil {
+				err = fmt.Errorf("%w: %v", err, err2)
+				return
+			}
+			err = err2
+		}
+	}()
+	// Bring the dev environment to the base point.
+	for _, f := range base {
+		stmt, err := d.Scan.Stmts(f)
+		if err != nil {
+			return nil, &FileError{File: f.Name(), Err: fmt.Errorf("scanning statements: %w", err)}
+		}
+		for _, s := range stmt {
+			if _, err := d.Dev.ExecContext(ctx, s); err != nil {
+				return nil, &FileError{File: f.Name(), Err: fmt.Errorf("executing statement: %q: %w", s, err)}
+			}
+		}
+	}
 	diff := make([]*sqlcheck.File, len(files))
 	current, err := d.Dev.InspectRealm(ctx, nil)
 	if err != nil {

--- a/cmd/atlas/internal/ci/run.go
+++ b/cmd/atlas/internal/ci/run.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"strings"
 	"text/template"
@@ -62,20 +61,8 @@ func (r *Runner) summary(ctx context.Context) (*SummaryReport, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Bring the dev environment to the base point.
-	for _, f := range base {
-		stmt, err := r.Dir.Stmts(f)
-		if err != nil {
-			return nil, &FileError{File: f.Name(), Err: fmt.Errorf("scanning statements: %w", err)}
-		}
-		for _, s := range stmt {
-			if _, err := r.Dev.ExecContext(ctx, s); err != nil {
-				return nil, &FileError{File: f.Name(), Err: fmt.Errorf("executing statement: %q: %w", s, err)}
-			}
-		}
-	}
 	l := &DevLoader{Dev: r.Dev, Scan: r.Dir}
-	files, err := l.LoadChanges(ctx, feat)
+	files, err := l.LoadChanges(ctx, base, feat)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/migrate/migrate_test.go
+++ b/sql/migrate/migrate_test.go
@@ -521,8 +521,8 @@ func (m *lockMockDriver) Lock(_ context.Context, name string, _ time.Duration) (
 func (m *lockMockDriver) released() bool {
 	return len(m.locks) == 0
 }
-func (m *emptyMockDriver) IsClean(context.Context) (bool, error) {
-	return true, nil
+func (m *emptyMockDriver) IsClean(context.Context) error {
+	return nil
 }
 
 type mockRevisionReadWriter migrate.Revisions

--- a/sql/sqlite/driver.go
+++ b/sql/sqlite/driver.go
@@ -87,12 +87,15 @@ func Open(db schema.ExecQuerier) (migrate.Driver, error) {
 }
 
 // IsClean implements the inlined IsClean interface to override what to consider a clean database.
-func (d *Driver) IsClean(ctx context.Context) (bool, error) {
+func (d *Driver) IsClean(ctx context.Context) error {
 	r, err := d.InspectRealm(ctx, nil)
 	if err != nil {
-		return false, err
+		return err
 	}
-	return r == nil || len(r.Schemas) == 1 && r.Schemas[0].Name == mainFile && len(r.Schemas[0].Tables) == 0, nil
+	if !(r == nil || (len(r.Schemas) == 1 && r.Schemas[0].Name == mainFile && len(r.Schemas[0].Tables) == 0)) {
+		return migrate.ErrNotClean
+	}
+	return nil
 }
 
 // Clean implements the inlined Clean interface to override the "emptying" behavior.


### PR DESCRIPTION
let change loader acquire a lock, handle base state, check for clean state of dev DB and clean up after itself.