### PR TITLE
doc/md: updating install from source instructions

### DIFF
--- a/doc/md/cli/reference.md
+++ b/doc/md/cli/reference.md
@@ -21,7 +21,13 @@ If you would like to build Atlas from source follow the instructions [here](http
 
 If you would like to build Atlas from source without the UI code run:
 ```shell
-go get ariga.io/atlas/cmd/atlas
+go install ariga.io/atlas/cmd/atlas@latest
+```
+This will install the latest version to your `$GOPATH/bin` directory.
+
+You can also build a specific version by using the [release tags](https://github.com/ariga/atlas/releases) published on GitHub, for example:
+```shell
+go install ariga.io/atlas/cmd/atlas@v0.4.2
 ```
 
 ## atlas env


### PR DESCRIPTION
Current instructions won't install `atlas` in a usable form, and are more for using Atlas in other ways.

This PR updates the docs to use the `go install` command instead, along with specifying version information, which is more likely to achieve what users are expecting when following other links in the docs to this section.