### PR TITLE
sql/migrate: utilize partial hashes to check for changes in applied s…

### DIFF
--- a/cmd/atlas/go.mod
+++ b/cmd/atlas/go.mod
@@ -3,7 +3,7 @@ module ariga.io/atlas/cmd/atlas
 go 1.18
 
 require (
-	ariga.io/atlas v0.5.1-0.20220714090227-c1fa4872ecf7
+	ariga.io/atlas v0.5.1-0.20220714144633-63ec7fc8c49a
 	entgo.io/ent v0.11.1
 	github.com/fatih/color v1.13.0
 	github.com/go-sql-driver/mysql v1.6.0

--- a/cmd/atlas/go.sum
+++ b/cmd/atlas/go.sum
@@ -1,5 +1,7 @@
 ariga.io/atlas v0.5.1-0.20220714090227-c1fa4872ecf7 h1:SSmcPvU2K/1U2D5S12xIbriQ5FUj88cuW80H4aGNuOQ=
 ariga.io/atlas v0.5.1-0.20220714090227-c1fa4872ecf7/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
+ariga.io/atlas v0.5.1-0.20220714144633-63ec7fc8c49a h1:pi8bppDVEpHRRqUiRoBvbzFV0wirfNrSQxQp9Q6AHTU=
+ariga.io/atlas v0.5.1-0.20220714144633-63ec7fc8c49a/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
 entgo.io/ent v0.11.1 h1:im67R+2W3Nee2bNS2YnoYz8oAF0Qz4AOlIvKRIAEISY=
 entgo.io/ent v0.11.1/go.mod h1:X5b1YfMayrRTgKGO//8IqpL7XJx0uqdeReEkxNpXROA=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -905,8 +905,8 @@ func (l *LogTTY) Log(e migrate.LogEntry) {
 		fmt.Fprintf(l.out, "%s %s\n", indent4, redBgWhiteFg(e.Error.Error()))
 		fmt.Fprintf(l.out, "\n%s%v\n", indent2, cyan(strings.Repeat("-", 25)))
 		fmt.Fprintf(l.out, "%s%v %v\n", indent2, dash, time.Since(l.start))
-		fmt.Fprintf(l.out, "%s%v %v migrations ok (%s)\n", indent2, dash, l.fileCounter-1, red("1 with errors"))
-		fmt.Fprintf(l.out, "%s%v %v sql statements ok (%s)\n", indent2, dash, l.stmtCounter-1, red("1 with errors"))
+		fmt.Fprintf(l.out, "%s%v %v migrations ok (%s)\n", indent2, dash, zero(l.fileCounter-1), red("1 with errors"))
+		fmt.Fprintf(l.out, "%s%v %v sql statements ok (%s)\n", indent2, dash, zero(l.stmtCounter-1), red("1 with errors"))
 		fmt.Fprintf(l.out, "\n%s\n%v\n\n", red("Error: Execution had errors:"), redBgWhiteFg(e.Error.Error()))
 	default:
 		fmt.Fprintf(l.out, "%v", e)
@@ -915,6 +915,13 @@ func (l *LogTTY) Log(e migrate.LogEntry) {
 
 func (l *LogTTY) reportFileEnd() {
 	fmt.Fprintf(l.out, "%s%v ok (%v)\n", indent2, dash, yellow("%s", time.Since(l.fileStart)))
+}
+
+func zero(v int) int {
+	if v < 0 {
+		return 0
+	}
+	return v
 }
 
 func logFormat(out io.Writer) (migrate.Logger, error) {

--- a/cmd/atlas/internal/migrate/ent/migrate/schema.go
+++ b/cmd/atlas/internal/migrate/ent/migrate/schema.go
@@ -23,6 +23,7 @@ var (
 		{Name: "execution_time", Type: field.TypeInt64},
 		{Name: "error", Type: field.TypeString, Nullable: true},
 		{Name: "hash", Type: field.TypeString},
+		{Name: "partial_hashes", Type: field.TypeJSON, Nullable: true},
 		{Name: "operator_version", Type: field.TypeString},
 		{Name: "meta", Type: field.TypeJSON},
 	}

--- a/cmd/atlas/internal/migrate/ent/mutation.go
+++ b/cmd/atlas/internal/migrate/ent/mutation.go
@@ -47,6 +47,7 @@ type RevisionMutation struct {
 	addexecution_time *time.Duration
 	error             *string
 	hash              *string
+	partial_hashes    *[]string
 	operator_version  *string
 	meta              *map[string]string
 	clearedFields     map[string]struct{}
@@ -484,6 +485,55 @@ func (m *RevisionMutation) ResetHash() {
 	m.hash = nil
 }
 
+// SetPartialHashes sets the "partial_hashes" field.
+func (m *RevisionMutation) SetPartialHashes(s []string) {
+	m.partial_hashes = &s
+}
+
+// PartialHashes returns the value of the "partial_hashes" field in the mutation.
+func (m *RevisionMutation) PartialHashes() (r []string, exists bool) {
+	v := m.partial_hashes
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPartialHashes returns the old "partial_hashes" field's value of the Revision entity.
+// If the Revision object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *RevisionMutation) OldPartialHashes(ctx context.Context) (v []string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPartialHashes is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPartialHashes requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPartialHashes: %w", err)
+	}
+	return oldValue.PartialHashes, nil
+}
+
+// ClearPartialHashes clears the value of the "partial_hashes" field.
+func (m *RevisionMutation) ClearPartialHashes() {
+	m.partial_hashes = nil
+	m.clearedFields[revision.FieldPartialHashes] = struct{}{}
+}
+
+// PartialHashesCleared returns if the "partial_hashes" field was cleared in this mutation.
+func (m *RevisionMutation) PartialHashesCleared() bool {
+	_, ok := m.clearedFields[revision.FieldPartialHashes]
+	return ok
+}
+
+// ResetPartialHashes resets all changes to the "partial_hashes" field.
+func (m *RevisionMutation) ResetPartialHashes() {
+	m.partial_hashes = nil
+	delete(m.clearedFields, revision.FieldPartialHashes)
+}
+
 // SetOperatorVersion sets the "operator_version" field.
 func (m *RevisionMutation) SetOperatorVersion(s string) {
 	m.operator_version = &s
@@ -575,7 +625,7 @@ func (m *RevisionMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *RevisionMutation) Fields() []string {
-	fields := make([]string, 0, 9)
+	fields := make([]string, 0, 10)
 	if m.description != nil {
 		fields = append(fields, revision.FieldDescription)
 	}
@@ -596,6 +646,9 @@ func (m *RevisionMutation) Fields() []string {
 	}
 	if m.hash != nil {
 		fields = append(fields, revision.FieldHash)
+	}
+	if m.partial_hashes != nil {
+		fields = append(fields, revision.FieldPartialHashes)
 	}
 	if m.operator_version != nil {
 		fields = append(fields, revision.FieldOperatorVersion)
@@ -625,6 +678,8 @@ func (m *RevisionMutation) Field(name string) (ent.Value, bool) {
 		return m.Error()
 	case revision.FieldHash:
 		return m.Hash()
+	case revision.FieldPartialHashes:
+		return m.PartialHashes()
 	case revision.FieldOperatorVersion:
 		return m.OperatorVersion()
 	case revision.FieldMeta:
@@ -652,6 +707,8 @@ func (m *RevisionMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldError(ctx)
 	case revision.FieldHash:
 		return m.OldHash(ctx)
+	case revision.FieldPartialHashes:
+		return m.OldPartialHashes(ctx)
 	case revision.FieldOperatorVersion:
 		return m.OldOperatorVersion(ctx)
 	case revision.FieldMeta:
@@ -713,6 +770,13 @@ func (m *RevisionMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetHash(v)
+		return nil
+	case revision.FieldPartialHashes:
+		v, ok := value.([]string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPartialHashes(v)
 		return nil
 	case revision.FieldOperatorVersion:
 		v, ok := value.(string)
@@ -800,6 +864,9 @@ func (m *RevisionMutation) ClearedFields() []string {
 	if m.FieldCleared(revision.FieldError) {
 		fields = append(fields, revision.FieldError)
 	}
+	if m.FieldCleared(revision.FieldPartialHashes) {
+		fields = append(fields, revision.FieldPartialHashes)
+	}
 	return fields
 }
 
@@ -816,6 +883,9 @@ func (m *RevisionMutation) ClearField(name string) error {
 	switch name {
 	case revision.FieldError:
 		m.ClearError()
+		return nil
+	case revision.FieldPartialHashes:
+		m.ClearPartialHashes()
 		return nil
 	}
 	return fmt.Errorf("unknown Revision nullable field %s", name)
@@ -845,6 +915,9 @@ func (m *RevisionMutation) ResetField(name string) error {
 		return nil
 	case revision.FieldHash:
 		m.ResetHash()
+		return nil
+	case revision.FieldPartialHashes:
+		m.ResetPartialHashes()
 		return nil
 	case revision.FieldOperatorVersion:
 		m.ResetOperatorVersion()

--- a/cmd/atlas/internal/migrate/ent/revision/revision.go
+++ b/cmd/atlas/internal/migrate/ent/revision/revision.go
@@ -25,6 +25,8 @@ const (
 	FieldError = "error"
 	// FieldHash holds the string denoting the hash field in the database.
 	FieldHash = "hash"
+	// FieldPartialHashes holds the string denoting the partial_hashes field in the database.
+	FieldPartialHashes = "partial_hashes"
 	// FieldOperatorVersion holds the string denoting the operator_version field in the database.
 	FieldOperatorVersion = "operator_version"
 	// FieldMeta holds the string denoting the meta field in the database.
@@ -43,6 +45,7 @@ var Columns = []string{
 	FieldExecutionTime,
 	FieldError,
 	FieldHash,
+	FieldPartialHashes,
 	FieldOperatorVersion,
 	FieldMeta,
 }

--- a/cmd/atlas/internal/migrate/ent/revision/where.go
+++ b/cmd/atlas/internal/migrate/ent/revision/where.go
@@ -798,6 +798,20 @@ func HashContainsFold(v string) predicate.Revision {
 	})
 }
 
+// PartialHashesIsNil applies the IsNil predicate on the "partial_hashes" field.
+func PartialHashesIsNil() predicate.Revision {
+	return predicate.Revision(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldPartialHashes)))
+	})
+}
+
+// PartialHashesNotNil applies the NotNil predicate on the "partial_hashes" field.
+func PartialHashesNotNil() predicate.Revision {
+	return predicate.Revision(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldPartialHashes)))
+	})
+}
+
 // OperatorVersionEQ applies the EQ predicate on the "operator_version" field.
 func OperatorVersionEQ(v string) predicate.Revision {
 	return predicate.Revision(func(s *sql.Selector) {

--- a/cmd/atlas/internal/migrate/ent/revision_create.go
+++ b/cmd/atlas/internal/migrate/ent/revision_create.go
@@ -77,6 +77,12 @@ func (rc *RevisionCreate) SetHash(s string) *RevisionCreate {
 	return rc
 }
 
+// SetPartialHashes sets the "partial_hashes" field.
+func (rc *RevisionCreate) SetPartialHashes(s []string) *RevisionCreate {
+	rc.mutation.SetPartialHashes(s)
+	return rc
+}
+
 // SetOperatorVersion sets the "operator_version" field.
 func (rc *RevisionCreate) SetOperatorVersion(s string) *RevisionCreate {
 	rc.mutation.SetOperatorVersion(s)
@@ -294,6 +300,14 @@ func (rc *RevisionCreate) createSpec() (*Revision, *sqlgraph.CreateSpec) {
 		})
 		_node.Hash = value
 	}
+	if value, ok := rc.mutation.PartialHashes(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Value:  value,
+			Column: revision.FieldPartialHashes,
+		})
+		_node.PartialHashes = value
+	}
 	if value, ok := rc.mutation.OperatorVersion(); ok {
 		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
@@ -469,6 +483,24 @@ func (u *RevisionUpsert) SetHash(v string) *RevisionUpsert {
 // UpdateHash sets the "hash" field to the value that was provided on create.
 func (u *RevisionUpsert) UpdateHash() *RevisionUpsert {
 	u.SetExcluded(revision.FieldHash)
+	return u
+}
+
+// SetPartialHashes sets the "partial_hashes" field.
+func (u *RevisionUpsert) SetPartialHashes(v []string) *RevisionUpsert {
+	u.Set(revision.FieldPartialHashes, v)
+	return u
+}
+
+// UpdatePartialHashes sets the "partial_hashes" field to the value that was provided on create.
+func (u *RevisionUpsert) UpdatePartialHashes() *RevisionUpsert {
+	u.SetExcluded(revision.FieldPartialHashes)
+	return u
+}
+
+// ClearPartialHashes clears the value of the "partial_hashes" field.
+func (u *RevisionUpsert) ClearPartialHashes() *RevisionUpsert {
+	u.SetNull(revision.FieldPartialHashes)
 	return u
 }
 
@@ -675,6 +707,27 @@ func (u *RevisionUpsertOne) SetHash(v string) *RevisionUpsertOne {
 func (u *RevisionUpsertOne) UpdateHash() *RevisionUpsertOne {
 	return u.Update(func(s *RevisionUpsert) {
 		s.UpdateHash()
+	})
+}
+
+// SetPartialHashes sets the "partial_hashes" field.
+func (u *RevisionUpsertOne) SetPartialHashes(v []string) *RevisionUpsertOne {
+	return u.Update(func(s *RevisionUpsert) {
+		s.SetPartialHashes(v)
+	})
+}
+
+// UpdatePartialHashes sets the "partial_hashes" field to the value that was provided on create.
+func (u *RevisionUpsertOne) UpdatePartialHashes() *RevisionUpsertOne {
+	return u.Update(func(s *RevisionUpsert) {
+		s.UpdatePartialHashes()
+	})
+}
+
+// ClearPartialHashes clears the value of the "partial_hashes" field.
+func (u *RevisionUpsertOne) ClearPartialHashes() *RevisionUpsertOne {
+	return u.Update(func(s *RevisionUpsert) {
+		s.ClearPartialHashes()
 	})
 }
 
@@ -1050,6 +1103,27 @@ func (u *RevisionUpsertBulk) SetHash(v string) *RevisionUpsertBulk {
 func (u *RevisionUpsertBulk) UpdateHash() *RevisionUpsertBulk {
 	return u.Update(func(s *RevisionUpsert) {
 		s.UpdateHash()
+	})
+}
+
+// SetPartialHashes sets the "partial_hashes" field.
+func (u *RevisionUpsertBulk) SetPartialHashes(v []string) *RevisionUpsertBulk {
+	return u.Update(func(s *RevisionUpsert) {
+		s.SetPartialHashes(v)
+	})
+}
+
+// UpdatePartialHashes sets the "partial_hashes" field to the value that was provided on create.
+func (u *RevisionUpsertBulk) UpdatePartialHashes() *RevisionUpsertBulk {
+	return u.Update(func(s *RevisionUpsert) {
+		s.UpdatePartialHashes()
+	})
+}
+
+// ClearPartialHashes clears the value of the "partial_hashes" field.
+func (u *RevisionUpsertBulk) ClearPartialHashes() *RevisionUpsertBulk {
+	return u.Update(func(s *RevisionUpsert) {
+		s.ClearPartialHashes()
 	})
 }
 

--- a/cmd/atlas/internal/migrate/ent/revision_update.go
+++ b/cmd/atlas/internal/migrate/ent/revision_update.go
@@ -98,6 +98,18 @@ func (ru *RevisionUpdate) SetHash(s string) *RevisionUpdate {
 	return ru
 }
 
+// SetPartialHashes sets the "partial_hashes" field.
+func (ru *RevisionUpdate) SetPartialHashes(s []string) *RevisionUpdate {
+	ru.mutation.SetPartialHashes(s)
+	return ru
+}
+
+// ClearPartialHashes clears the value of the "partial_hashes" field.
+func (ru *RevisionUpdate) ClearPartialHashes() *RevisionUpdate {
+	ru.mutation.ClearPartialHashes()
+	return ru
+}
+
 // SetOperatorVersion sets the "operator_version" field.
 func (ru *RevisionUpdate) SetOperatorVersion(s string) *RevisionUpdate {
 	ru.mutation.SetOperatorVersion(s)
@@ -265,6 +277,19 @@ func (ru *RevisionUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: revision.FieldHash,
 		})
 	}
+	if value, ok := ru.mutation.PartialHashes(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Value:  value,
+			Column: revision.FieldPartialHashes,
+		})
+	}
+	if ru.mutation.PartialHashesCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Column: revision.FieldPartialHashes,
+		})
+	}
 	if value, ok := ru.mutation.OperatorVersion(); ok {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
@@ -362,6 +387,18 @@ func (ruo *RevisionUpdateOne) ClearError() *RevisionUpdateOne {
 // SetHash sets the "hash" field.
 func (ruo *RevisionUpdateOne) SetHash(s string) *RevisionUpdateOne {
 	ruo.mutation.SetHash(s)
+	return ruo
+}
+
+// SetPartialHashes sets the "partial_hashes" field.
+func (ruo *RevisionUpdateOne) SetPartialHashes(s []string) *RevisionUpdateOne {
+	ruo.mutation.SetPartialHashes(s)
+	return ruo
+}
+
+// ClearPartialHashes clears the value of the "partial_hashes" field.
+func (ruo *RevisionUpdateOne) ClearPartialHashes() *RevisionUpdateOne {
+	ruo.mutation.ClearPartialHashes()
 	return ruo
 }
 
@@ -560,6 +597,19 @@ func (ruo *RevisionUpdateOne) sqlSave(ctx context.Context) (_node *Revision, err
 			Type:   field.TypeString,
 			Value:  value,
 			Column: revision.FieldHash,
+		})
+	}
+	if value, ok := ruo.mutation.PartialHashes(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Value:  value,
+			Column: revision.FieldPartialHashes,
+		})
+	}
+	if ruo.mutation.PartialHashesCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Column: revision.FieldPartialHashes,
 		})
 	}
 	if value, ok := ruo.mutation.OperatorVersion(); ok {

--- a/cmd/atlas/internal/migrate/ent/schema/revision.go
+++ b/cmd/atlas/internal/migrate/ent/schema/revision.go
@@ -36,6 +36,8 @@ func (Revision) Fields() []ent.Field {
 		field.String("error").
 			Optional(),
 		field.String("hash"),
+		field.Strings("partial_hashes").
+			Optional(),
 		field.String("operator_version"),
 		field.JSON("meta", make(map[string]string)),
 	}

--- a/cmd/atlas/internal/migrate/migrate.go
+++ b/cmd/atlas/internal/migrate/migrate.go
@@ -157,6 +157,7 @@ func (r *EntRevisions) write(ctx context.Context, rev *migrate.Revision) error {
 		SetExecutionTime(rev.ExecutionTime).
 		SetError(rev.Error).
 		SetHash(rev.Hash).
+		SetPartialHashes(rev.PartialHashes).
 		SetOperatorVersion(rev.OperatorVersion).
 		SetMeta(rev.Meta).
 		OnConflict(sql.ConflictColumns(revision.FieldID)).
@@ -174,6 +175,7 @@ func fromEnt(r *ent.Revision) *migrate.Revision {
 		ExecutionTime:   r.ExecutionTime,
 		Error:           r.Error,
 		Hash:            r.Hash,
+		PartialHashes:   r.PartialHashes,
 		OperatorVersion: r.OperatorVersion,
 		Meta:            r.Meta,
 	}

--- a/internal/integration/go.mod
+++ b/internal/integration/go.mod
@@ -7,7 +7,7 @@ replace ariga.io/atlas => ../../
 replace ariga.io/atlas/cmd/atlas => ../../cmd/atlas
 
 require (
-	ariga.io/atlas v0.5.1-0.20220714090227-c1fa4872ecf7
+	ariga.io/atlas v0.5.1-0.20220714144633-63ec7fc8c49a
 	entgo.io/ent v0.11.1
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/hashicorp/hcl/v2 v2.13.0

--- a/sql/migrate/migrate.go
+++ b/sql/migrate/migrate.go
@@ -514,7 +514,7 @@ func (e *Executor) Execute(ctx context.Context, m File) (err error) {
 	}(ctx, e.rrw, r)
 	if r.Applied > 0 {
 		// If the file has been applied partially before, check if the
-		// applied history didn't change, as this is dangerous.
+		// applied statements were not changed.
 		for i := 0; i < r.Applied; i++ {
 			if i > len(sums) || sums[i] != strings.TrimPrefix(r.PartialHashes[i], "h1:") {
 				err = HistoryChangedError{m.Name(), i + 1}


### PR DESCRIPTION
…tatements of partially applied files

If a file has been partially applied, we now check if the already applied part of a migration file was edited and refuse to work, if the history was changed.

![image](https://user-images.githubusercontent.com/12862103/179011820-d50b514a-d682-4007-a0a9-41e55570cb64.png)
