### PR TITLE
cmd/atlas/internal/cmdapi: add migrate clean command

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -74,6 +74,9 @@ var (
 			BaselineVersion string
 			TxMode          string
 		}
+		Clean struct {
+			AutoApprove bool
+		}
 		Diff struct {
 			Qualifier string // optional table qualifier
 		}

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -74,9 +74,6 @@ var (
 			BaselineVersion string
 			TxMode          string
 		}
-		Clean struct {
-			AutoApprove bool
-		}
 		Diff struct {
 			Qualifier string // optional table qualifier
 		}

--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -26,7 +26,6 @@ import (
 	"ariga.io/atlas/sql/sqlite"
 	_ "ariga.io/atlas/sql/sqlite"
 	_ "ariga.io/atlas/sql/sqlite/sqlitecheck"
-
 	"github.com/fatih/color"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"

--- a/cmd/atlas/internal/cmdapi/schema.go
+++ b/cmd/atlas/internal/cmdapi/schema.go
@@ -100,10 +100,10 @@ migration.`,
 	SchemaClean = &cobra.Command{
 		Use:   "clean [flags]",
 		Short: "Removes all objects from the connected database.",
-		Long: `'atlas migrate clean' drops all objects in the connected database and leaves it in an empty state.
-As a safety feature, 'atlas migrate clean' will ask for confirmation before attempting to execute any SQL.`,
-		Example: `  atlas migrate clean -u mysql://user:pass@localhost:3306/dbname
-  atlas migrate clean --auto-approve --env local `,
+		Long: `'atlas schema clean' drops all objects in the connected database and leaves it in an empty state.
+As a safety feature, 'atlas schema clean' will ask for confirmation before attempting to execute any SQL.`,
+		Example: `  atlas schema clean -u mysql://user:pass@localhost:3306/dbname
+  atlas schema clean -u mysql://user:pass@localhost:3306/`,
 		PreRunE: schemaFlagsFromEnv,
 		RunE:    CmdCleanRun,
 	}

--- a/cmd/atlas/internal/cmdapi/schema.go
+++ b/cmd/atlas/internal/cmdapi/schema.go
@@ -8,9 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,9 +32,6 @@ const (
 )
 
 var (
-	promptIn  io.ReadCloser  = nil
-	promptOut io.WriteCloser = nil
-
 	// schemaCmd represents the subcommand 'atlas schema'.
 	schemaCmd = &cobra.Command{
 		Use:   "schema",
@@ -458,10 +453,8 @@ func applyRun(cmd *cobra.Command, client *sqlclient.Client, devURL string, paths
 
 func promptUser() bool {
 	prompt := promptui.Select{
-		Label:  "Are you sure?",
-		Items:  []string{answerApply, answerAbort},
-		Stdin:  promptIn,
-		Stdout: promptOut,
+		Label: "Are you sure?",
+		Items: []string{answerApply, answerAbort},
 	}
 	_, result, err := prompt.Run()
 	cobra.CheckErr(err)
@@ -495,7 +488,7 @@ func tasks(path string) ([]fmttask, error) {
 		}
 		return tasks, nil
 	}
-	all, err := ioutil.ReadDir(path)
+	all, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
@@ -504,9 +497,13 @@ func tasks(path string) ([]fmttask, error) {
 			continue
 		}
 		if strings.HasSuffix(f.Name(), ".hcl") {
+			i, err := f.Info()
+			if err != nil {
+				return nil, err
+			}
 			tasks = append(tasks, fmttask{
 				path: filepath.Join(path, f.Name()),
-				info: f,
+				info: i,
 			})
 		}
 	}

--- a/cmd/atlas/internal/cmdapi/schema_test.go
+++ b/cmd/atlas/internal/cmdapi/schema_test.go
@@ -6,12 +6,18 @@ package cmdapi
 
 import (
 	"bytes"
+	"context"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
 
+	"ariga.io/atlas/sql/migrate"
+	"ariga.io/atlas/sql/sqlclient"
+	"github.com/chzyer/readline"
 	"github.com/stretchr/testify/require"
 )
 
@@ -102,6 +108,58 @@ func TestFmt(t *testing.T) {
 		})
 	}
 }
