### PR TITLE
doc/md/knowledge: Small fix to make article links display in separate lines

### DIFF
--- a/doc/md/knowledge/knowledge.md
+++ b/doc/md/knowledge/knowledge.md
@@ -17,6 +17,7 @@ Welcome to the Atlas Knowledge Center.
 ### PostgreSQL
 
 [Serial Type Columns](postgres/serial-columns.md)
+
 [Partial Indexes](postgres/partial-indexes.md)
 
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/112630201/191259318-458c8153-8267-4f4e-8c8f-8355a37c23da.png)
After:
![image](https://user-images.githubusercontent.com/112630201/191259374-a149f8c5-fcda-439c-b7e4-1c12f1d14845.png)
