### PR TITLE
sql/migrate: allow setting --from and --baseline versions

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -582,6 +582,10 @@ func (d *sqliteLockerDriver) Snapshot(ctx context.Context) (migrate.RestoreFunc,
 	return d.Driver.(migrate.Snapshoter).Snapshot(ctx)
 }
 
+func (d *sqliteLockerDriver) CheckClean(ctx context.Context, revT *migrate.TableIdent) error {
+	return d.Driver.(migrate.CleanChecker).CheckClean(ctx, revT)
+}
+
 func countFiles(t *testing.T, p string) int {
 	files, err := os.ReadDir(p)
 	require.NoError(t, err)

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -107,7 +107,10 @@ If run with the "--dry-run" flag, atlas will not execute any SQL.
 ```
 #### Flags
 ```
+      --allow-dirty               allow start working on a non-clean database
+      --baseline string           start the first migration after the given baseline version
       --dry-run                   do not actually execute any SQL but show it on screen
+      --from string               calculate pending files from the given version (including it)
       --log string                log format to use (default "tty")
       --revisions-schema string   schema name where the revisions table resides (default "atlas_schema_revisions")
   -u, --url string                [driver://username:password@address/dbname?param=value] select a database using the URL format

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -527,6 +527,10 @@ func plan(t T, name string, changes ...schema.Change) *migrate.Plan {
 
 type rrw migrate.Revisions
 
+func (r *rrw) Ident() *migrate.TableIdent {
+	return &migrate.TableIdent{}
+}
+
 func (r *rrw) WriteRevision(_ context.Context, rev *migrate.Revision) error {
 	for i, rev2 := range *r {
 		if rev2.Version == rev.Version {
@@ -544,7 +548,7 @@ func (r *rrw) ReadRevision(_ context.Context, v string) (*migrate.Revision, erro
 			return rev, nil
 		}
 	}
-	return nil, migrate.ErrNotExist
+	return nil, migrate.ErrRevisionNotExist
 }
 
 func (r *rrw) ReadRevisions(context.Context) (migrate.Revisions, error) {

--- a/sql/migrate/dir.go
+++ b/sql/migrate/dir.go
@@ -48,8 +48,6 @@ type (
 		Desc() string
 		// Version returns the version of the migration File.
 		Version() string
-		// Baseline indicates if this file is marked as a baseline migration.
-		Baseline() bool
 		// Bytes returns the read content of the file.
 		Bytes() []byte
 		// Stmts returns the set of SQL statements this file holds.
@@ -131,12 +129,6 @@ func (f LocalFile) Name() string {
 	return f.n
 }
 
-// Baseline reports if this file marked as a baseline migration.
-func (f LocalFile) Baseline() bool {
-	_, ok := directive(string(f.b), directiveBaseline, directivePrefixSQL)
-	return ok
-}
-
 // Desc implements File.Desc.
 func (f LocalFile) Desc() string {
 	parts := strings.SplitN(f.n, "_", 2)
@@ -148,7 +140,7 @@ func (f LocalFile) Desc() string {
 
 // Version implements File.Version.
 func (f LocalFile) Version() string {
-	return strings.SplitN(f.n, "_", 2)[0]
+	return strings.SplitN(strings.TrimSuffix(f.n, ".sql"), "_", 2)[0]
 }
 
 // Stmts implements Scanner.Stmts. It reads migration file line-by-line and expects a statement to be one line only.
@@ -374,10 +366,9 @@ func FilesLastIndex(files []File, f func(File) bool) int {
 }
 
 const (
+	// atlas:sum directive.
 	directiveSum  = "sum"
 	sumModeIgnore = "ignore"
-	// atlas:baseline directive.
-	directiveBaseline = "baseline"
 	// atlas:delimiter directive.
 	directiveDelimiter = "delimiter"
 	directivePrefixSQL = "-- "

--- a/sql/migrate/dir_test.go
+++ b/sql/migrate/dir_test.go
@@ -182,16 +182,3 @@ func TestLocalDir(t *testing.T) {
 	require.Equal(t, "2.10.x-20", files[1].Version())
 	require.Equal(t, "description", files[1].Desc())
 }
-
-func TestLocalFile_Baseline(t *testing.T) {
-	dir, err := migrate.NewLocalDir("testdata/baseline")
-	require.NoError(t, err)
-	files, err := dir.Files()
-	require.NoError(t, err)
-	idx := migrate.FilesLastIndex(files, func(f migrate.File) bool {
-		return f.Baseline()
-	})
-	require.Equal(t, 2, idx)
-	require.True(t, files[idx].Baseline())
-	require.False(t, files[idx+1].Baseline())
-}

--- a/sql/migrate/testdata/baseline/1_v1.sql
+++ b/sql/migrate/testdata/baseline/1_v1.sql
@@ -1,2 +1,0 @@
-CREATE DATABASE market;
-CREATE TABLE orders (name varchar(255));

--- a/sql/migrate/testdata/baseline/2_v2.sql
+++ b/sql/migrate/testdata/baseline/2_v2.sql
@@ -1,1 +1,0 @@
-CREATE TABLE products (name varchar(255), price decimal);

--- a/sql/migrate/testdata/baseline/3_baseline.sql
+++ b/sql/migrate/testdata/baseline/3_baseline.sql
@@ -1,6 +1,0 @@
--- atlas:baseline
-
-CREATE DATABASE market;
-CREATE TABLE orders (name varchar(255));
-CREATE TABLE products (name varchar(255), price decimal);
-

--- a/sql/migrate/testdata/baseline/4_initial.sql
+++ b/sql/migrate/testdata/baseline/4_initial.sql
@@ -1,1 +1,0 @@
-ALTER TABLE orders ADD COLUMN product_id bigint;

--- a/sql/postgres/driver_test.go
+++ b/sql/postgres/driver_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"ariga.io/atlas/sql/internal/sqltest"
+	"ariga.io/atlas/sql/migrate"
 	"ariga.io/atlas/sql/schema"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -100,4 +101,62 @@ func TestDriver_UnlockError(t *testing.T) {
 			RowsWillBeClosed()
 		require.Error(t, unlock())
 	})
+}
+
+func TestDriver_CheckClean(t *testing.T) {
+	s := schema.New("test")
+	drv := &Driver{Inspector: &mockInspector{schema: s}, schema: "test"}
+	// Empty schema.
+	err := drv.CheckClean(context.Background(), nil)
+	require.NoError(t, err)
+	// Revisions table found.
+	s.AddTables(schema.NewTable("revisions"))
+	err = drv.CheckClean(context.Background(), &migrate.TableIdent{Name: "revisions", Schema: "test"})
+	require.NoError(t, err)
+	// Multiple tables.
+	s.Tables = []*schema.Table{schema.NewTable("a"), schema.NewTable("revisions")}
+	err = drv.CheckClean(context.Background(), &migrate.TableIdent{Name: "revisions", Schema: "test"})
+	require.EqualError(t, err, `sql/migrate: connected database is not clean: found table "a" in schema "test"`)
+
+	r := schema.NewRealm()
+	drv.schema = ""
+	drv.Inspector = &mockInspector{realm: r}
+	// Empty realm.
+	err = drv.CheckClean(context.Background(), nil)
+	require.NoError(t, err)
+	// Revisions table found.
+	s.Tables = []*schema.Table{schema.NewTable("revisions").SetSchema(s)}
+	r.AddSchemas(s)
+	err = drv.CheckClean(context.Background(), &migrate.TableIdent{Name: "revisions", Schema: "test"})
+	require.NoError(t, err)
+	// Unknown table.
+	s.Tables[0].Name = "unknown"
+	err = drv.CheckClean(context.Background(), &migrate.TableIdent{Schema: "test", Name: "revisions"})
+	require.EqualError(t, err, `sql/migrate: connected database is not clean: found table "unknown" in schema "test"`)
+	// Multiple tables.
+	s.Tables = []*schema.Table{schema.NewTable("a"), schema.NewTable("revisions")}
+	err = drv.CheckClean(context.Background(), &migrate.TableIdent{Schema: "test", Name: "revisions"})
+	require.EqualError(t, err, `sql/migrate: connected database is not clean: found 2 tables in schema "test"`)
+	// With auto created public schema.
+	s.Tables = []*schema.Table{schema.NewTable("revisions")}
+	r.AddSchemas(schema.New("public"))
+	err = drv.CheckClean(context.Background(), &migrate.TableIdent{Schema: "test", Name: "revisions"})
+	require.NoError(t, err)
+}
+
+type mockInspector struct {
+	schema.Inspector
+	realm  *schema.Realm
+	schema *schema.Schema
+}
+
+func (m *mockInspector) InspectSchema(context.Context, string, *schema.InspectOptions) (*schema.Schema, error) {
+	if m.schema == nil {
+		return nil, &schema.NotExistError{}
+	}
+	return m.schema, nil
+}
+
+func (m *mockInspector) InspectRealm(context.Context, *schema.InspectRealmOption) (*schema.Realm, error) {
+	return m.realm, nil
 }

--- a/sql/schema/dsl.go
+++ b/sql/schema/dsl.go
@@ -79,6 +79,15 @@ func NewRealm(schemas ...*Schema) *Realm {
 	return r
 }
 
+// AddSchemas adds and links the given schemas to the realm.
+func (r *Realm) AddSchemas(schemas ...*Schema) *Realm {
+	for _, s := range schemas {
+		s.SetRealm(r)
+	}
+	r.Schemas = append(r.Schemas, schemas...)
+	return r
+}
+
 // SetCharset sets or appends the Charset attribute
 // to the realm with the given value.
 func (r *Realm) SetCharset(v string) *Realm {

--- a/sql/sqlite/migrate_test.go
+++ b/sql/sqlite/migrate_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"ariga.io/atlas/sql/internal/sqltest"
-
 	"ariga.io/atlas/sql/migrate"
 	"ariga.io/atlas/sql/schema"
 


### PR DESCRIPTION
`--from` and `--baseline` may look the same but they are not; this will be explained soon in the docs.