### PR TITLE
doc/website: Fix redirection for articles under "Guides"

### DIFF
--- a/doc/website/docusaurus.config.js
+++ b/doc/website/docusaurus.config.js
@@ -178,6 +178,22 @@ module.exports = {
             to: '/guides',
             from: '/knowledge',
           },
+          {
+            to: '/guides/mysql/generated-columns',
+            from: '/knowledge/mysql/generated-columns',
+          },
+          {
+            to: '/guides/postgres/partial-indexes',
+            from: '/knowledge/postgres/partial-indexes',
+          },
+          {
+            to: '/guides/postgres/serial-columns',
+            from: '/knowledge/postgres/serial-columns',
+          },
+          {
+            to: '/guides/ddl',
+            from: '/knowledge/ddl',
+          },          
         ],
       },
     ],


### PR DESCRIPTION
Changes: in docusaurus.config.js, added code to redirect all articles under knowledge center from their old links to new links