### PR TITLE
sql/migrate: pending files are all files after the last fully applied one

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -383,7 +383,7 @@ func TestMigrate_New(t *testing.T) {
 	require.Equal(t, 2, countFiles(t, p))
 
 	p = t.TempDir()
-	s, err = runCmd(Root, "migrate", "new", "dbmate", "--dir", "file://"+p, "--dir-format", formatDbmate)
+	s, err = runCmd(Root, "migrate", "new", "dbmate", "--dir", "file://"+p, "--dir-format", formatDBMate)
 	require.Zero(t, s)
 	require.NoError(t, err)
 	require.FileExists(t, filepath.Join(p, v+"_dbmate.sql"))

--- a/cmd/atlas/internal/migrate/ent/convert.tmpl
+++ b/cmd/atlas/internal/migrate/ent/convert.tmpl
@@ -1,0 +1,34 @@
+{{/* gotype: entgo.io/ent/entc/gen.Graph */}}
+
+{{ define "convert" }}
+
+{{ $pkg := base $.Config.Package }}
+{{ template "header" $ }}
+
+import "ariga.io/atlas/sql/migrate"
+
+{{ range $n := $.Nodes }}
+    {{ if eq $n.Name "Revision" }}
+        {{ $builder := $n.CreateName }}
+        {{ $receiver := receiver $builder }}
+
+        // SetRevision takes the values for each field from the given migrate.Revision.
+        func ({{ $receiver }} *{{ $builder }}) SetRevision(rev *migrate.Revision) *{{ $builder }} {
+            {{- range $f := $n.Fields }}
+                {{ $receiver }}.Set{{ $f.StructField }}(rev.{{ $f.StructField }})
+            {{- end }}
+            return {{ $receiver }}
+        }
+
+        // AtlasRevision returns an migrate.Revision from the current Revision.
+        func({{ $n.Receiver}} *Revision) AtlasRevision() *migrate.Revision {
+            return &migrate.Revision{
+                {{- range $f := $n.Fields }}
+                    {{ $f.StructField }}: r.{{ $f.StructField }},
+                {{- end }}
+            }
+        }
+    {{ end }}
+{{ end }}
+
+{{ end }}

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -107,12 +107,12 @@ If run with the "--dry-run" flag, atlas will not execute any SQL.
 ```
 #### Flags
 ```
-      --allow-dirty               allow start working on a non-clean database
-      --baseline string           start the first migration after the given baseline version
-      --dry-run                   do not actually execute any SQL but show it on screen
-      --from string               calculate pending files from the given version (including it)
       --log string                log format to use (default "tty")
       --revisions-schema string   schema name where the revisions table resides (default "atlas_schema_revisions")
+      --dry-run                   do not actually execute any SQL but show it on screen
+      --from string               calculate pending files from the given version (including it)
+      --baseline string           start the first migration after the given baseline version
+      --allow-dirty               allow start working on a non-clean database
   -u, --url string                [driver://username:password@address/dbname?param=value] select a database using the URL format
 
 ```

--- a/sql/migrate/migrate.go
+++ b/sql/migrate/migrate.go
@@ -521,6 +521,10 @@ func (e *Executor) Pending(ctx context.Context) ([]File, error) {
 		lastIdx := RevisionsLastIndex(revs, func(r *Revision) bool {
 			return r.Applied == r.Total
 		})
+		if lastIdx == -1 {
+			pending = migrations
+			break
+		}
 		last := revs[lastIdx]
 		idx := FilesLastIndex(migrations, func(f File) bool {
 			return f.Version() == last.Version

--- a/sql/migrate/migrate_test.go
+++ b/sql/migrate/migrate_test.go
@@ -414,7 +414,7 @@ func TestExecutor_FromVersion(t *testing.T) {
 	ex, err = migrate.NewExecutor(drv, dir, rrw, migrate.WithLogger(log), migrate.WithFromVersion("4"))
 	require.NoError(t, err)
 	files, err = ex.Pending(context.Background())
-	require.EqualError(t, err, `starting point version "4" was not found in the migration directory`)
+	require.EqualError(t, err, `starting point version "4" not found in the migration directory`)
 	require.Nil(t, files)
 }
 

--- a/sql/migrate/migrate_test.go
+++ b/sql/migrate/migrate_test.go
@@ -195,6 +195,21 @@ func TestExecutor_Pending(t *testing.T) {
 	p, err = ex.Pending(context.Background())
 	require.NoError(t, err)
 	require.Len(t, p, 1)
+
+	// All versions have revisions, but are last two are rolled back (0 applied).
+	rev2.Applied = 0
+	rev3.Applied = 0
+	*rrw = mockRevisionReadWriter(migrate.Revisions{rev1, rev2, rev3})
+	p, err = ex.Pending(context.Background())
+	require.NoError(t, err)
+	require.Len(t, p, 2)
+
+	// All versions have revisions, but are all rolled back (0 applied).
+	rev1.Applied = 0
+	*rrw = mockRevisionReadWriter(migrate.Revisions{rev1, rev2, rev3})
+	p, err = ex.Pending(context.Background())
+	require.NoError(t, err)
+	require.Len(t, p, 3)
 }
 
 func TestExecutor(t *testing.T) {


### PR DESCRIPTION
Next PR will add the possibility to rollback more than one file in a transaction and therefore we need to re-apply more than one file in that case.