### PR TITLE
doc/md: keep shell commands in consistent formatting

### DIFF
--- a/doc/md/versioned/apply.mdx
+++ b/doc/md/versioned/apply.mdx
@@ -115,36 +115,36 @@ flag:
 First time apply with baseline on production environment:
 ```shell
 atlas migrate apply \
-  --env production \
-  --baseline 20220811074144
+  --env "production" \
+  --baseline "20220811074144"
 ```
 
 Execute 1 pending migration file, but don't run, but print SQL statements on screen:
 ```shell
 atlas migrate apply 1 \
-  --env production \
-  --baseline 20220811074144 \
+  --env "production" \
+  --baseline "20220811074144" \
   --dry-run
 ```
 
 Specify revision table schema and custom migration directory path:
 ```shell
 atlas migrate apply \
-  --url mysql://root:pass@remote:3306/my_database \
-  --revisions-schema atlas_migration_history \
-  --dir file://custom/path/to/dir
+  --url "mysql://root:pass@remote:3306/my_database" \
+  --revisions-schema "atlas_migration_history" \
+  --dir "file://custom/path/to/dir"
 ```
 
 Ignore unclean database and run the first 3 migrations:
 ```shell
 atlas migrate apply 3 \
-  --url mysql://root:pass@remote:3306/my_database \
-  --dir file://custom/path/to/dir
+  --url "mysql://root:pass@remote:3306/my_database" \
+  --dir "file://custom/path/to/dir"
 ```
 
 Run all pending migrations, but do not use a transaction:
 ```shell
 atlas migrate apply \
-  --url mysql://root:pass@remote:3306/my_database \
-  --tx-mode none
+  --url "mysql://root:pass@remote:3306/my_database" \
+  --tx-mode "none"
 ```

--- a/doc/md/versioned/diff.mdx
+++ b/doc/md/versioned/diff.mdx
@@ -323,8 +323,10 @@ values={[
 <TabItem value="mysql">
 
 ```shell
-atlas migrate diff --dir="file://migrations" --to="file://schema.hcl" \
- --dev-url="mysql://root:pass@:3306/" create_all
+atlas migrate diff create_all \
+  --dir "file://migrations" \
+  --to "file://schema.hcl" \
+  --dev-url "mysql://root:pass@:3306/"
 ```
 
 Running `cat migrations/*.sql` will print the followings:
@@ -344,8 +346,10 @@ CREATE TABLE `market`.`users` (`name` int NOT NULL) CHARSET utf8mb4 COLLATE utf8
 <TabItem value="postgres">
 
 ```shell
-atlas migrate diff --dir="file://migrations" --to="file://schema.hcl" \
- --dev-url="postgres://root:pass@:5434/database?sslmode=disable" create_all
+atlas migrate diff create_all \
+  --dir "file://migrations" \
+  --to "file://schema.hcl" \
+  --dev-url "postgres://root:pass@:5434/database?sslmode=disable"
 ```
 
 Running `cat migrations/*.sql` will print the followings:

--- a/doc/md/versioned/lint.md
+++ b/doc/md/versioned/lint.md
@@ -36,24 +36,24 @@ format the output of the `lint` command.
 Analyze all changes relative to the `master` Git branch:
 ```shell
 atlas migrate lint \
-  --dir file://my/project/migrations \
-  --dev-url mysql://root:pass@localhost:3306/dev \
-  --git-base master
+  --dir "file://my/project/migrations" \
+  --dev-url "mysql://root:pass@localhost:3306/dev" \
+  --git-base "master"
 ```
 Analyze the latest 2 migration files:
 ```shell
 atlas migrate lint \
-  --dir file://my/project/migrations \
-  --dev-url mysql://root:pass@localhost:3306/dev \
+  --dir "file://my/project/migrations" \
+  --dev-url "mysql://root:pass@localhost:3306/dev" \
   --latest 2
 ```
 Format output as JSON:
 ```shell
 atlas migrate lint \
-  --dir file://my/project/migrations \
-  --dev-url mysql://root:pass@localhost:3306/dev \
-  --git-base master \
-  --log '{{ json .Files }}'
+  --dir "file://my/project/migrations" \
+  --dev-url "mysql://root:pass@localhost:3306/dev" \
+  --git-base "master" \
+  --log "{{ json .Files }}"
 ```
 
 ### Reference


### PR DESCRIPTION
Some of the CLI commands are formatted like this: 
![image](https://user-images.githubusercontent.com/12862103/188258404-c438b3ab-a43c-4219-8038-53f49750a1b1.png)

This PR addresses those to match the rest, which look like this:
![image](https://user-images.githubusercontent.com/12862103/188258422-ea1c9cf2-c67e-485e-bade-4e242c2dcdb7.png)

This also enables copy pasting for "new generation" shells like fish (which happens to be the one I am using).