### PR TITLE
cmd/atlas/internal: change default behavior of revision table location

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -331,13 +331,13 @@ func CmdMigrateApplyRun(cmd *cobra.Command, args []string) error {
 			s, err := c.InspectSchema(cmd.Context(), defaultRevisionSchema, opts)
 			switch {
 			case schema.IsNotExistError(err):
-				goto proceed
 			case err != nil:
 				return err
-			}
-			if _, ok := s.Table(revision.Table); ok {
-				fmt.Fprintf(cmd.OutOrStderr(), `We couldn't find a revision table in the connected schema but 
-found one in the schema 'atlas_schema_revisions' and cannot.
+			default:
+				if _, ok := s.Table(revision.Table); ok {
+					fmt.Fprintf(cmd.OutOrStderr(),
+						`We couldn't find a revision table in the connected schema but found one in 
+the schema 'atlas_schema_revisions' and cannot determine the desired behavior.
 
 As a safety guard, we require you to specify whether to use the existing
 table in 'atlas_schema_revisions' or create a new one in the connected schema
@@ -345,12 +345,12 @@ by providing the '--revisions-schema' flag or deleting the 'atlas_schema_revisio
 schema if it is unused.
 
 `)
-				cmd.SilenceUsage = true
-				return errors.New("ambiguous revision table")
+					cmd.SilenceUsage = true
+					return errors.New("ambiguous revision table")
+				}
 			}
 		}
 	}
-proceed:
 	// Get the correct log format and destination. Currently, only os.Stdout is supported.
 	l, err := logFormat(cmd.OutOrStdout())
 	if err != nil {

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -422,6 +422,7 @@ schema if it is unused.
 
 `)
 					cmd.SilenceUsage = true
+					cmd.SilenceErrors = true
 					return errors.New("ambiguous revision table")
 				}
 			}
@@ -444,7 +445,7 @@ func revisionSchemaName(c *sqlclient.Client) string {
 	case c.URL.Schema != "":
 		return c.URL.Schema
 	default:
-		return "atlas_schema_revisions"
+		return defaultRevisionSchema
 	}
 }
 

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -276,9 +276,6 @@ func init() {
 	receivesEnv(MigrateCmd)
 }
 
