### PR TITLE
doc/website/blog: add all posts to side nav

### DIFF
--- a/doc/website/docusaurus.config.js
+++ b/doc/website/docusaurus.config.js
@@ -134,6 +134,8 @@ module.exports = {
         },
         blog: {
           showReadingTime: true,
+          blogSidebarTitle: 'All our posts',
+          blogSidebarCount: 'ALL',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Before:
![Screen Shot 2022-07-14 at 17 03 24](https://user-images.githubusercontent.com/73284641/179001060-207bfb13-09f5-4395-b11b-5c1c892011c0.png)

After:
<img width="356" alt="Screen Shot 2022-07-14 at 17 36 27" src="https://user-images.githubusercontent.com/73284641/179008309-84f775cc-5b43-41a4-8529-5b97b067e59f.png">



