### PR TITLE
cmd/atlas/internal/cmdapi: url attr optional in env

### DIFF
--- a/cmd/atlas/internal/cmdapi/project.go
+++ b/cmd/atlas/internal/cmdapi/project.go
@@ -120,9 +120,6 @@ func LoadEnv(path string, name string, opts ...LoadOption) (*Env, error) {
 		if e.Name == "" {
 			return nil, fmt.Errorf("all envs must have names on file %q", path)
 		}
-		if e.URL == "" {
-			return nil, fmt.Errorf("no url set for env %q", e.Name)
-		}
 		if _, err := e.Sources(); err != nil {
 			return nil, err
 		}

--- a/internal/integration/testdata/sqlite/cli-migrate-diff-minimal-env.txt
+++ b/internal/integration/testdata/sqlite/cli-migrate-diff-minimal-env.txt
@@ -1,0 +1,20 @@
+atlas migrate diff --env local
+cmpmig 0 diff.sql
+-- atlas.hcl --
+env "local" {
+    src = "1.hcl"
+    dev = "sqlite://devdb"
+}
+-- 1.hcl --
+table "users" {
+  schema = schema.main
+  column "id" {
+    null = false
+    type = int
+  }
+}
+schema "main" {
+}
+-- diff.sql --
+-- create "users" table
+CREATE TABLE `users` (`id` int NOT NULL);

--- a/internal/integration/testdata/sqlite/cli-migrate-lint-minimal-env.txt
+++ b/internal/integration/testdata/sqlite/cli-migrate-lint-minimal-env.txt
@@ -1,0 +1,15 @@
+atlas migrate lint --env local --latest=2 > got1.txt
+cmp got1.txt expected1.txt
+-- atlas.hcl --
+env "local" {
+    dev = "URL"
+}
+-- migrations/1.sql --
+CREATE TABLE users (id int);
+-- migrations/2.sql --
+DROP TABLE users;
+-- expected1.txt --
+Destructive changes detected in file 2.sql:
+
+	L1: Dropping table "users"
+


### PR DESCRIPTION
As pointed by @masseelch , some commands can live fine without the `url` attr defined in the env. 