+
+func TestSchema_Clean(t *testing.T) {
+	var (
+		u      = fmt.Sprintf("sqlite://file:%s?cache=shared&_fk=1", filepath.Join(t.TempDir(), "test.db"))
+		c, err = sqlclient.Open(context.Background(), u)
+	)
+	require.NoError(t, err)
+
+	// Apply migrations onto database.
+	_, err = runCmd(Root, "migrate", "apply", "--dir", "file://testdata/sqlite", "--url", u)
+	require.NoError(t, err)
+
+	// Shows confirmation and aborts on "Abort".
+	promptIn = readCloserString(string(rune(readline.CharNext)) + "\n")
+	promptOut = writeClose{io.Discard}
+	t.Cleanup(func() {
+		promptIn = nil
+		promptOut = nil
+	})
+	s, err := runCmd(Root, "schema", "clean", "--url", u)
+	require.NoError(t, err)
+	require.NotZero(t, s)
+	require.ErrorAs(t, c.Driver.(migrate.CleanChecker).CheckClean(context.Background(), nil), &migrate.NotCleanError{})
+
+	// // Shows confirmation and proceeds on "Apply".
+	promptIn = readCloserString("\n")
+	s, err = runCmd(Root, "schema", "clean", "--url", u)
+	require.NoError(t, err)
+	require.NotZero(t, s)
+	require.NoError(t, c.Driver.(migrate.CleanChecker).CheckClean(context.Background(), nil))
+
+	// Auto-Approve does not require a confirmation.
+	_, err = runCmd(Root, "migrate", "apply", "--dir", "file://testdata/sqlite", "--url", u)
+	require.NoError(t, err)
+	s, err = runCmd(Root, "schema", "clean", "--url", u, "--auto-approve")
+	require.NoError(t, err)
+	require.NotZero(t, s)
+	require.NoError(t, c.Driver.(migrate.CleanChecker).CheckClean(context.Background(), nil))
+}
+
+func readCloserString(s string) io.ReadCloser {
+	return bufClose{bytes.NewBufferString(s)}
+}
+
+type (
+	bufClose   struct{ *bytes.Buffer }
+	writeClose struct{ io.Writer }
+)
+
+func (bufClose) Close() error { return nil }
+
+func (writeClose) Close() error { return nil }
 
 func runFmt(t *testing.T, args []string) string {
 	var out bytes.Buffer

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -119,6 +119,33 @@ If run with the "--dry-run" flag, atlas will not execute any SQL.
 ```
 
 
+### atlas migrate clean
+
+Removes all objects from the connected database.
+
+#### Usage
+```
+atlas migrate clean [flags]
+```
+
+#### Details
+'atlas migrate clean' drops all objects in the connected database and leaves it in an empty state.
+As a safety feature, 'atlas migrate clean' will ask for confirmation before attempting to execute any SQL.
+
+#### Example
+
+```
+  atlas migrate clean -u mysql://user:pass@localhost:3306/dbname
+  atlas migrate clean --auto-approve --env local 
+```
+#### Flags
+```
+      --local-url string   [driver://username:password@address/dbname?param=value] select a database using the URL format
+      --auto-approve       Auto approve. Drop the resources without prompting for approval.
+
+```
+
+
 ### atlas migrate diff
 
 Compute the diff between the migration directory and a desired state and create a new migration file.

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -349,14 +349,14 @@ atlas schema clean [flags]
 ```
 
 #### Details
-'atlas migrate clean' drops all objects in the connected database and leaves it in an empty state.
-As a safety feature, 'atlas migrate clean' will ask for confirmation before attempting to execute any SQL.
+'atlas schema clean' drops all objects in the connected database and leaves it in an empty state.
+As a safety feature, 'atlas schema clean' will ask for confirmation before attempting to execute any SQL.
 
 #### Example
 
 ```
-  atlas migrate clean -u mysql://user:pass@localhost:3306/dbname
-  atlas migrate clean --auto-approve --env local 
+  atlas schema clean -u mysql://user:pass@localhost:3306/dbname
+  atlas schema clean -u mysql://user:pass@localhost:3306/
 ```
 #### Flags
 ```

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -119,33 +119,6 @@ If run with the "--dry-run" flag, atlas will not execute any SQL.
 ```
 
 
-### atlas migrate clean
-
-Removes all objects from the connected database.
-
-#### Usage
-```
-atlas migrate clean [flags]
-```
-
-#### Details
-'atlas migrate clean' drops all objects in the connected database and leaves it in an empty state.
-As a safety feature, 'atlas migrate clean' will ask for confirmation before attempting to execute any SQL.
-
-#### Example
-
-```
-  atlas migrate clean -u mysql://user:pass@localhost:3306/dbname
-  atlas migrate clean --auto-approve --env local 
-```
-#### Flags
-```
-      --local-url string   [driver://username:password@address/dbname?param=value] select a database using the URL format
-      --auto-approve       Auto approve. Drop the resources without prompting for approval.
-
-```
-
-
 ### atlas migrate diff
 
 Compute the diff between the migration directory and a desired state and create a new migration file.
@@ -362,6 +335,34 @@ migration.
                           before running migration.
       --dry-run           Dry-run. Print SQL plan without prompting for execution.
       --auto-approve      Auto approve. Apply the schema changes without prompting for approval.
+
+```
+
+
+### atlas schema clean
+
+Removes all objects from the connected database.
+
+#### Usage
+```
+atlas schema clean [flags]
+```
+
+#### Details
+'atlas migrate clean' drops all objects in the connected database and leaves it in an empty state.
+As a safety feature, 'atlas migrate clean' will ask for confirmation before attempting to execute any SQL.
+
+#### Example
+
+```
+  atlas migrate clean -u mysql://user:pass@localhost:3306/dbname
+  atlas migrate clean --auto-approve --env local 
+```
+#### Flags
+```
+      --auto-approve   Auto approve. Apply the schema changes without prompting for approval.
+  -u, --url string     URL to the database using the format:
+                       [driver://username:password@address/dbname?param=value]
 
 ```
 


### PR DESCRIPTION
As a safety guard this command requires the `--local-url` flag as well as a confirmation from the user, unless the `--auto-approve` flag is given.