### PR TITLE
cmd/atlas/internal/ent: drop columns on revisions table migration and…

### DIFF
--- a/cmd/atlas/internal/migrate/ent/migrate/schema.go
+++ b/cmd/atlas/internal/migrate/ent/migrate/schema.go
@@ -17,7 +17,7 @@ var (
 	AtlasSchemaRevisionsColumns = []*schema.Column{
 		{Name: "version", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString},
-		{Name: "type", Type: field.TypeUint},
+		{Name: "type", Type: field.TypeUint, Default: 2},
 		{Name: "applied", Type: field.TypeInt},
 		{Name: "total", Type: field.TypeInt},
 		{Name: "executed_at", Type: field.TypeTime},

--- a/cmd/atlas/internal/migrate/ent/revision/revision.go
+++ b/cmd/atlas/internal/migrate/ent/revision/revision.go
@@ -6,6 +6,10 @@
 
 package revision
 
+import (
+	"ariga.io/atlas/sql/migrate"
+)
+
 const (
 	// Label holds the string label denoting the revision type in the database.
 	Label = "revision"
@@ -61,6 +65,8 @@ func ValidColumn(column string) bool {
 }
 
 var (
+	// DefaultType holds the default value on creation for the "type" field.
+	DefaultType migrate.RevisionType
 	// AppliedValidator is a validator for the "applied" field. It is called by the builders before save.
 	AppliedValidator func(int) error
 	// TotalValidator is a validator for the "total" field. It is called by the builders before save.

--- a/cmd/atlas/internal/migrate/ent/revision_update.go
+++ b/cmd/atlas/internal/migrate/ent/revision_update.go
@@ -41,6 +41,14 @@ func (ru *RevisionUpdate) SetType(mt migrate.RevisionType) *RevisionUpdate {
 	return ru
 }
 
+// SetNillableType sets the "type" field if the given value is not nil.
+func (ru *RevisionUpdate) SetNillableType(mt *migrate.RevisionType) *RevisionUpdate {
+	if mt != nil {
+		ru.SetType(*mt)
+	}
+	return ru
+}
+
 // AddType adds mt to the "type" field.
 func (ru *RevisionUpdate) AddType(mt migrate.RevisionType) *RevisionUpdate {
 	ru.mutation.AddType(mt)
@@ -349,6 +357,14 @@ type RevisionUpdateOne struct {
 func (ruo *RevisionUpdateOne) SetType(mt migrate.RevisionType) *RevisionUpdateOne {
 	ruo.mutation.ResetType()
 	ruo.mutation.SetType(mt)
+	return ruo
+}
+
+// SetNillableType sets the "type" field if the given value is not nil.
+func (ruo *RevisionUpdateOne) SetNillableType(mt *migrate.RevisionType) *RevisionUpdateOne {
+	if mt != nil {
+		ruo.SetType(*mt)
+	}
 	return ruo
 }
 

--- a/cmd/atlas/internal/migrate/ent/runtime.go
+++ b/cmd/atlas/internal/migrate/ent/runtime.go
@@ -9,6 +9,7 @@ package ent
 import (
 	"ariga.io/atlas/cmd/atlas/internal/migrate/ent/revision"
 	"ariga.io/atlas/cmd/atlas/internal/migrate/ent/schema"
+	"ariga.io/atlas/sql/migrate"
 )
 
 // The init function reads all schema descriptors with runtime code
@@ -17,6 +18,10 @@ import (
 func init() {
 	revisionFields := schema.Revision{}.Fields()
 	_ = revisionFields
+	// revisionDescType is the schema descriptor for type field.
+	revisionDescType := revisionFields[2].Descriptor()
+	// revision.DefaultType holds the default value on creation for the type field.
+	revision.DefaultType = migrate.RevisionType(revisionDescType.Default.(uint))
 	// revisionDescApplied is the schema descriptor for applied field.
 	revisionDescApplied := revisionFields[3].Descriptor()
 	// revision.AppliedValidator is a validator for the "applied" field. It is called by the builders before save.

--- a/cmd/atlas/internal/migrate/ent/schema/revision.go
+++ b/cmd/atlas/internal/migrate/ent/schema/revision.go
@@ -29,7 +29,8 @@ func (Revision) Fields() []ent.Field {
 		field.String("description").
 			Immutable(),
 		field.Uint("type").
-			GoType(migrate.RevisionType(0)),
+			GoType(migrate.RevisionType(0)).
+			Default(uint(migrate.RevisionTypeExecute)),
 		field.Int("applied").
 			NonNegative(),
 		field.Int("total").

--- a/cmd/atlas/internal/migrate/migrate.go
+++ b/cmd/atlas/internal/migrate/migrate.go
@@ -15,6 +15,7 @@ import (
 	"ariga.io/atlas/sql/sqlclient"
 	"entgo.io/ent/dialect"
 	"entgo.io/ent/dialect/sql"
+	entschema "entgo.io/ent/dialect/sql/schema"
 )
 
 // DefaultRevisionSchema is the default schema for storing revisions table.
@@ -91,7 +92,7 @@ func (r *EntRevisions) Init(ctx context.Context) error {
 	}
 	r.ac.AddClosers(sc)
 	r.ec = ent.NewClient(ent.Driver(sql.OpenDB(sc.Name, sc.DB)))
-	return r.ec.Schema.Create(ctx)
+	return r.ec.Schema.Create(ctx, entschema.WithDropColumn(true))
 }
 
 // ReadRevision reads a revision from the revisions table.


### PR DESCRIPTION
… set default value for backwards compatability

Resolves #1093