### PR TITLE
cmd/atlas/internal/cmdapi: support multi file schemas in project files

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -917,14 +917,17 @@ func migrateFlagsFromEnv(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	// Transform "src" to a URL.
-	toURL := activeEnv.Source
-	if toURL != "" {
-		if toURL, err = filepath.Abs(activeEnv.Source); err != nil {
-			return fmt.Errorf("finding abs path to source: %q: %w", activeEnv.Source, err)
-		}
-		toURL = "file://" + toURL
+	srcs, err := activeEnv.Sources()
+	if err != nil {
+		return err
 	}
-	if err := maySetFlag(cmd, migrateFlagTo, toURL); err != nil {
+	for i, s := range srcs {
+		if s, err = filepath.Abs(s); err != nil {
+			return fmt.Errorf("finding abs path to source: %q: %w", s, err)
+		}
+		srcs[i] = "file://" + s
+	}
+	if err := maySetFlag(cmd, migrateFlagTo, strings.Join(srcs, ",")); err != nil {
 		return err
 	}
 	if s := "[" + strings.Join(activeEnv.Schemas, "") + "]"; len(activeEnv.Schemas) > 0 {

--- a/cmd/atlas/internal/cmdapi/schema.go
+++ b/cmd/atlas/internal/cmdapi/schema.go
@@ -203,7 +203,11 @@ func schemaFlagsFromEnv(cmd *cobra.Command, _ []string) error {
 	if err := maySetFlag(cmd, devURLFlag, activeEnv.DevURL); err != nil {
 		return err
 	}
-	if err := maySetFlag(cmd, fileFlag, activeEnv.Source); err != nil {
+	srcs, err := activeEnv.Sources()
+	if err != nil {
+		return err
+	}
+	if err := maySetFlag(cmd, fileFlag, strings.Join(srcs, "")); err != nil {
 		return err
 	}
 	if s := strings.Join(activeEnv.Schemas, ""); len(activeEnv.Schemas) > 0 {

--- a/doc/md/cli/projects.md
+++ b/doc/md/cli/projects.md
@@ -12,7 +12,10 @@ environments when working with Atlas. A project file is a file named
 ```hcl
 // Define an environment named "local"
 env "local" {
-  // Declare where the schema definition file resides.
+  // Declare where the schema definition resides.
+  // Also supported:
+  //   src = "./dir/with/schema" 
+  //   src = ["multi.hcl", "file.hcl"]
   src = "./project/schema.hcl"
   
   // Define the URL of the database which is managed in

--- a/internal/integration/testdata/sqlite/cli-migrate-project-multifile.txt
+++ b/internal/integration/testdata/sqlite/cli-migrate-project-multifile.txt
@@ -1,24 +1,45 @@
-exec mkdir migrations
 atlas migrate diff --env local
 cmpmig 0 diff.sql
 
-atlas migrate validate --env local
+# reset
+exec rm -rf migrations
 
-atlas migrate new 1 --env local
-cmpmig 1 empty.sql
+atlas migrate diff --env src_list
+cmpmig 0 diff.sql
 
-exec touch migrations/2.sql
-! atlas migrate validate --env local
-stderr 'Error: checksum mismatch'
+# reset
+exec rm -rf migrations
 
-atlas migrate hash --force --env local
-atlas migrate validate --env local
-
+atlas migrate diff --env single_elem
+cmpmig 0 diff.sql
 -- atlas.hcl --
 env "local" {
     url = "URL"
     dev = "sqlite://test?mode=memory&_fk=1"
     src = "./schema"
+    migration_dir {
+        url = "file://migrations"
+        format = atlas
+    }
+}
+env "src_list" {
+    url = "URL"
+    dev = "sqlite://test?mode=memory&_fk=1"
+    src = [
+        "./schema/1.hcl",
+        "./schema/2.hcl",
+    ]
+    migration_dir {
+        url = "file://migrations"
+        format = atlas
+    }
+}
+env "single_elem" {
+    url = "URL"
+    dev = "sqlite://test?mode=memory&_fk=1"
+    src = [
+        "./schema/",
+    ]
     migration_dir {
         url = "file://migrations"
         format = atlas


### PR DESCRIPTION
adds support for lists of values in the `src` attr of a project file env block:
```hcl
env "src_list" {
    url = "URL"
    dev = "sqlite://test?mode=memory&_fk=1"
    src = [
        "./schema/1.hcl",
        "./schema/2.hcl",
    ]
    migration_dir {
        url = "file://migrations"
        format = atlas
    }
}
```