### PR TITLE
sql/mysql: ensure parseTime is always set

### DIFF
--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -228,7 +228,9 @@ type parser struct{}
 
 // ParseURL implements the sqlclient.URLParser interface.
 func (parser) ParseURL(u *url.URL) *sqlclient.URL {
-	u.Query().Set("parseTime", "true")
+	v := u.Query()
+	v.Set("parseTime", "true")
+	u.RawQuery = v.Encode()
 	return &sqlclient.URL{URL: u, DSN: dsn(u), Schema: strings.TrimPrefix(u.Path, "/")}
 }
 

--- a/sql/mysql/driver_test.go
+++ b/sql/mysql/driver_test.go
@@ -7,6 +7,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"net/url"
 	"testing"
 	"time"
 
@@ -17,6 +18,13 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestParser_ParseURLParseTime(t *testing.T) {
+	u, err := url.Parse("mysql://user:pass@localhost:3306/my_db?foo=bar")
+	require.NoError(t, err)
+	ac := parser{}.ParseURL(u)
+	require.Equal(t, "true", ac.Query().Get("parseTime"))
+}
 
 func TestDriver_LockAcquired(t *testing.T) {
 	db, m, err := sqlmock.New()


### PR DESCRIPTION
Should have been done in https://github.com/ariga/atlas/pull/1109, but that PR forgot to set the changed values on the URL.

