### PR TITLE
sql/migrate: scan associated comments from files

### DIFF
--- a/sql/migrate/dir.go
+++ b/sql/migrate/dir.go
@@ -171,8 +171,22 @@ func (f LocalFile) Version() string {
 	return strings.SplitN(strings.TrimSuffix(f.n, ".sql"), "_", 2)[0]
 }
 
-// Stmts implements Scanner.Stmts. It reads migration file line-by-line and expects a statement to be one line only.
+// Stmts returns the SQL statement exists in the local file.
 func (f LocalFile) Stmts() ([]string, error) {
+	s, err := stmts(string(f.b))
+	if err != nil {
+		return nil, err
+	}
+	stmts := make([]string, len(s))
+	for i := range s {
+		stmts[i] = s[i].Text
+	}
+	return stmts, nil
+}
+
+// StmtDecls returns the all statement declarations exist
+// in the local file.
+func (f LocalFile) StmtDecls() ([]*Stmt, error) {
 	return stmts(string(f.b))
 }
 

--- a/sql/migrate/lex_test.go
+++ b/sql/migrate/lex_test.go
@@ -27,3 +27,41 @@ func TestLocalFile_Stmts(t *testing.T) {
 		require.Equal(t, string(buf), strings.Join(stmts, "\n-- end --\n"))
 	}
 }
+
+func TestLocalFile_StmtDecls(t *testing.T) {
+	f := NewLocalFile("f", []byte(`
+-- test
+cmd1;
+
+-- hello
+-- world
+cmd2;
+
+-- skip
+-- this
+# comment
+
+/* Skip this as well */
+
+# Skip this
+/* one */
+
+# command
+cmd3;
+
+/* comment1 */
+/* comment2 */
+cmd4;
+`))
+	stmts, err := f.StmtDecls()
+	require.NoError(t, err)
+	require.Len(t, stmts, 4)
+	require.Equal(t, "cmd1;", stmts[0].Text)
+	require.Equal(t, []string{"-- test\n"}, stmts[0].Comments)
+	require.Equal(t, "cmd2;", stmts[1].Text)
+	require.Equal(t, []string{"-- hello\n", "-- world\n"}, stmts[1].Comments)
+	require.Equal(t, "cmd3;", stmts[2].Text)
+	require.Equal(t, []string{"# command\n"}, stmts[2].Comments)
+	require.Equal(t, "cmd4;", stmts[3].Text)
+	require.Equal(t, []string{"/* comment1 */", "/* comment2 */"}, stmts[3].Comments)
+}


### PR DESCRIPTION
Next PRs will add support for additional position information and implement the `-- nolint` directive. 