### PR TITLE
cmd/atlas/internal/cmdapi: add atlas migrate set-revision

### DIFF
--- a/cmd/atlas/doc.go
+++ b/cmd/atlas/doc.go
@@ -8,7 +8,6 @@
 package main
 
 import (
-	"io"
 	"log"
 	"os"
 	"strings"
@@ -17,7 +16,6 @@ import (
 	"ariga.io/atlas/cmd/atlas/internal/cmdapi"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/cobra/doc"
 )
 
 func main() {
@@ -65,13 +63,4 @@ func prepare(cmd *cobra.Command, existing []*block, depth int) []*block {
 		existing = prepare(child, existing, depth+1)
 	}
 	return existing
-}
-
-func markdown(cmd *cobra.Command, w io.Writer, i int) {
-	if i > 0 {
-		doc.GenMarkdown(cmd, w)
-	}
-	for _, child := range cmd.Commands() {
-		markdown(child, w, i+1)
-	}
 }

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -803,12 +803,20 @@ func CmdMigrateSetRevisionRun(cmd *cobra.Command, args []string) error {
 	if err := checkRevisionSchemaClarity(cmd, client); err != nil {
 		return err
 	}
+	// Ensure revision table exists.
+	rrw, err := entRevisions(cmd.Context(), client)
+	if err != nil {
+		return err
+	}
+	if err := rrw.Migrate(cmd.Context()); err != nil {
+		return err
+	}
 	// Wrap manipulation in a transaction.
 	tx, err := client.Tx(cmd.Context(), nil)
 	if err != nil {
 		return err
 	}
-	rrw, err := entRevisions(cmd.Context(), tx.Client)
+	rrw, err = entRevisions(cmd.Context(), tx.Client)
 	if err != nil {
 		return err
 	}

--- a/cmd/atlas/internal/migrate/migrate.go
+++ b/cmd/atlas/internal/migrate/migrate.go
@@ -114,6 +114,11 @@ func (r *EntRevisions) WriteRevision(ctx context.Context, rev *migrate.Revision)
 		Exec(ctx)
 }
 
+// DeleteRevision deletes a revision from the revisions table.
+func (r *EntRevisions) DeleteRevision(ctx context.Context, v string) error {
+	return r.ec.Revision.DeleteOneID(v).Exec(ctx)
+}
+
 // Migrate attempts to create / update the revisions table. This is separated since Ent attempts to wrap the migration
 // execution in a transaction and assumes the underlying connection is of type *sql.DB, which is not true for actually
 // reading and writing revisions.

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -234,6 +234,35 @@ atlas migrate new [name]
   atlas migrate new my-new-migration
 ```
 
+### atlas migrate set-revision
+
+Override the revision history.
+
+#### Usage
+```
+atlas migrate set-revision <version> [flags]
+```
+
+#### Details
+'atlas migrate set-revision' edits the revision table to consider all migrations up to and including the given version
+to be applied. This command is usually used after manually making changes to the managed database.
+
+#### Example
+
+```
+  atlas migrate set-revision 3 --url mysql://user:pass@localhost:3306/
+  atlas migrate set-revision 4 --env local
+  atlas migrate set-revision 1.2.4 --url mysql://user:pass@localhost:3306/my_db --revision-schema my_revisions
+  atlas migrate set-revision foo --env dev --ignore-missing-migration
+```
+#### Flags
+```
+      --ignore-missing-migration   allow setting a version for to a non-existing migration
+  -u, --url string                 [driver://username:password@address/dbname?param=value] select a database using the URL format
+
+```
+
+
 ### atlas migrate status
 
 Get information about the current migration status.

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -234,17 +234,17 @@ atlas migrate new [name]
   atlas migrate new my-new-migration
 ```
 
-### atlas migrate set-revision
+### atlas migrate set
 
-Override the revision history.
+Set the current version of the migration history table.
 
 #### Usage
 ```
-atlas migrate set-revision <version> [flags]
+atlas migrate set <version> [flags]
 ```
 
 #### Details
-'atlas migrate set-revision' edits the revision table to consider all migrations up to and including the given version
+'atlas migrate set' edits the revision table to consider all migrations up to and including the given version
 to be applied. This command is usually used after manually making changes to the managed database.
 
 #### Example
@@ -253,12 +253,10 @@ to be applied. This command is usually used after manually making changes to the
   atlas migrate set-revision 3 --url mysql://user:pass@localhost:3306/
   atlas migrate set-revision 4 --env local
   atlas migrate set-revision 1.2.4 --url mysql://user:pass@localhost:3306/my_db --revision-schema my_revisions
-  atlas migrate set-revision foo --env dev --ignore-missing-migration
 ```
 #### Flags
 ```
-      --ignore-missing-migration   allow setting a version for to a non-existing migration
-  -u, --url string                 [driver://username:password@address/dbname?param=value] select a database using the URL format
+  -u, --url string   [driver://username:password@address/dbname?param=value] select a database using the URL format
 
 ```
 

--- a/internal/integration/go.mod
+++ b/internal/integration/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/lib/pq v1.10.6
 	github.com/mattn/go-sqlite3 v1.14.14
 	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e
-	github.com/rogpeppe/go-internal v1.8.2-0.20220112175052-f3cb5c2c6412
+	github.com/rogpeppe/go-internal v1.9.0
 	github.com/stretchr/testify v1.8.0
 	github.com/zclconf/go-cty v1.10.0 // indirect
 )

--- a/internal/integration/go.sum
+++ b/internal/integration/go.sum
@@ -238,6 +238,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qq
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.8.2-0.20220112175052-f3cb5c2c6412 h1:BVgfta5l+NeAx6l597tEbF2TkiVi+Mw+2vxJjwSfyRU=
 github.com/rogpeppe/go-internal v1.8.2-0.20220112175052-f3cb5c2c6412/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -648,6 +648,22 @@ func (r *rrw) ReadRevision(_ context.Context, v string) (*migrate.Revision, erro
 	return nil, migrate.ErrRevisionNotExist
 }
 
+func (r *rrw) DeleteRevision(_ context.Context, v string) error {
+	i := -1
+	for j, r := range *r {
+		if r.Version == v {
+			i = j
+			break
+		}
+	}
+	if i == -1 {
+		return nil
+	}
+	copy((*r)[i:], (*r)[i+1:])
+	*r = (*r)[:len(*r)-1]
+	return nil
+}
+
 func (r *rrw) ReadRevisions(context.Context) ([]*migrate.Revision, error) {
 	return *r, nil
 }
@@ -655,6 +671,8 @@ func (r *rrw) ReadRevisions(context.Context) ([]*migrate.Revision, error) {
 func (r *rrw) clean() {
 	*r = []*migrate.Revision{}
 }
+
+var _ migrate.RevisionReadWriter = (*rrw)(nil)
 
 func buildCmd(t *testing.T) (string, error) {
 	td := t.TempDir()

--- a/internal/integration/testdata/sqlite/cli-migrate-set-revision.txt
+++ b/internal/integration/testdata/sqlite/cli-migrate-set-revision.txt
@@ -1,0 +1,62 @@
+! atlas migrate set-revision
+stderr 'Error: accepts 1 arg\(s\), received 0'
+
+! atlas migrate set-revision foo bar
+stderr 'Error: accepts 1 arg\(s\), received 2'
+
+! atlas migrate set-revision 0
+stderr 'Error: checksum file not found'
+stdout 'You have a checksum error in your migration directory.'
+
+atlas migrate hash
+
+# Works on fresh database.
+atlas migrate set-revision 1 --url URL
+atlas migrate apply 1 --url URL --dry-run
+stdout 'Migrating to version 2 from 1'
+
+# Set to second last migration.
+atlas migrate set-revision 2 --url URL
+atlas migrate apply 1 --url URL --dry-run
+stdout 'Migrating to version 3 from 2'
+
+# Have one migration applied, manual do second, set revision and continue apply.
+clearSchema
+atlas migrate apply 1 --url URL
+stdout 'Migrating to version 1'
+atlas migrate set-revision 2 --url URL
+atlas migrate apply 1 --url URL --dry-run
+stdout 'Migrating to version 3 from 2'
+
+# Set to non-existing migration requires flag.
+! atlas migrate set-revision 4 --url URL
+stdout 'You are trying to set a revision with no matching migration file\.\s+If this is your intention, consider adding the --ignore-missing-migration flag\.'
+stderr 'Error: migration with version "4" not found'
+
+# If set to version succeeding every migration, nothing to do.
+atlas migrate set-revision 4 --url URL --ignore-missing-migration
+atlas migrate apply 1 --url URL
+stdout 'No migration files to execute'
+
+# Partially applied (error), fix with set-revision.
+clearSchema
+mv broken.sql migrations/4.sql
+atlas migrate hash
+! atlas migrate apply --url URL --tx-mode none
+stdout 'Migrating to version 4'
+atlas migrate set-revision 4 --url URL
+atlas migrate apply --url URL
+stdout 'No migration files to execute'
+
+-- migrations/1_first.sql --
+CREATE TABLE `users` (`id` bigint NOT NULL, `age` bigint NOT NULL, `name` varchar(255) NOT NULL, PRIMARY KEY (`id`));
+
+-- migrations/2_second.sql --
+ALTER TABLE `users` ADD UNIQUE INDEX `age` (`age`);
+
+-- migrations/3_third.sql --
+CREATE TABLE `pets` (`id` bigint NOT NULL, `name` varchar(255) NOT NULL, PRIMARY KEY (`id`));
+
+-- broken.sql --
+CREATE TABLE `vets` (`id` bigint NOT NULL, `name` varchar(255) NOT NULL, PRIMARY KEY(`id`));
+asdf ALTER TABLE `users` ADD UNIQUE INDEX `name` (`name`);

--- a/internal/integration/testdata/sqlite/cli-migrate-set.txt
+++ b/internal/integration/testdata/sqlite/cli-migrate-set.txt
@@ -1,22 +1,22 @@
-! atlas migrate set-revision
+! atlas migrate set
 stderr 'Error: accepts 1 arg\(s\), received 0'
 
-! atlas migrate set-revision foo bar
+! atlas migrate set foo bar
 stderr 'Error: accepts 1 arg\(s\), received 2'
 
-! atlas migrate set-revision 0
+! atlas migrate set 0
 stderr 'Error: checksum file not found'
 stdout 'You have a checksum error in your migration directory.'
 
 atlas migrate hash
 
 # Works on fresh database.
-atlas migrate set-revision 1 --url URL
+atlas migrate set 1 --url URL
 atlas migrate apply 1 --url URL --dry-run
 stdout 'Migrating to version 2 from 1'
 
 # Set to second last migration.
-atlas migrate set-revision 2 --url URL
+atlas migrate set 2 --url URL
 atlas migrate apply 1 --url URL --dry-run
 stdout 'Migrating to version 3 from 2'
 
@@ -24,27 +24,26 @@ stdout 'Migrating to version 3 from 2'
 clearSchema
 atlas migrate apply 1 --url URL
 stdout 'Migrating to version 1'
-atlas migrate set-revision 2 --url URL
+atlas migrate set 2 --url URL
 atlas migrate apply 1 --url URL --dry-run
 stdout 'Migrating to version 3 from 2'
 
 # Set to non-existing migration requires flag.
-! atlas migrate set-revision 4 --url URL
-stdout 'You are trying to set a revision with no matching migration file\.\s+If this is your intention, consider adding the --ignore-missing-migration flag\.'
+! atlas migrate set 4 --url URL
 stderr 'Error: migration with version "4" not found'
 
-# If set to version succeeding every migration, nothing to do.
-atlas migrate set-revision 4 --url URL --ignore-missing-migration
-atlas migrate apply 1 --url URL
+# If set to last version, nothing to do.
+atlas migrate set 3 --url URL
+atlas migrate apply --url URL
 stdout 'No migration files to execute'
 
-# Partially applied (error), fix with set-revision.
+# Partially applied (error), fix with set.
 clearSchema
 mv broken.sql migrations/4.sql
 atlas migrate hash
 ! atlas migrate apply --url URL --tx-mode none
 stdout 'Migrating to version 4'
-atlas migrate set-revision 4 --url URL
+atlas migrate set 4 --url URL
 atlas migrate apply --url URL
 stdout 'No migration files to execute'
 

--- a/sql/migrate/dir.go
+++ b/sql/migrate/dir.go
@@ -315,7 +315,8 @@ func (f *HashFile) UnmarshalText(b []byte) error {
 	return sc.Err()
 }
 
-func (f HashFile) sumByName(n string) (string, error) {
+// SumByName returns the hash for a migration file by its name.
+func (f HashFile) SumByName(n string) (string, error) {
 	for _, f := range f {
 		if f.N == n {
 			return f.H, nil

--- a/sql/migrate/migrate.go
+++ b/sql/migrate/migrate.go
@@ -172,6 +172,8 @@ type (
 		ReadRevision(context.Context, string) (*Revision, error)
 		// WriteRevision saves the revision to the storage.
 		WriteRevision(context.Context, *Revision) error
+		// DeleteRevision deletes a revision by version from the storage.
+		DeleteRevision(context.Context, string) error
 	}
 
 	// A Revision denotes an applied migration in a deployment. Used to track migration executions state of a database.
@@ -576,7 +578,7 @@ func (e *Executor) Execute(ctx context.Context, m File) (err error) {
 	if err != nil {
 		return fmt.Errorf("sql/migrate: execute: compute hash: %w", err)
 	}
-	hash, err := hf.sumByName(m.Name())
+	hash, err := hf.SumByName(m.Name())
 	if err != nil {
 		return fmt.Errorf("sql/migrate: execute: scanning checksum from %q: %w", m.Name(), err)
 	}
@@ -774,6 +776,11 @@ func (NopRevisionReadWriter) ReadRevision(context.Context, string) (*Revision, e
 
 // WriteRevision implements RevisionsReadWriter.WriteRevision.
 func (NopRevisionReadWriter) WriteRevision(context.Context, *Revision) error {
+	return nil
+}
+
+// DeleteRevision implements RevisionsReadWriter.DeleteRevision.
+func (NopRevisionReadWriter) DeleteRevision(context.Context, string) error {
 	return nil
 }
 

--- a/sql/migrate/migrate_test.go
+++ b/sql/migrate/migrate_test.go
@@ -571,12 +571,28 @@ func (rrw *mockRevisionReadWriter) WriteRevision(_ context.Context, r *migrate.R
 }
 
 func (rrw *mockRevisionReadWriter) ReadRevision(_ context.Context, v string) (*migrate.Revision, error) {
-	for _, r := range []*migrate.Revision(*rrw) {
+	for _, r := range *rrw {
 		if r.Version == v {
 			return r, nil
 		}
 	}
 	return nil, migrate.ErrRevisionNotExist
+}
+
+func (rrw *mockRevisionReadWriter) DeleteRevision(_ context.Context, v string) error {
+	i := -1
+	for j, r := range *rrw {
+		if r.Version == v {
+			i = j
+			break
+		}
+	}
+	if i == -1 {
+		return nil
+	}
+	copy((*rrw)[i:], (*rrw)[i+1:])
+	*rrw = (*rrw)[:len(*rrw)-1]
+	return nil
 }
 
 func (rrw *mockRevisionReadWriter) ReadRevisions(context.Context) ([]*migrate.Revision, error) {


### PR DESCRIPTION
This PR introduces the `atlas migrate set-revision version` command.

It will manipulate the revision table such, that, with linear history in mind, we end up with all migration versions up-to and including the given version marked as applied.

**Example**

```
Migrations: 1, 2, 4, 5, 6
Revisions : 1, 2, 4
                  ^
             has an error
```

Running `atlas migrate set-revision 2` will result in:
```
Migrations: 1, 2, 4, 5, 6
Revisions : 1, 2
```
Running `atlas migrate set-revision 4` will result in:
```
Migrations: 1, 2, 4, 5, 6
Revisions : 1, 2, 4
```
Running `atlas migrate set-revision 7 --ignore-missing-migration ` will result in:
```
Migrations: 1, 2, 4, 5, 6
Revisions : 1, 2, 4, 5, 6, 7
```
Running `atlas migrate set-revision 3 --ignore-missing-migration && atlas migrate set-revision 6` will result in:
```
Migrations: 1, 2, 4, 5, 6
Revisions : 1, 2, 3, 4, 5, 6
```

The `--ignore-missing-migration` flag is a safe-guard against typos. If the user wants to mark a revision as applied, that has no matching migration, he has to provide that flag to the command.