### PR TITLE
internal: database connections for a test are established in the test…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql56
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/mysql56|MySQL.*/.*/mysql56|MySQL.*/.*/.*/mysql56" -dialect=mysql56 ./...
+        run: go test -race -count=2 -v -run="MySQL" -dialect="mysql56" ./...
   
   integration-mysql57:
     runs-on: ubuntu-latest
@@ -168,7 +168,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql57
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/mysql57|MySQL.*/.*/mysql57|MySQL.*/.*/.*/mysql57" -dialect=mysql57 ./...
+        run: go test -race -count=2 -v -run="MySQL" -dialect="mysql57" ./...
   
   integration-mysql8:
     runs-on: ubuntu-latest
@@ -199,7 +199,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for mysql8
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/mysql8|MySQL.*/.*/mysql8|MySQL.*/.*/.*/mysql8" -dialect=mysql8 ./...
+        run: go test -race -count=2 -v -run="MySQL" -dialect="mysql8" ./...
   
   integration-maria107:
     runs-on: ubuntu-latest
@@ -230,7 +230,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria107
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/maria107|MySQL.*/.*/maria107|MySQL.*/.*/.*/maria107" -dialect=maria107 ./...
+        run: go test -race -count=2 -v -run="MySQL" -dialect="maria107" ./...
   
   integration-maria102:
     runs-on: ubuntu-latest
@@ -261,7 +261,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria102
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/maria102|MySQL.*/.*/maria102|MySQL.*/.*/.*/maria102" -dialect=maria102 ./...
+        run: go test -race -count=2 -v -run="MySQL" -dialect="maria102" ./...
   
   integration-maria103:
     runs-on: ubuntu-latest
@@ -292,7 +292,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for maria103
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL.*/maria103|MySQL.*/.*/maria103|MySQL.*/.*/.*/maria103" -dialect=maria103 ./...
+        run: go test -race -count=2 -v -run="MySQL" -dialect="maria103" ./...
   
   integration-postgres10:
     runs-on: ubuntu-latest
@@ -322,7 +322,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres10
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/postgres10|Postgres.*/.*/postgres10|Postgres.*/.*/.*/postgres10" -dialect=postgres10 ./...
+        run: go test -race -count=2 -v -run="Postgres" -dialect="postgres10" ./...
   
   integration-postgres11:
     runs-on: ubuntu-latest
@@ -352,7 +352,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres11
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/postgres11|Postgres.*/.*/postgres11|Postgres.*/.*/.*/postgres11" -dialect=postgres11 ./...
+        run: go test -race -count=2 -v -run="Postgres" -dialect="postgres11" ./...
   
   integration-postgres12:
     runs-on: ubuntu-latest
@@ -382,7 +382,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres12
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/postgres12|Postgres.*/.*/postgres12|Postgres.*/.*/.*/postgres12" -dialect=postgres12 ./...
+        run: go test -race -count=2 -v -run="Postgres" -dialect="postgres12" ./...
   
   integration-postgres13:
     runs-on: ubuntu-latest
@@ -412,7 +412,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres13
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/postgres13|Postgres.*/.*/postgres13|Postgres.*/.*/.*/postgres13" -dialect=postgres13 ./...
+        run: go test -race -count=2 -v -run="Postgres" -dialect="postgres13" ./...
   
   integration-postgres14:
     runs-on: ubuntu-latest
@@ -442,7 +442,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for postgres14
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Postgres.*/postgres14|Postgres.*/.*/postgres14|Postgres.*/.*/.*/postgres14" -dialect=postgres14 ./...
+        run: go test -race -count=2 -v -run="Postgres" -dialect="postgres14" ./...
   
   integration-tidb5:
     runs-on: ubuntu-latest
@@ -466,7 +466,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for tidb5
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="TiDB.*/tidb5|TiDB.*/.*/tidb5|TiDB.*/.*/.*/tidb5" -dialect=tidb5 ./...
+        run: go test -race -count=2 -v -run="TiDB" -dialect="tidb5" ./...
   
   integration-tidb6:
     runs-on: ubuntu-latest
