### PR TITLE
cmd/atlas/internal/cmdapi: remove force flag

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -159,8 +159,9 @@ directory state to the desired schema. The desired state can be another connecte
 		Short: "Hash (re-)creates an integrity hash file for the migration directory.",
 		Long: `'atlas migrate hash' computes the integrity hash sum of the migration directory and stores it in the atlas.sum file.
 This command should be used whenever a manual change in the migration directory was made.`,
-		Example: `  atlas migrate hash`,
-		RunE:    CmdMigrateHashRun,
+		Example:           `  atlas migrate hash`,
+		PersistentPreRunE: migrateFlagsFromEnv,
+		RunE:              CmdMigrateHashRun,
 	}
 	// MigrateNewCmd represents the 'atlas migrate new' command.
 	MigrateNewCmd = &cobra.Command{

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -257,6 +257,9 @@ func init() {
 	// Status flags.
 	urlFlag(&MigrateFlags.URL, migrateFlagURL, "u", MigrateStatusCmd.Flags())
 	revisionsFlag(MigrateStatusCmd.Flags())
+	// Hash flags.
+	MigrateHashCmd.Flags().Bool("force", false, "")
+	cobra.CheckErr(MigrateHashCmd.Flags().MarkDeprecated("force", "you can safely omit it."))
 	// Lint flags.
 	urlFlag(&MigrateFlags.DevURL, migrateFlagDevURL, "", MigrateLintCmd.Flags())
 	MigrateLintCmd.PersistentFlags().StringVarP(&MigrateFlags.Lint.Format, migrateFlagLog, "", "", "custom logging using a Go template")

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -39,7 +39,6 @@ const (
 	migrateFlagDevURL           = "dev-url"
 	migrateFlagDir              = "dir"
 	migrateFlagDirFormat        = "dir-format"
-	migrateFlagForce            = "force"
 	migrateFlagLog              = "log"
 	migrateFlagRevisionsSchema  = "revisions-schema"
 	migrateFlagDryRun           = "dry-run"
@@ -65,7 +64,6 @@ var (
 		DirURL         string
 		DirFormat      string
 		RevisionSchema string
-		Force          bool
 		Apply          struct {
 			DryRun          bool
 			LogFormat       string
@@ -93,17 +91,14 @@ var (
 			if err := migrateFlagsFromEnv(cmd, nil); err != nil {
 				return err
 			}
-			// Migrate commands will not run on a broken migration directory, unless the force flag is given.
-			if !MigrateFlags.Force {
-				dir, err := dir(false)
-				if err != nil {
-					return err
-				}
-				if err := migrate.Validate(dir); err != nil {
-					printChecksumErr(cmd.OutOrStderr())
-					cmd.SilenceUsage = true
-					return err
-				}
+			dir, err := dir(false)
+			if err != nil {
+				return err
+			}
+			if err := migrate.Validate(dir); err != nil {
+				printChecksumErr(cmd.OutOrStderr())
+				cmd.SilenceUsage = true
+				return err
 			}
 			return nil
 		},
@@ -145,17 +140,14 @@ directory state to the desired schema. The desired state can be another connecte
 			if err := migrateFlagsFromEnv(cmd, nil); err != nil {
 				return err
 			}
-			// Migrate commands will not run on a broken migration directory, unless the force flag is given.
-			if !MigrateFlags.Force {
-				dir, err := dir(true)
-				if err != nil {
-					return err
-				}
-				if err := migrate.Validate(dir); err != nil {
-					printChecksumErr(cmd.OutOrStderr())
-					cmd.SilenceUsage = true
-					return err
-				}
+			dir, err := dir(true)
+			if err != nil {
+				return err
+			}
+			if err := migrate.Validate(dir); err != nil {
+				printChecksumErr(cmd.OutOrStderr())
+				cmd.SilenceUsage = true
+				return err
 			}
 			return nil
 		},
@@ -167,7 +159,7 @@ directory state to the desired schema. The desired state can be another connecte
 		Short: "Hash (re-)creates an integrity hash file for the migration directory.",
 		Long: `'atlas migrate hash' computes the integrity hash sum of the migration directory and stores it in the atlas.sum file.
 This command should be used whenever a manual change in the migration directory was made.`,
-		Example: `  atlas migrate hash --force`,
+		Example: `  atlas migrate hash`,
 		RunE:    CmdMigrateHashRun,
 	}
 	// MigrateNewCmd represents the 'atlas migrate new' command.
@@ -237,7 +229,6 @@ func init() {
 	MigrateCmd.PersistentFlags().StringVarP(&MigrateFlags.DirURL, migrateFlagDir, "", "file://migrations", "select migration directory using URL format")
 	MigrateCmd.PersistentFlags().StringSliceVarP(&MigrateFlags.Schemas, migrateFlagSchema, "", nil, "set schema names")
 	MigrateCmd.PersistentFlags().StringVarP(&MigrateFlags.DirFormat, migrateFlagDirFormat, "", formatAtlas, "set migration file format")
-	MigrateCmd.PersistentFlags().BoolVarP(&MigrateFlags.Force, migrateFlagForce, "", false, "force a command to run on a broken migration directory state")
 	MigrateCmd.PersistentFlags().SortFlags = false
 	// Apply flags.
 	MigrateApplyCmd.Flags().StringVarP(&MigrateFlags.Apply.LogFormat, migrateFlagLog, "", logFormatTTY, "log format to use")
@@ -252,7 +243,6 @@ func init() {
 	cobra.CheckErr(MigrateApplyCmd.MarkFlagRequired(migrateFlagURL))
 	MigrateApplyCmd.MarkFlagsMutuallyExclusive(migrateApplyFromVersion, migrateApplyBaselineVersion)
 	cobra.CheckErr(MigrateApplyCmd.Flags().MarkHidden(migrateFlagDirFormat))
-	cobra.CheckErr(MigrateApplyCmd.Flags().MarkHidden(migrateFlagForce))
 	cobra.CheckErr(MigrateApplyCmd.Flags().MarkHidden(migrateFlagSchema))
 	// Diff flags.
 	urlFlag(&MigrateFlags.DevURL, migrateFlagDevURL, "", MigrateDiffCmd.Flags())
@@ -848,7 +838,7 @@ func printChecksumErr(out io.Writer) {
 This happens if you manually create or edit a migration file.
 Please check your migration files and run
 
-'atlas migrate hash --force'
+'atlas migrate hash'
 
 to re-hash the contents and resolve the error
 

--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -451,6 +450,11 @@ func TestMigrate_Hash(t *testing.T) {
 	require.Zero(t, s)
 	require.NoError(t, err)
 
+	// Prints a warning if --force flag is still used.
+	s, err = runCmd(Root, "migrate", "hash", "--dir", "file://testdata/mysql", "--force")
+	require.NoError(t, err)
+	require.Equal(t, "Flag --force has been deprecated, you can safely omit it.\n", s)
+
 	p := t.TempDir()
 	err = copyFile(filepath.Join("testdata", "mysql", "20220318104614_initial.sql"), filepath.Join(p, "20220318104614_initial.sql"))
 	require.NoError(t, err)
@@ -459,7 +463,7 @@ func TestMigrate_Hash(t *testing.T) {
 	require.Zero(t, s)
 	require.NoError(t, err)
 	require.FileExists(t, filepath.Join(p, "atlas.sum"))
-	d, err := ioutil.ReadFile(filepath.Join(p, "atlas.sum"))
+	d, err := os.ReadFile(filepath.Join(p, "atlas.sum"))
 	require.NoError(t, err)
 	dir, err := migrate.NewLocalDir(p)
 	require.NoError(t, err)

--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -195,7 +195,7 @@ func TestMigrate_Apply(t *testing.T) {
 		require.NoError(t, os.RemoveAll("testdata/sqlite3"))
 	})
 	sed(t, "s/col_2/col_5/g", "testdata/sqlite3/20220318104615_second.sql")
-	_, err = runCmd(Root, "migrate", "hash", "--force", "--dir", "file://testdata/sqlite3")
+	_, err = runCmd(Root, "migrate", "hash", "--dir", "file://testdata/sqlite3")
 	require.NoError(t, err)
 	s, err = runCmd(
 		Root, "migrate", "apply",
@@ -207,7 +207,7 @@ func TestMigrate_Apply(t *testing.T) {
 	// Fixing the migration file will finish without errors.
 	sed(t, "s/col_5/col_2/g", "testdata/sqlite3/20220318104615_second.sql")
 	sed(t, "s/asdasd //g", "testdata/sqlite3/20220318104615_second.sql")
-	_, err = runCmd(Root, "migrate", "hash", "--force", "--dir", "file://testdata/sqlite3")
+	_, err = runCmd(Root, "migrate", "hash", "--dir", "file://testdata/sqlite3")
 	require.NoError(t, err)
 	s, err = runCmd(
 		Root, "migrate", "apply",
@@ -288,7 +288,6 @@ func TestMigrate_Diff(t *testing.T) {
 	to := hclURL(t)
 
 	// Will create migration directory if not existing.
-	MigrateFlags.Force = false
 	_, err := runCmd(
 		Root, "migrate", "diff",
 		"name",
@@ -432,7 +431,7 @@ func TestMigrate_Validate(t *testing.T) {
 	p := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(p, "1_initial.sql"), []byte("create table t1 (c1 int)"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(p, "2_second.sql"), []byte("create table t2 (c2 int)"), 0644))
-	_, err = runCmd(Root, "migrate", "hash", "--force", "--dir", "file://"+p)
+	_, err = runCmd(Root, "migrate", "hash", "--dir", "file://"+p)
 	require.NoError(t, err)
 	s, err = runCmd(
 		Root, "migrate", "validate",
@@ -456,7 +455,7 @@ func TestMigrate_Hash(t *testing.T) {
 	err = copyFile(filepath.Join("testdata", "mysql", "20220318104614_initial.sql"), filepath.Join(p, "20220318104614_initial.sql"))
 	require.NoError(t, err)
 
-	s, err = runCmd(Root, "migrate", "hash", "--dir", "file://"+p, "--force")
+	s, err = runCmd(Root, "migrate", "hash", "--dir", "file://"+p)
 	require.Zero(t, s)
 	require.NoError(t, err)
 	require.FileExists(t, filepath.Join(p, "atlas.sum"))

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -163,7 +163,7 @@ This command should be used whenever a manual change in the migration directory 
 #### Example
 
 ```
-  atlas migrate hash --force
+  atlas migrate hash
 ```
 
 ### atlas migrate lint

--- a/doc/md/versioned/new.mdx
+++ b/doc/md/versioned/new.mdx
@@ -169,7 +169,7 @@ ensure the integrity of the migration directory and force developers to deal wit
 situations where migration order or contents was modified after the fact. 
 
 After manually editing the contents of a newly created migration file, the checksums for
-the directory must be recalculated. This can be done by running `atlas migrate hash --force`
+the directory must be recalculated. This can be done by running `atlas migrate hash`
 command.
 
 ### Examples

--- a/internal/integration/testdata/mysql/cli-migrate-apply.txt
+++ b/internal/integration/testdata/mysql/cli-migrate-apply.txt
@@ -3,9 +3,9 @@ only mysql
 ! atlas migrate apply
 stderr 'Error: checksum file not found'
 stdout 'You have a checksum error in your migration directory.'
-stdout 'atlas migrate hash --force'
+stdout 'atlas migrate hash'
 
-atlas migrate hash --force
+atlas migrate hash
 
 # Apply all of them
 atlas migrate apply --url URL --revisions-schema $db

--- a/internal/integration/testdata/postgres/cli-migrate-apply.txt
+++ b/internal/integration/testdata/postgres/cli-migrate-apply.txt
@@ -1,9 +1,9 @@
 ! atlas migrate apply
 stderr 'Error: checksum file not found'
 stdout 'You have a checksum error in your migration directory.'
-stdout 'atlas migrate hash --force'
+stdout 'atlas migrate hash'
 
-atlas migrate hash --force
+atlas migrate hash
 
 # Apply all of them
 atlas migrate apply --url URL --revisions-schema $db
@@ -45,7 +45,7 @@ clearSchema
 
 # Move the broken migration into the migrations directory and check the different transaction modes.
 cp broken.sql migrations/4_fourth.sql
-atlas migrate hash --force
+atlas migrate hash
 
 ! atlas migrate apply --url URL --revisions-schema $db --tx-mode invalid
 stderr 'unknown tx-mode "invalid"'
@@ -70,7 +70,7 @@ cmp stdout empty.hcl
 
 # If the broken migration is gone, we can apply everything without any problems.
 rm migrations/4_fourth.sql
-atlas migrate hash --force
+atlas migrate hash
 
 atlas migrate apply --url URL --revisions-schema $db
 cmpshow users users.sql
@@ -83,7 +83,7 @@ clearSchema
 # Test --tx-mode file
 
 cp broken.sql migrations/4_fourth.sql
-atlas migrate hash --force
+atlas migrate hash
 
 ! atlas migrate apply --url URL --revisions-schema $db --tx-mode file
 stderr 'executing statement "THIS IS A FAILING STATEMENT;" from version "4"'
@@ -97,7 +97,7 @@ cmp stdout empty.hcl
 
 # If the broken migration is gone, we can apply everything without any problems.
 rm migrations/4_fourth.sql
-atlas migrate hash --force
+atlas migrate hash
 
 atlas migrate apply --url URL --revisions-schema $db
 cmpshow users users.sql
@@ -110,7 +110,7 @@ clearSchema
 # Test --tx-mode none
 
 cp broken.sql migrations/4_fourth.sql
-atlas migrate hash --force
+atlas migrate hash
 
 ! atlas migrate apply --url URL --revisions-schema $db --tx-mode none
 stderr 'executing statement "THIS IS A FAILING STATEMENT;" from version "4"'

--- a/internal/integration/testdata/postgres/cli-migrate-status.txt
+++ b/internal/integration/testdata/postgres/cli-migrate-status.txt
@@ -1,5 +1,5 @@
 # make sure sum file is correct
-atlas migrate hash --force
+atlas migrate hash
 
 # for clean database
 atlas migrate status --url URL --revisions-schema $db

--- a/internal/integration/testdata/sqlite/cli-migrate-apply.txt
+++ b/internal/integration/testdata/sqlite/cli-migrate-apply.txt
@@ -1,9 +1,9 @@
 ! atlas migrate apply
 stderr 'Error: checksum file not found'
 stdout 'You have a checksum error in your migration directory.'
-stdout 'atlas migrate hash --force'
+stdout 'atlas migrate hash'
 
-atlas migrate hash --force
+atlas migrate hash
 
 # Apply all of them
 atlas migrate apply --url URL
@@ -39,7 +39,7 @@ clearSchema
 
 # Move the broken migration into the migrations directory and check the different transaction modes.
 cp broken.sql migrations/3_third.sql
-atlas migrate hash --force
+atlas migrate hash
 
 ! atlas migrate apply --url URL --tx-mode invalid
 stderr 'unknown tx-mode "invalid"'
@@ -64,7 +64,7 @@ cmp stdout empty.hcl
 
 # If the broken migration is gone, we can apply everything without any problems.
 rm migrations/3_third.sql
-atlas migrate hash --force
+atlas migrate hash
 
 atlas migrate apply --url URL --revisions-schema $db
 cmpshow users users.sql
@@ -77,7 +77,7 @@ clearSchema
 # Test --tx-mode file
 
 cp broken.sql migrations/3_third.sql
-atlas migrate hash --force
+atlas migrate hash
 
 ! atlas migrate apply --url URL --tx-mode file
 stderr 'executing statement "THIS IS A FAILING STATEMENT;" from version "3"'
@@ -91,7 +91,7 @@ cmp stdout empty.hcl
 
 # If the broken migration is gone, we can apply everything without any problems.
 rm migrations/3_third.sql
-atlas migrate hash --force
+atlas migrate hash
 
 atlas migrate apply --url URL --revisions-schema $db
 cmpshow users users.sql
@@ -104,7 +104,7 @@ clearSchema
 # Test --tx-mode none
 
 cp broken.sql migrations/3_third.sql
-atlas migrate hash --force
+atlas migrate hash
 
 ! atlas migrate apply --url URL --tx-mode none
 stderr 'executing statement "THIS IS A FAILING STATEMENT;" from version "3"'

--- a/internal/integration/testdata/sqlite/cli-migrate-project.txt
+++ b/internal/integration/testdata/sqlite/cli-migrate-project.txt
@@ -11,7 +11,7 @@ exec touch migrations/2.sql
 ! atlas migrate validate --env local
 stderr 'Error: checksum mismatch'
 
-atlas migrate hash --force --env local
+atlas migrate hash --env local
 atlas migrate validate --env local
 
 -- atlas.hcl --


### PR DESCRIPTION
Flag is usually never present in normal commands and always present in the hash command. It has no value.