### PR TITLE
sql/migrate: introduce Snapshoter interface

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -937,6 +937,12 @@ func (dryRunDriver) Lock(context.Context, string, time.Duration) (schema.UnlockF
 	return func() error { return nil }, nil
 }
 
+// Snapshot implements the migrate.Snapshoter interface.
+func (dryRunDriver) Snapshot(context.Context) (migrate.RestoreFunc, error) {
+	// We dry-run, we don't execute anything. Snapshotting not required.
+	return func(context.Context) error { return nil }, nil
+}
+
 // WriteRevision overrides the wrapped migrate.RevisionReadWriter to not saved any changes to revisions.
 func (dryRunRevisions) WriteRevision(context.Context, *migrate.Revision) error {
 	return nil

--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -472,6 +472,10 @@ func (d *sqliteLockerDriver) Lock(context.Context, string, time.Duration) (schem
 	return func() error { return nil }, errLock
 }
 
+func (d *sqliteLockerDriver) Snapshot(ctx context.Context) (migrate.RestoreFunc, error) {
+	return d.Driver.(migrate.Snapshoter).Snapshot(ctx)
+}
+
 func countFiles(t *testing.T, p string) int {
 	files, err := os.ReadDir(p)
 	require.NoError(t, err)

--- a/internal/integration/postgres_test.go
+++ b/internal/integration/postgres_test.go
@@ -563,7 +563,11 @@ func TestPostgres_Snapshot(t *testing.T) {
 	pgRun(t, func(t *pgTest) {
 		client, err := sqlclient.Open(context.Background(), fmt.Sprintf("postgres://postgres:pass@localhost:%d/test?sslmode=disable&search_path=another", t.port))
 		require.NoError(t, err)
+
+		_, err = client.ExecContext(context.Background(), "CREATE SCHEMA another")
+		require.NoError(t, err)
 		t.Cleanup(func() {
+			_, err = client.ExecContext(context.Background(), "DROP SCHEMA IF EXISTS another")
 			require.NoError(t, client.Close())
 		})
 		drv := client.Driver

--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -117,6 +117,7 @@ func (d *Driver) Lock(ctx context.Context, name string, timeout time.Duration) (
 	}, nil
 }
 
+// Snapshot implements migrate.Snapshoter.
 func (d *Driver) Snapshot(ctx context.Context) (migrate.RestoreFunc, error) {
 	// If the connection is bound to a schema, we can restore the state if the schema has no tables.
 	s, err := d.InspectSchema(ctx, "", nil)

--- a/sql/postgres/driver.go
+++ b/sql/postgres/driver.go
@@ -57,7 +57,7 @@ func init() {
 
 func opener(_ context.Context, u *url.URL) (*sqlclient.Client, error) {
 	ur := parser{}.ParseURL(u)
-	db, err := sql.Open("postgres", ur.DSN)
+	db, err := sql.Open(DriverName, ur.DSN)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func opener(_ context.Context, u *url.URL) (*sqlclient.Client, error) {
 	}
 	drv.(*Driver).schema = ur.Schema
 	return &sqlclient.Client{
-		Name:   "postgres",
+		Name:   DriverName,
 		DB:     db,
 		URL:    ur,
 		Driver: drv,

--- a/sql/postgres/driver.go
+++ b/sql/postgres/driver.go
@@ -159,6 +159,7 @@ func (d *Driver) Lock(ctx context.Context, name string, timeout time.Duration) (
 	}, nil
 }
 
+// Snapshot implements migrate.Snapshoter.
 func (d *Driver) Snapshot(ctx context.Context) (migrate.RestoreFunc, error) {
 	// Postgres will only then be considered bound to a schema if the `search_path` was given.
 	// In all other cases, the connection is considered bound to the realm.

--- a/sql/sqlclient/client.go
+++ b/sql/sqlclient/client.go
@@ -273,7 +273,7 @@ func RegisterDriverOpener(open func(schema.ExecQuerier) (migrate.Driver, error))
 
 // DriverOpener is a helper Opener creator for sharing between all drivers.
 func DriverOpener(open func(schema.ExecQuerier) (migrate.Driver, error)) Opener {
-	return OpenerFunc(func(ctx context.Context, u *url.URL) (*Client, error) {
+	return OpenerFunc(func(_ context.Context, u *url.URL) (*Client, error) {
 		v, ok := drivers.Load(u.Scheme)
 		if !ok {
 			return nil, fmt.Errorf("sql/sqlclient: unexpected missing opener %q", u.Scheme)

--- a/sql/sqlite/driver.go
+++ b/sql/sqlite/driver.go
@@ -89,6 +89,7 @@ func Open(db schema.ExecQuerier) (migrate.Driver, error) {
 	}, nil
 }
 
+// Snapshot implements migrate.Snapshoter.
 func (d *Driver) Snapshot(ctx context.Context) (migrate.RestoreFunc, error) {
 	r, err := d.InspectRealm(ctx, nil)
 	if err != nil {

--- a/sql/sqlite/driver.go
+++ b/sql/sqlite/driver.go
@@ -89,31 +89,27 @@ func Open(db schema.ExecQuerier) (migrate.Driver, error) {
 	}, nil
 }
 
-// IsClean implements the inlined IsClean interface to override what to consider a clean database.
-func (d *Driver) IsClean(ctx context.Context) error {
+func (d *Driver) Snapshot(ctx context.Context) (migrate.RestoreFunc, error) {
 	r, err := d.InspectRealm(ctx, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if !(r == nil || (len(r.Schemas) == 1 && r.Schemas[0].Name == mainFile && len(r.Schemas[0].Tables) == 0)) {
-		return migrate.NotCleanError{Reason: fmt.Sprintf("found table %q", r.Schemas[0].Tables[0].Name)}
+		return nil, migrate.NotCleanError{Reason: fmt.Sprintf("found table %q", r.Schemas[0].Tables[0].Name)}
 	}
-	return nil
-}
-
-// Clean implements the inlined Clean interface to override the "emptying" behavior.
-func (d *Driver) Clean(ctx context.Context) error {
-	for _, stmt := range []string{
-		"PRAGMA writable_schema = 1;",
-		"DELETE FROM sqlite_master WHERE type IN ('table', 'index', 'trigger');",
-		"PRAGMA writable_schema = 0;",
-		"VACUUM;",
-	} {
-		if _, err := d.ExecContext(ctx, stmt); err != nil {
-			return err
+	return func(ctx context.Context) error {
+		for _, stmt := range []string{
+			"PRAGMA writable_schema = 1;",
+			"DELETE FROM sqlite_master WHERE type IN ('table', 'index', 'trigger');",
+			"PRAGMA writable_schema = 0;",
+			"VACUUM;",
+		} {
+			if _, err := d.ExecContext(ctx, stmt); err != nil {
+				return err
+			}
 		}
-	}
-	return nil
+		return nil
+	}, nil
 }
 
 // Lock implements the schema.Locker interface.


### PR DESCRIPTION
This is a most basic implementation, that will only accept taking a snapshot, if a database is clean.

The drivers handle this differently:
- MySQL will consider a clean state if in case of a schema bound connection there are not tables, and in realm-bound connection there are not schemas.

- Postgres will consider a connection schema-bound, if it is connected to any other schema than `public`, or if the connection string explicitly requested `public` to be the connected schema (by using `search_path`). In the former, the database is clean of there are not tables in public and no other schemas. In the latter only the tables in public are taken into account.

- SQLite is not allowed to have any tables.