@@ -490,7 +490,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for tidb6
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="TiDB.*/tidb6|TiDB.*/.*/tidb6|TiDB.*/.*/.*/tidb6" -dialect=tidb6 ./...
+        run: go test -race -count=2 -v -run="TiDB" -dialect="tidb6" ./...
   
   integration-sqlite:
     runs-on: ubuntu-latest
@@ -508,7 +508,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for sqlite
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="SQLite.*" -dialect=sqlite ./...
+        run: go test -race -count=2 -v -run="SQLite.*" -dialect="sqlite" ./...
   
   integration-cockroach:
     runs-on: ubuntu-latest
@@ -532,5 +532,5 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run integration tests for cockroach
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="Cockroach.*/Cockroach|Cockroach.*/.*/Cockroach|Cockroach.*/.*/.*/Cockroach" -dialect=cockroach ./...
+        run: go test -race -count=2 -v -run="Cockroach" -dialect="cockroach" ./...
   

--- a/internal/ci/ci.tmpl
+++ b/internal/ci/ci.tmpl
@@ -135,5 +135,5 @@ jobs:
             {{ "${{ runner.os }}-go-" }}
       - name: Run integration tests for {{ .Version }}
         working-directory: internal/integration
-        run: go test -race -count=2 -v -run="{{ .Regex }}" -dialect={{ .Version }} ./...
+        run: go test -race -count=2 -v -run="{{ .Regex }}" -dialect="{{ .Version }}" ./...
   {{ end }}

--- a/internal/ci/main.go
+++ b/internal/ci/main.go
@@ -7,10 +7,8 @@ package main
 import (
 	"bytes"
 	_ "embed"
-	"fmt"
 	"log"
 	"os"
-	"strings"
 	"text/template"
 )
 