-// defaultRevisionSchema is the default schema for storing revisions table.
-const defaultRevisionSchema = "atlas_schema_revisions"
-
 // CmdMigrateApplyRun is the command executed when running the CLI with 'migrate apply' args.
 func CmdMigrateApplyRun(cmd *cobra.Command, args []string) error {
 	var (
@@ -314,42 +311,8 @@ func CmdMigrateApplyRun(cmd *cobra.Command, args []string) error {
 		// If unlocking fails notify the user about it.
 		defer cobra.CheckErr(unlock())
 	}
-	// The "old" default  behavior for the revision schema location was to store the revision table in its own schema.
-	// Now, the table is saved in the connected schema, if any. To keep the backwards compatability, we now require
-	// for schema bound connections to have the schema-revision flag present if there is no revision table in the schema
-	// but the old default schema does have one.
-	if c.URL.Schema != "" && MigrateFlags.RevisionSchema == "" {
-		// If the scheme does not contain a revision table, but we can find a table in the previous default schema,
-		// abort and tell the user to specify the intention.
-		opts := &schema.InspectOptions{Tables: []string{revision.Table}}
-		s, err := c.InspectSchema(cmd.Context(), "", opts)
-		if err != nil {
-			return err
-		}
-		if _, ok := s.Table(revision.Table); !ok {
-			// Check for the old default schema. If it does not exist, we have no problem.
-			s, err := c.InspectSchema(cmd.Context(), defaultRevisionSchema, opts)
-			switch {
-			case schema.IsNotExistError(err):
-			case err != nil:
-				return err
-			default:
-				if _, ok := s.Table(revision.Table); ok {
-					fmt.Fprintf(cmd.OutOrStderr(),
-						`We couldn't find a revision table in the connected schema but found one in 
-the schema 'atlas_schema_revisions' and cannot determine the desired behavior.
-
-As a safety guard, we require you to specify whether to use the existing
-table in 'atlas_schema_revisions' or create a new one in the connected schema
-by providing the '--revisions-schema' flag or deleting the 'atlas_schema_revisions'
-schema if it is unused.
-
-`)
-					cmd.SilenceUsage = true
-					return errors.New("ambiguous revision table")
-				}
-			}
-		}
+	if err := checkRevisionSchemaClarity(cmd, c); err != nil {
+		return err
 	}
 	// Get the correct log format and destination. Currently, only os.Stdout is supported.
 	l, err := logFormat(cmd.OutOrStdout())
@@ -418,17 +381,71 @@ schema if it is unused.
 	return mux.commit()
 }
 
+func checkRevisionSchemaClarity(cmd *cobra.Command, c *sqlclient.Client) error {
+	// The "old" default  behavior for the revision schema location was to store the revision table in its own schema.
+	// Now, the table is saved in the connected schema, if any. To keep the backwards compatability, we now require
+	// for schema bound connections to have the schema-revision flag present if there is no revision table in the schema
+	// but the old default schema does have one.
+	if c.URL.Schema != "" && MigrateFlags.RevisionSchema == "" {
+		// If the schema does not contain a revision table, but we can find a table in the previous default schema,
+		// abort and tell the user to specify the intention.
+		opts := &schema.InspectOptions{Tables: []string{revision.Table}}
+		s, err := c.InspectSchema(cmd.Context(), "", opts)
+		var ok bool
+		switch {
+		case schema.IsNotExistError(err):
+			// If the schema does not exist, the table does not as well.
+		case err != nil:
+			return err
+		default:
+			// Connected schema does exist, check if the table does.
+			_, ok = s.Table(revision.Table)
+		}
+		if !ok { // Either schema or table does not exist.
+			// Check for the old default schema. If it does not exist, we have no problem.
+			s, err := c.InspectSchema(cmd.Context(), defaultRevisionSchema, opts)
+			switch {
+			case schema.IsNotExistError(err):
+				// Schema does not exist, we can proceed.
+			case err != nil:
+				return err
+			default:
+				if _, ok := s.Table(revision.Table); ok {
+					fmt.Fprintf(cmd.OutOrStderr(),
+						`We couldn't find a revision table in the connected schema but found one in 
+the schema 'atlas_schema_revisions' and cannot determine the desired behavior.
+
+As a safety guard, we require you to specify whether to use the existing
+table in 'atlas_schema_revisions' or create a new one in the connected schema
+by providing the '--revisions-schema' flag or deleting the 'atlas_schema_revisions'
+schema if it is unused.
+
+`)
+					cmd.SilenceUsage = true
+					return errors.New("ambiguous revision table")
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func entRevisions(ctx context.Context, c *sqlclient.Client) (*entmigrate.EntRevisions, error) {
-	var s string
+	return entmigrate.NewEntRevisions(ctx, c, entmigrate.WithSchema(revisionSchemaName(c)))
+}
+
+// defaultRevisionSchema is the default schema for storing revisions table.
+const defaultRevisionSchema = "atlas_schema_revisions"
+
+func revisionSchemaName(c *sqlclient.Client) string {
 	switch {
 	case MigrateFlags.RevisionSchema != "":
-		s = MigrateFlags.RevisionSchema
+		return MigrateFlags.RevisionSchema
 	case c.URL.Schema != "":
-		s = c.URL.Schema
+		return c.URL.Schema
 	default:
-		s = defaultRevisionSchema
+		return "atlas_schema_revisions"
 	}
-	return entmigrate.NewEntRevisions(ctx, c, entmigrate.WithSchema(s))
 }
 
 // tx handles wrapping migration execution in transactions.
@@ -639,14 +656,27 @@ func CmdMigrateStatusRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	defer client.Close()
-	if ok, err := revisionsTableExists(cmd.Context(), client); !ok || err != nil {
-		if err != nil {
-			return err
-		}
+	if err := checkRevisionSchemaClarity(cmd, client); err != nil {
+		return err
+	}
+	// Inspect schema and check if the table does already exist.
+	s, err := client.InspectSchema(
+		cmd.Context(),
+		revisionSchemaName(client),
+		&schema.InspectOptions{Tables: []string{revision.Table}},
+	)
+	switch {
+	case err != nil && !schema.IsNotExistError(err):
+		return err
+	case schema.IsNotExistError(err):
+		return statusPrint(cmd.OutOrStdout(), avail, avail, nil)
+	}
+	if _, ok := s.Table(revision.Table); !ok {
+		// Table does not exist.
 		return statusPrint(cmd.OutOrStdout(), avail, avail, nil)
 	}
 	// Currently, only in DB revisions are supported.
-	rrw, err := entmigrate.NewEntRevisions(cmd.Context(), client, entmigrate.WithSchema(MigrateFlags.RevisionSchema))
+	rrw, err := entRevisions(cmd.Context(), client)
 	if err != nil {
 		return err
 	}
@@ -818,36 +848,6 @@ Please check your migration files and run
 to re-hash the contents and resolve the error
 
 `)
-}
-
-func revisionsTableExists(ctx context.Context, c *sqlclient.Client) (bool, error) {
-	// Connect to the given schema name.
-	sc, err := sqlclient.Open(ctx, MigrateFlags.URL, sqlclient.OpenSchema(MigrateFlags.RevisionSchema))
-	switch {
-	case err != nil && !errors.Is(err, sqlclient.ErrUnsupported):
-		return false, err
-	case errors.Is(err, sqlclient.ErrUnsupported):
-		// If the driver does not support changing the schema use the existing connection.
-		sc = c
-	case err == nil:
-		// Connecting attempt to the schema was successful, make sure to close it.
-		defer sc.Close()
-	}
-	// Inspect schema and check if the table does already exist.
-	s, err := sc.InspectSchema(ctx, "", &schema.InspectOptions{Tables: []string{revision.Table}})
-	switch {
-	case err != nil && !schema.IsNotExistError(err):
-		return false, err
-	case schema.IsNotExistError(err):
-		// Schema does not exist.
-		return false, nil
-	}
-	if _, ok := s.Table(revision.Table); !ok {
-		// Table does not exist.
-		return false, nil
-	}
-	// Schema and Table are present.
-	return true, nil
 }
 
 // dir returns a migrate.Dir to use as migration directory. For now only local directories are supported.

--- a/cmd/atlas/internal/migrate/migrate.go
+++ b/cmd/atlas/internal/migrate/migrate.go
@@ -39,9 +39,6 @@ func NewEntRevisions(ctx context.Context, ac *sqlclient.Client, opts ...Option) 
 			return nil, err
 		}
 	}
-	if r.schema == "" {
-		r.schema = sch.DefaultRevisionSchema
-	}
 	// Create the connection with the underlying migrate.Driver to have it inside a possible transaction.
 	entopts := []ent.Option{ent.Driver(sql.NewDriver(r.ac.Name, sql.Conn{ExecQuerier: r.ac.Driver}))}
 	// SQLite does not support multiple schema, therefore schema-config is only needed for other dialects.
@@ -58,8 +55,10 @@ func NewEntRevisions(ctx context.Context, ac *sqlclient.Client, opts ...Option) 
 				return nil, err
 			}
 		}
-		// Tell Ent to operate on that schema.
-		entopts = append(entopts, ent.AlternateSchema(ent.SchemaConfig{Revision: r.schema}))
+		// Tell Ent to operate on a given schema.
+		if r.schema != "" {
+			entopts = append(entopts, ent.AlternateSchema(ent.SchemaConfig{Revision: r.schema}))
+		}
 	}
 	// Instantiate the Ent client and migrate the revision schema.
 	r.ec = ent.NewClient(entopts...)

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -105,7 +105,7 @@ If run with the "--dry-run" flag, atlas will not execute any SQL.
 #### Flags
 ```
       --log string                log format to use (default "tty")
-      --revisions-schema string   schema name where the revisions table resides (default "atlas_schema_revisions")
+      --revisions-schema string   schema name where the revisions table resides
       --dry-run                   do not actually execute any SQL but show it on screen
       --from string               calculate pending files from the given version (including it)
       --baseline string           start the first migration after the given baseline version
@@ -232,7 +232,7 @@ atlas migrate status [flags]
 ```
 #### Flags
 ```
-      --revisions-schema string   schema name where the revisions table resides (default "atlas_schema_revisions")
+      --revisions-schema string   schema name where the revisions table resides
   -u, --url string                [driver://username:password@address/dbname?param=value] select a database using the URL format
 
 ```

--- a/internal/integration/cockroach_test.go
+++ b/internal/integration/cockroach_test.go
@@ -369,17 +369,17 @@ func TestCockroach_CLI(t *testing.T) {
 			}`
 	t.Run("SchemaInspect", func(t *testing.T) {
 		crdbRun(t, func(t *crdbTest) {
-			testCLISchemaInspect(t, h, t.dsn(), postgres.EvalHCL, "-s", "public")
+			testCLISchemaInspect(t, h, t.url(""), postgres.EvalHCL, "-s", "public")
 		})
 	})
 	t.Run("SchemaApply", func(t *testing.T) {
 		crdbRun(t, func(t *crdbTest) {
-			testCLISchemaApply(t, h, t.dsn(), "-s", "public")
+			testCLISchemaApply(t, h, t.url(""), "-s", "public")
 		})
 	})
 	t.Run("SchemaApplyDryRun", func(t *testing.T) {
 		crdbRun(t, func(t *crdbTest) {
-			testCLISchemaApplyDry(t, h, t.dsn())
+			testCLISchemaApplyDry(t, h, t.url(""))
 		})
 	})
 	t.Run("SchemaApplyWithVars", func(t *testing.T) {
@@ -398,17 +398,17 @@ table "users" {
 }
 `
 		crdbRun(t, func(t *crdbTest) {
-			testCLISchemaApply(t, h, t.dsn(), "--var", "tenant=public", "-s", "public")
+			testCLISchemaApply(t, h, t.url(""), "--var", "tenant=public", "-s", "public")
 		})
 	})
 	t.Run("SchemaDiffRun", func(t *testing.T) {
 		crdbRun(t, func(t *crdbTest) {
-			testCLISchemaDiff(t, t.dsn())
+			testCLISchemaDiff(t, t.url(""))
 		})
 	})
 	t.Run("SchemaApplyAutoApprove", func(t *testing.T) {
 		crdbRun(t, func(t *crdbTest) {
-			testCLISchemaApplyAutoApprove(t, h, t.dsn(), "-s", "public")
+			testCLISchemaApplyAutoApprove(t, h, t.url(""), "-s", "public")
 		})
 	})
 }
@@ -441,14 +441,14 @@ func TestCockroach_CLI_MultiSchema(t *testing.T) {
 		crdbRun(t, func(t *crdbTest) {
 			t.dropSchemas("test2")
 			t.dropTables("users")
-			testCLIMultiSchemaInspect(t, h, t.dsn(), []string{"public", "test2"}, postgres.EvalHCL)
+			testCLIMultiSchemaInspect(t, h, t.url(""), []string{"public", "test2"}, postgres.EvalHCL)
 		})
 	})
 	t.Run("SchemaApply", func(t *testing.T) {
 		crdbRun(t, func(t *crdbTest) {
 			t.dropSchemas("test2")
 			t.dropTables("users")
-			testCLIMultiSchemaApply(t, h, t.dsn(), []string{"public", "test2"}, postgres.EvalHCL)
+			testCLIMultiSchemaApply(t, h, t.url(""), []string{"public", "test2"}, postgres.EvalHCL)
 		})
 	})
 }
@@ -806,11 +806,7 @@ create table atlas_types_sanity
 	})
 }
 
-func (t *crdbTest) url() string {
-	return t.dsn()
-}
-
-func (t *crdbTest) dsn() string {
+func (t *crdbTest) url(_ string) string {
 	return fmt.Sprintf("postgres://root:pass@localhost:%d/defaultdb?sslmode=disable", t.port)
 }
 
@@ -922,24 +918,6 @@ func (t *crdbTest) posts() *schema.Table {
 		{Symbol: "author_id", Table: postsT, Columns: postsT.Columns[1:2], RefTable: usersT, RefColumns: usersT.Columns[:1], OnDelete: schema.NoAction},
 	}
 	return postsT
-}
-
-func (t *crdbTest) revisions() *schema.Table {
-	versionsT := &schema.Table{
-		Name: "atlas_schema_revisions",
-		Columns: []*schema.Column{
-			{Name: "version", Type: &schema.ColumnType{Type: &schema.StringType{T: "character varying"}}},
-			{Name: "description", Type: &schema.ColumnType{Type: &schema.StringType{T: "character varying"}}},
-			{Name: "execution_state", Type: &schema.ColumnType{Type: &schema.StringType{T: "character varying"}}},
-			{Name: "executed_at", Type: &schema.ColumnType{Type: &schema.TimeType{T: "timestamp with time zone"}}},
-			{Name: "execution_time", Type: &schema.ColumnType{Type: &schema.IntegerType{T: "bigint"}}},
-			{Name: "hash", Type: &schema.ColumnType{Type: &schema.StringType{T: "character varying"}}},
-			{Name: "operator_version", Type: &schema.ColumnType{Type: &schema.StringType{T: "character varying"}}},
-			{Name: "meta", Type: &schema.ColumnType{Type: &schema.JSONType{T: "jsonb"}, Raw: "jsonb"}},
-		},
-	}
-	versionsT.PrimaryKey = &schema.Index{Parts: []*schema.IndexPart{{C: versionsT.Columns[0]}}}
-	return versionsT
 }
 
 func (t *crdbTest) realm() *schema.Realm {

--- a/internal/integration/script_test.go
+++ b/internal/integration/script_test.go
@@ -96,7 +96,7 @@ func (t *myTest) setupScript(env *testscript.Env) error {
 	env.Setenv("version", t.version)
 	env.Setenv("charset", attrs[0].(*schema.Charset).V)
 	env.Setenv("collate", attrs[1].(*schema.Collation).V)
-	if err := replaceDBURL(env, t.dsn("")); err != nil {
+	if err := replaceDBURL(env, t.url("")); err != nil {
 		return err
 	}
 	return setupScript(t.T, env, t.db, "DROP SCHEMA IF EXISTS %s")
@@ -114,7 +114,7 @@ func replaceDBURL(env *testscript.Env, url string) error {
 
 func (t *pgTest) setupScript(env *testscript.Env) error {
 	env.Setenv("version", t.version)
-	u := strings.ReplaceAll(t.dsn(""), "/test", "/")
+	u := strings.ReplaceAll(t.url(""), "/test", "/")
 	if err := replaceDBURL(env, u); err != nil {
 		return err
 	}
@@ -369,11 +369,11 @@ func (t *liteTest) cmdExec(ts *testscript.TestScript, _ bool, args []string) {
 }
 
 func (t *myTest) cmdCLI(ts *testscript.TestScript, neg bool, args []string) {
-	cmdCLI(ts, neg, args, t.dsn(ts.Getenv("db")), ts.Getenv(atlasPathKey))
+	cmdCLI(ts, neg, args, t.url(ts.Getenv("db")), ts.Getenv(atlasPathKey))
 }
 
 func (t *pgTest) cmdCLI(ts *testscript.TestScript, neg bool, args []string) {
-	cmdCLI(ts, neg, args, t.dsn(ts.Getenv("db")), ts.Getenv(atlasPathKey))
+	cmdCLI(ts, neg, args, t.url(ts.Getenv("db")), ts.Getenv(atlasPathKey))
 }
 
 func (t *liteTest) cmdCLI(ts *testscript.TestScript, neg bool, args []string) {

--- a/internal/integration/sqlite_test.go
+++ b/internal/integration/sqlite_test.go
@@ -495,7 +495,7 @@ env "hello" {
 	url = "%s"
 	src = "./schema.hcl"
 }
-`, t.dsn())
+`, t.url(""))
 			wd, _ := os.Getwd()
 			envfile := filepath.Join(wd, "atlas.hcl")
 			err := os.WriteFile(envfile, []byte(env), 0600)
@@ -509,12 +509,12 @@ env "hello" {
 	})
 	t.Run("SchemaInspect", func(t *testing.T) {
 		liteRun(t, func(t *liteTest) {
-			testCLISchemaInspect(t, h, t.dsn(), sqlite.EvalHCL)
+			testCLISchemaInspect(t, h, t.url(""), sqlite.EvalHCL)
 		})
 	})
 	t.Run("SchemaApply", func(t *testing.T) {
 		liteRun(t, func(t *liteTest) {
-			testCLISchemaApply(t, h, t.dsn())
+			testCLISchemaApply(t, h, t.url(""))
 		})
 	})
 	t.Run("SchemaApplyWithVars", func(t *testing.T) {
@@ -533,22 +533,22 @@ table "users" {
 }
 `
 		liteRun(t, func(t *liteTest) {
-			testCLISchemaApply(t, h, t.dsn(), "--var", "tenant=main")
+			testCLISchemaApply(t, h, t.url(""), "--var", "tenant=main")
 		})
 	})
 	t.Run("SchemaApplyDryRun", func(t *testing.T) {
 		liteRun(t, func(t *liteTest) {
-			testCLISchemaApplyDry(t, h, t.dsn())
+			testCLISchemaApplyDry(t, h, t.url(""))
 		})
 	})
 	t.Run("SchemaDiffRun", func(t *testing.T) {
 		liteRun(t, func(t *liteTest) {
-			testCLISchemaDiff(t, t.dsn())
+			testCLISchemaDiff(t, t.url(""))
 		})
 	})
 	t.Run("SchemaApplyAutoApprove", func(t *testing.T) {
 		liteRun(t, func(t *liteTest) {
-			testCLISchemaApplyAutoApprove(t, h, t.dsn())
+			testCLISchemaApplyAutoApprove(t, h, t.url(""))
 		})
 	})
 }
@@ -905,24 +905,6 @@ func (t *liteTest) posts() *schema.Table {
 	return postsT
 }
 
-func (t *liteTest) revisions() *schema.Table {
-	versionsT := &schema.Table{
-		Name: "atlas_schema_revisions",
-		Columns: []*schema.Column{
-			{Name: "version", Type: &schema.ColumnType{Type: &schema.StringType{T: "varchar(255)"}}},
-			{Name: "description", Type: &schema.ColumnType{Type: &schema.StringType{T: "varchar(255)"}}},
-			{Name: "execution_state", Type: &schema.ColumnType{Type: &schema.StringType{T: "varchar(7)"}}},
-			{Name: "executed_at", Type: &schema.ColumnType{Type: &schema.TimeType{T: "datetime"}}},
-			{Name: "execution_time", Type: &schema.ColumnType{Type: &schema.IntegerType{T: "int"}}},
-			{Name: "hash", Type: &schema.ColumnType{Type: &schema.StringType{T: "varchar(44)"}}},
-			{Name: "operator_version", Type: &schema.ColumnType{Type: &schema.StringType{T: "varchar(255)"}}},
-			{Name: "meta", Type: &schema.ColumnType{Type: &schema.JSONType{T: "json"}, Raw: "json"}},
-		},
-	}
-	versionsT.PrimaryKey = &schema.Index{Parts: []*schema.IndexPart{{C: versionsT.Columns[0]}}}
-	return versionsT
-}
-
 func (t *liteTest) realm() *schema.Realm {
 	r := &schema.Realm{
 		Schemas: []*schema.Schema{
@@ -958,12 +940,8 @@ func (t *liteTest) dropTables(names ...string) {
 	})
 }
 
-func (t *liteTest) dsn() string {
+func (t *liteTest) url(_ string) string {
 	return fmt.Sprintf("sqlite://file:%s?cache=shared&_fk=1", t.file)
-}
-
-func (t *liteTest) url() string {
-	return t.dsn()
 }
 
 func (t *liteTest) applyRealmHcl(spec string) {

--- a/internal/integration/testdata/migrations/mysql/1_initial.sql
+++ b/internal/integration/testdata/migrations/mysql/1_initial.sql
@@ -1,0 +1,2 @@
+CREATE SCHEMA IF NOT EXISTS `bc_test`;
+CREATE TABLE `bc_test`.`bc_tbl` (`col` INTEGER NULL);

--- a/internal/integration/testdata/migrations/mysql/atlas.sum
+++ b/internal/integration/testdata/migrations/mysql/atlas.sum
@@ -1,0 +1,2 @@
+h1:FT0VjrL64KJmuOe1Dq4dpbG/50Kwn0lZqfopa6BhJM8=
+1_initial.sql h1:bWUYLjb0oiGQHf45Q08aKFKxVZ3pZBArJnSmuGBw9X4=

--- a/internal/integration/testdata/migrations/postgres/1_initial.sql
+++ b/internal/integration/testdata/migrations/postgres/1_initial.sql
@@ -1,0 +1,2 @@
+CREATE SCHEMA IF NOT EXISTS "bc_test";
+CREATE TABLE "bc_test"."bc_tbl" ("col" INTEGER NULL);

--- a/internal/integration/testdata/migrations/postgres/atlas.sum
+++ b/internal/integration/testdata/migrations/postgres/atlas.sum
@@ -1,0 +1,2 @@
+h1:80V3wCzovMg2ot2hR0arbEjEfMfKWDeQNrXZJbFPF10=
+1_initial.sql h1:53poyM34ShPWCVU41ldi4d9LUrzqPiQfBdEq//yH4Jo=

--- a/internal/integration/tidb_test.go
+++ b/internal/integration/tidb_test.go
@@ -538,7 +538,7 @@ func TestTiDB_CLI_MultiSchema(t *testing.T) {
 			t.dropTables("users")
 			attrs := t.defaultAttrs()
 			charset, collate := attrs[0].(*schema.Charset), attrs[1].(*schema.Collation)
-			testCLIMultiSchemaInspect(t, fmt.Sprintf(h, charset.V, collate.V, charset.V, collate.V), t.dsn(""), []string{"test", "test2"}, mysql.EvalHCL)
+			testCLIMultiSchemaInspect(t, fmt.Sprintf(h, charset.V, collate.V, charset.V, collate.V), t.url(""), []string{"test", "test2"}, mysql.EvalHCL)
 		})
 	})
 	t.Run("SchemaApply", func(t *testing.T) {
@@ -547,7 +547,7 @@ func TestTiDB_CLI_MultiSchema(t *testing.T) {
 			t.dropTables("users")
 			attrs := t.defaultAttrs()
 			charset, collate := attrs[0].(*schema.Charset), attrs[1].(*schema.Collation)
-			testCLIMultiSchemaApply(t, fmt.Sprintf(h, charset.V, collate.V, charset.V, collate.V), t.dsn(""), []string{"test", "test2"}, mysql.EvalHCL)
+			testCLIMultiSchemaApply(t, fmt.Sprintf(h, charset.V, collate.V, charset.V, collate.V), t.url(""), []string{"test", "test2"}, mysql.EvalHCL)
 		})
 	})
 }
@@ -571,14 +571,14 @@ func TestTiDB_CLI(t *testing.T) {
 		tidbRun(t, func(t *myTest) {
 			attrs := t.defaultAttrs()
 			charset, collate := attrs[0].(*schema.Charset), attrs[1].(*schema.Collation)
-			testCLISchemaInspect(t, fmt.Sprintf(h, charset.V, collate.V), t.dsn("test"), mysql.EvalHCL)
+			testCLISchemaInspect(t, fmt.Sprintf(h, charset.V, collate.V), t.url("test"), mysql.EvalHCL)
 		})
 	})
 	t.Run("SchemaApply", func(t *testing.T) {
 		tidbRun(t, func(t *myTest) {
 			attrs := t.defaultAttrs()
 			charset, collate := attrs[0].(*schema.Charset), attrs[1].(*schema.Collation)
-			testCLISchemaApply(t, fmt.Sprintf(h, charset.V, collate.V), t.dsn("test"))
+			testCLISchemaApply(t, fmt.Sprintf(h, charset.V, collate.V), t.url("test"))
 		})
 	})
 	t.Run("SchemaApplyWithVars", func(t *testing.T) {
@@ -597,19 +597,19 @@ table "users" {
 }
 `
 		tidbRun(t, func(t *myTest) {
-			testCLISchemaApply(t, h, t.dsn("test"), "--var", "tenant=test")
+			testCLISchemaApply(t, h, t.url("test"), "--var", "tenant=test")
 		})
 	})
 	t.Run("SchemaApplyDryRun", func(t *testing.T) {
 		tidbRun(t, func(t *myTest) {
 			attrs := t.defaultAttrs()
 			charset, collate := attrs[0].(*schema.Charset), attrs[1].(*schema.Collation)
-			testCLISchemaApplyDry(t, fmt.Sprintf(h, charset.V, collate.V), t.dsn("test"))
+			testCLISchemaApplyDry(t, fmt.Sprintf(h, charset.V, collate.V), t.url("test"))
 		})
 	})
 	t.Run("SchemaDiffRun", func(t *testing.T) {
 		tidbRun(t, func(t *myTest) {
-			testCLISchemaDiff(t, t.dsn("test"))
+			testCLISchemaDiff(t, t.url("test"))
 		})
 	})
 }


### PR DESCRIPTION
This PR changes the default location of the revision information table. The old behavior was to store the table in a separate schema called `atlas_schema_revisions`. Now, if the connection is bound to a schema (e.g. when working with Ent), the table will be stored in that schema, unless the `--revision-schema` flag is given.

To not destroy pre-existing projects, we require the flag to be present, if the connection is schema bound, no table exists in that schema but we can find one in the old default schema.

- [x] add test for the above