@@ -55,7 +53,7 @@ var (
 		{
 			Version: "mysql56",
 			Image:   "mysql:5.6.35",
-			Regex:   re("MySQL.*/%smysql56"),
+			Regex:   "MySQL",
 			Env:     mysqlEnv,
 			Ports:   []string{"3306:3306"},
 			Options: mysqlOptions,
@@ -63,7 +61,7 @@ var (
 		{
 			Version: "mysql57",
 			Image:   "mysql:5.7.26",
-			Regex:   re("MySQL.*/%smysql57"),
+			Regex:   "MySQL",
 			Env:     mysqlEnv,
 			Ports:   []string{"3307:3306"},
 			Options: mysqlOptions,
@@ -71,7 +69,7 @@ var (
 		{
 			Version: "mysql8",
 			Image:   "mysql:8",
-			Regex:   re("MySQL.*/%smysql8"),
+			Regex:   "MySQL",
 			Env:     mysqlEnv,
 			Ports:   []string{"3308:3306"},
 			Options: mysqlOptions,
@@ -79,7 +77,7 @@ var (
 		{
 			Version: "maria107",
 			Image:   "mariadb:10.7",
-			Regex:   re("MySQL.*/%smaria107"),
+			Regex:   "MySQL",
 			Env:     mysqlEnv,
 			Ports:   []string{"4306:3306"},
 			Options: mysqlOptions,
@@ -87,7 +85,7 @@ var (
 		{
 			Version: "maria102",
 			Image:   "mariadb:10.2.32",
-			Regex:   re("MySQL.*/%smaria102"),
+			Regex:   "MySQL",
 			Env:     mysqlEnv,
 			Ports:   []string{"4307:3306"},
 			Options: mysqlOptions,
@@ -95,7 +93,7 @@ var (
 		{
 			Version: "maria103",
 			Image:   "mariadb:10.3.13",
-			Regex:   re("MySQL.*/%smaria103"),
+			Regex:   "MySQL",
 			Env:     mysqlEnv,
 			Ports:   []string{"4308:3306"},
 			Options: mysqlOptions,
@@ -103,7 +101,7 @@ var (
 		{
 			Version: "postgres10",
 			Image:   "postgres:10",
-			Regex:   re("Postgres.*/%spostgres10"),
+			Regex:   "Postgres",
 			Env:     pgEnv,
 			Ports:   []string{"5430:5432"},
 			Options: pgOptions,
@@ -111,7 +109,7 @@ var (
 		{
 			Version: "postgres11",
 			Image:   "postgres:11",
-			Regex:   re("Postgres.*/%spostgres11"),
+			Regex:   "Postgres",
 			Env:     pgEnv,
 			Ports:   []string{"5431:5432"},
 			Options: pgOptions,
@@ -119,7 +117,7 @@ var (
 		{
 			Version: "postgres12",
 			Image:   "postgres:12.3",
-			Regex:   re("Postgres.*/%spostgres12"),
+			Regex:   "Postgres",
 			Env:     pgEnv,
 			Ports:   []string{"5432:5432"},
 			Options: pgOptions,
@@ -127,7 +125,7 @@ var (
 		{
 			Version: "postgres13",
 			Image:   "postgres:13.1",
-			Regex:   re("Postgres.*/%spostgres13"),
+			Regex:   "Postgres",
 			Env:     pgEnv,
 			Ports:   []string{"5433:5432"},
 			Options: pgOptions,
@@ -135,7 +133,7 @@ var (
 		{
 			Version: "postgres14",
 			Image:   "postgres:14",
-			Regex:   re("Postgres.*/%spostgres14"),
+			Regex:   "Postgres",
 			Env:     pgEnv,
 			Ports:   []string{"5434:5432"},
 			Options: pgOptions,
@@ -143,13 +141,13 @@ var (
 		{
 			Version: "tidb5",
 			Image:   "pingcap/tidb:v5.4.0",
-			Regex:   re("TiDB.*/%stidb5"),
+			Regex:   "TiDB",
 			Ports:   []string{"4309:4000"},
 		},
 		{
 			Version: "tidb6",
 			Image:   "pingcap/tidb:v6.0.0",
-			Regex:   re("TiDB.*/%stidb6"),
+			Regex:   "TiDB",
 			Ports:   []string{"4310:4000"},
 		},
 		{
@@ -159,19 +157,11 @@ var (
 		{
 			Version: "cockroach",
 			Image:   "ghcr.io/ariga/cockroachdb-single-node:v21.2.11",
-			Regex:   re("Cockroach.*/%sCockroach"),
+			Regex:   "Cockroach",
 			Ports:   []string{"26257:26257"},
 		},
 	}
 )
-
-func re(p string) string {
-	var s []string
-	for i := 0; i < 3; i++ {
-		s = append(s, fmt.Sprintf(p, strings.Repeat(".*/", i)))
-	}
-	return strings.Join(s, "|")
-}
 
 func main() {
 	var buf bytes.Buffer

--- a/internal/integration/README.md
+++ b/internal/integration/README.md
@@ -1,0 +1,58 @@
+### This directory contains all integration tests for Atlas.
+
+The provided `docker-compose.yaml` file contains images for each database the integration tests are run on. You can
+start them by calling:
+
+```shell
+docker-compose --project-name atlas-integration up -d
+```
+
+The whole integration suite is then run by executing within this directory: 
+
+```shell
+go test ./...
+```
+
+#### Selectively running tests
+
+Running all integration tests (and keeping all database containers up all the time) consumes time and resources (and
+power). You can execute only some of the tests by using the `-run` and `-dialect` flags:
+
+The below examples don't require for you to have all docker containers running, instead only the ones used in the tests
+have to be up.
+
+Consider the following test in `mysql_test.go`:
+
+```go
+func TestMySQL_Executor(t *testing.T) {
+	myRun(t, func(t *myTest) {
+		testExecutor(t)
+	})
+}
+```
+
+If you'd wanted to run that test only for mysql56, simply pass its full name into the `-run` flag:
+
+```shell
+# Run TestMySQL_Executor for all mysql versions
+go test -run='MySQL_Executor' ./... 
+
+# Run TestMySQL_Executor for mysql 5.6 only
+go test -run='MySQL_Executor/mysql56' ./...
+```
+
+If you'd like to run the above for Postgres 10, change the name respectively:
+
+```shell
+# Run TestMySQL_Executor for all mysql versions
+go test -run='Postgres_Executor' ./... 
+
+# Run TestMySQL_Executor for postgres 10 only
+go test -run='Postgres_Executor/postgres10' ./...
+```
+
+If you want to run all tests for one specific dialect, like only TiDB 5, you can use the `-dialect` flag:
+
+```shell
+go test -run='TiDB' -dialect='tidb5' ./...
+```

--- a/internal/integration/cockroach_test.go
+++ b/internal/integration/cockroach_test.go
@@ -31,11 +31,11 @@ type crdbTest struct {
 	rrw     migrate.RevisionReadWriter
 	version string
 	port    int
-	once    *sync.Once
+	once    sync.Once
 }
 
 var crdbTests = map[string]*crdbTest{
-	"cockroach": {port: 26257, once: &sync.Once{}},
+	"cockroach": {port: 26257},
 }
 
 func crdbRun(t *testing.T, fn func(*crdbTest)) {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -31,21 +31,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	dbs         []io.Closer
+	flagDialect string
+)
+
 func TestMain(m *testing.M) {
-	var dialect string
-	flag.StringVar(&dialect, "dialect", "", "[mysql56, postgres10, tidb5, ...] what dialect (version) to test")
+	flag.StringVar(&flagDialect, "dialect", "", "[mysql56, postgres10, tidb5, ...] what dialect (version) to test")
 	flag.Parse()
-	var dbs []io.Closer
-	dbs = append(dbs, myInit(dialect)...)
-	dbs = append(dbs, pgInit(dialect)...)
-	dbs = append(dbs, tidbInit(dialect)...)
-	dbs = append(dbs, crdbInit(dialect)...)
-	defer func() {
-		for _, db := range dbs {
-			db.Close()
-		}
-	}()
-	os.Exit(m.Run())
+	code := m.Run()
+	for _, db := range dbs {
+		db.Close()
+	}
+	os.Exit(code)
 }
 
 // T holds the elements common between dialect tests.

--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -28,16 +28,16 @@ type myTest struct {
 	rrw     migrate.RevisionReadWriter
 	version string
 	port    int
-	once    *sync.Once
+	once    sync.Once
 }
 
 var myTests = map[string]*myTest{
-	"mysql56":  {port: 3306, once: &sync.Once{}},
-	"mysql57":  {port: 3307, once: &sync.Once{}},
-	"mysql8":   {port: 3308, once: &sync.Once{}},
-	"maria107": {port: 4306, once: &sync.Once{}},
-	"maria102": {port: 4307, once: &sync.Once{}},
-	"maria103": {port: 4308, once: &sync.Once{}},
+	"mysql56":  {port: 3306},
+	"mysql57":  {port: 3307},
+	"mysql8":   {port: 3308},
+	"maria107": {port: 4306},
+	"maria102": {port: 4307},
+	"maria103": {port: 4308},
 }
 
 func myRun(t *testing.T, fn func(*myTest)) {

--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -8,9 +8,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io"
 	"log"
 	"strings"
+	"sync"
 	"testing"
 
 	"ariga.io/atlas/sql/migrate"
@@ -28,54 +28,40 @@ type myTest struct {
 	rrw     migrate.RevisionReadWriter
 	version string
 	port    int
+	once    *sync.Once
 }
 
-var myTests = struct {
-	drivers map[string]*myTest
-	ports   map[string]int
-}{
-	drivers: make(map[string]*myTest),
-	ports: map[string]int{
-		"mysql56":  3306,
-		"mysql57":  3307,
-		"mysql8":   3308,
-		"maria107": 4306,
-		"maria102": 4307,
-		"maria103": 4308,
-	},
-}
-
-func myInit(d string) []io.Closer {
-	var cs []io.Closer
-	if d != "" {
-		p, ok := myTests.ports[d]
-		if ok {
-			myTests.ports = map[string]int{d: p}
-		} else {
-			myTests.ports = make(map[string]int)
-		}
-	}
-	for version, port := range myTests.ports {
-		db, err := sql.Open("mysql", fmt.Sprintf("root:pass@tcp(localhost:%d)/test?parseTime=True", port))
-		if err != nil {
-			log.Fatalln(err)
-		}
-		cs = append(cs, db)
-		drv, err := mysql.Open(db)
-		if err != nil {
-			log.Fatalln(err)
-		}
-		myTests.drivers[version] = &myTest{db: db, drv: drv, version: version, port: port, rrw: &rrw{}}
-	}
-	return cs
+var myTests = map[string]*myTest{
+	"mysql56":  {port: 3306, once: &sync.Once{}},
+	"mysql57":  {port: 3307, once: &sync.Once{}},
+	"mysql8":   {port: 3308, once: &sync.Once{}},
+	"maria107": {port: 4306, once: &sync.Once{}},
+	"maria102": {port: 4307, once: &sync.Once{}},
+	"maria103": {port: 4308, once: &sync.Once{}},
 }
 
 func myRun(t *testing.T, fn func(*myTest)) {
-	for version, tt := range myTests.drivers {
-		t.Run(version, func(t *testing.T) {
-			tt := &myTest{T: t, db: tt.db, drv: tt.drv, version: version, port: tt.port, rrw: tt.rrw}
-			fn(tt)
-		})
+	for version, tt := range myTests {
+		if flagDialect == "" || flagDialect == version {
+			t.Run(version, func(t *testing.T) {
+				tt.once.Do(func() {
+					var err error
+					tt.version = version
+					tt.rrw = &rrw{}
+					tt.db, err = sql.Open("mysql", fmt.Sprintf("root:pass@tcp(localhost:%d)/test?parseTime=True", tt.port))
+					if err != nil {
+						log.Fatalln(err)
+					}
+					dbs = append(dbs, tt.db) // close connection after all tests have been run
+					tt.drv, err = mysql.Open(tt.db)
+					if err != nil {
+						log.Fatalln(err)
+					}
+				})
+				tt := &myTest{T: t, db: tt.db, drv: tt.drv, version: version, port: tt.port, rrw: tt.rrw}
+				fn(tt)
+			})
+		}
 	}
 }
 

--- a/internal/integration/postgres_test.go
+++ b/internal/integration/postgres_test.go
@@ -30,15 +30,15 @@ type pgTest struct {
 	rrw     migrate.RevisionReadWriter
 	version string
 	port    int
-	once    *sync.Once
+	once    sync.Once
 }
 
 var pgTests = map[string]*pgTest{
-	"postgres10": {port: 5430, once: &sync.Once{}},
-	"postgres11": {port: 5431, once: &sync.Once{}},
-	"postgres12": {port: 5432, once: &sync.Once{}},
-	"postgres13": {port: 5433, once: &sync.Once{}},
-	"postgres14": {port: 5434, once: &sync.Once{}},
+	"postgres10": {port: 5430},
+	"postgres11": {port: 5431},
+	"postgres12": {port: 5432},
+	"postgres13": {port: 5433},
+	"postgres14": {port: 5434},
 }
 
 func pgRun(t *testing.T, fn func(*pgTest)) {

--- a/internal/integration/tidb_test.go
+++ b/internal/integration/tidb_test.go
@@ -9,7 +9,6 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
-	"sync"
 	"testing"
 
 	"ariga.io/atlas/sql/mysql"
@@ -26,8 +25,8 @@ import (
 )
 
 var tidbTests = map[string]*myTest{
-	"tidb5": {port: 4309, once: &sync.Once{}},
-	"tidb6": {port: 4310, once: &sync.Once{}},
+	"tidb5": {port: 4309},
+	"tidb6": {port: 4310},
 }
 
 func tidbRun(t *testing.T, fn func(*myTest)) {


### PR DESCRIPTION
…s itself.

With this changes it is no longer required to have all integration containers running if one only works on one dialect or version. This works by only then spinning up a connection to a database if it is requested the first time. Subsequent calls re-use the existing connection.

If a connection for a container is requested and the container is not running, there still will be an error and the test will fail.

CI has been changed to respect those changes.