### PR TITLE
cmd/atlas/internal/cmdapi: add format query parameter to migration dir URL

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -281,7 +281,6 @@ func init() {
 	MigrateCmd.PersistentFlags().StringSliceVarP(&MigrateFlags.Schemas, migrateFlagSchema, "", nil, "set schema names")
 	MigrateCmd.PersistentFlags().StringVarP(&MigrateFlags.DirFormat, migrateFlagDirFormat, "", formatAtlas, "set migration file format")
 	MigrateCmd.PersistentFlags().SortFlags = false
-	cobra.CheckErr(MigrateCmd.PersistentFlags().MarkDeprecated(migrateFlagDirFormat, "you can safely omit it."))
 	// Apply flags.
 	MigrateApplyCmd.Flags().StringVarP(&MigrateFlags.Apply.LogFormat, migrateFlagLog, "", logFormatTTY, "log format to use")
 	revisionsFlag(MigrateApplyCmd.Flags())

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -1078,26 +1078,27 @@ func dirURL(u *url.URL, create bool) (migrate.Dir, error) {
 		q.Set("format", MigrateFlags.DirFormat)
 		u.RawQuery = q.Encode()
 	}
-	fn := func() (migrate.Dir, error) { return migrate.NewLocalDir(u.Path) }
+	path := filepath.Join(u.Host, u.Path)
+	fn := func() (migrate.Dir, error) { return migrate.NewLocalDir(path) }
 	switch f := u.Query().Get("format"); f {
 	case formatAtlas:
 		// this is the default
 	case formatGolangMigrate:
-		fn = func() (migrate.Dir, error) { return sqltool.NewGolangMigrateDir(u.Path) }
+		fn = func() (migrate.Dir, error) { return sqltool.NewGolangMigrateDir(path) }
 	case formatGoose:
-		fn = func() (migrate.Dir, error) { return sqltool.NewGooseDir(u.Path) }
+		fn = func() (migrate.Dir, error) { return sqltool.NewGooseDir(path) }
 	case formatFlyway:
-		fn = func() (migrate.Dir, error) { return sqltool.NewFlywayDir(u.Path) }
+		fn = func() (migrate.Dir, error) { return sqltool.NewFlywayDir(path) }
 	case formatLiquibase:
-		fn = func() (migrate.Dir, error) { return sqltool.NewLiquibaseDir(u.Path) }
+		fn = func() (migrate.Dir, error) { return sqltool.NewLiquibaseDir(path) }
 	case formatDBMate:
-		fn = func() (migrate.Dir, error) { return sqltool.NewDBMateDir(u.Path) }
+		fn = func() (migrate.Dir, error) { return sqltool.NewDBMateDir(path) }
 	default:
 		return nil, fmt.Errorf("unknown dir format %q", f)
 	}
 	d, err := fn()
 	if create && errors.Is(err, fs.ErrNotExist) {
-		if err := os.MkdirAll(u.Path, 0755); err != nil {
+		if err := os.MkdirAll(path, 0755); err != nil {
 			return nil, err
 		}
 		d, err = fn()

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -1098,6 +1098,9 @@ func dirURL(u *url.URL, create bool) (migrate.Dir, error) {
 		return nil, fmt.Errorf("unsupported driver %q", u.Scheme)
 	}
 	path := filepath.Join(u.Host, u.Path)
+	if path == "" {
+		path = "migrations"
+	}
 	fn := func() (migrate.Dir, error) { return migrate.NewLocalDir(path) }
 	switch f := u.Query().Get("format"); f {
 	case formatAtlas:
@@ -1125,7 +1128,7 @@ func dirURL(u *url.URL, create bool) (migrate.Dir, error) {
 			return nil, err
 		}
 	}
-	return d, nil
+	return d, err
 }
 
 // dirFormatBC ensures the soon-to-be deprecated --dir-format flag gets set on all migration directory URLs.

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -281,7 +281,7 @@ func init() {
 	MigrateCmd.PersistentFlags().StringSliceVarP(&MigrateFlags.Schemas, migrateFlagSchema, "", nil, "set schema names")
 	MigrateCmd.PersistentFlags().StringVarP(&MigrateFlags.DirFormat, migrateFlagDirFormat, "", formatAtlas, "set migration file format")
 	MigrateCmd.PersistentFlags().SortFlags = false
-	cobra.CheckErr(MigrateCmd.Flags().MarkDeprecated(migrateFlagDirFormat, "you can safely omit it."))
+	cobra.CheckErr(MigrateCmd.PersistentFlags().MarkDeprecated(migrateFlagDirFormat, "you can safely omit it."))
 	// Apply flags.
 	MigrateApplyCmd.Flags().StringVarP(&MigrateFlags.Apply.LogFormat, migrateFlagLog, "", logFormatTTY, "log format to use")
 	revisionsFlag(MigrateApplyCmd.Flags())

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -62,7 +63,7 @@ var (
 		ToURLs         []string
 		Schemas        []string
 		DirURL         string
-		DirFormat      string
+		DirFormat      string // Deprecated: format is enclosed in the dir URL now.
 		RevisionSchema string
 		Apply          struct {
 			DryRun          bool
@@ -98,7 +99,7 @@ var (
 			if err := migrateFlagsFromEnv(cmd, nil); err != nil {
 				return err
 			}
-			dir, err := dir(false)
+			dir, err := dir(MigrateFlags.DirURL, false)
 			if err != nil {
 				return err
 			}
@@ -147,7 +148,7 @@ directory state to the desired schema. The desired state can be another connecte
 			if err := migrateFlagsFromEnv(cmd, nil); err != nil {
 				return err
 			}
-			dir, err := dir(true)
+			dir, err := dir(MigrateFlags.DirURL, true)
 			if err != nil {
 				return err
 			}
@@ -174,7 +175,7 @@ This command should be used whenever a manual change in the migration directory 
 	MigrateImportCmd = &cobra.Command{
 		Use:     "import",
 		Short:   "Import a migration directory from another migration management tool to the Atlas format.",
-		Example: `  atlas migrate import --dir-format liquibase --from file:///path/to/source/directory --to file:///path/to/migration/directory`,
+		Example: `  atlas migrate import --from file:///path/to/source/directory?format=liquibase --to file:///path/to/migration/directory`,
 		// Validate the source directory. Consider a directory with no sum file valid, since it might be an import
 		// from an existing project.
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
@@ -182,7 +183,7 @@ This command should be used whenever a manual change in the migration directory 
 				return err
 			}
 			MigrateFlags.DirURL = MigrateFlags.Import.FromURL
-			dir, err := dir(false)
+			dir, err := dir(MigrateFlags.DirURL, false)
 			if err != nil {
 				return err
 			}
@@ -280,6 +281,7 @@ func init() {
 	MigrateCmd.PersistentFlags().StringSliceVarP(&MigrateFlags.Schemas, migrateFlagSchema, "", nil, "set schema names")
 	MigrateCmd.PersistentFlags().StringVarP(&MigrateFlags.DirFormat, migrateFlagDirFormat, "", formatAtlas, "set migration file format")
 	MigrateCmd.PersistentFlags().SortFlags = false
+	cobra.CheckErr(MigrateCmd.Flags().MarkDeprecated(migrateFlagDirFormat, "you can safely omit it."))
 	// Apply flags.
 	MigrateApplyCmd.Flags().StringVarP(&MigrateFlags.Apply.LogFormat, migrateFlagLog, "", logFormatTTY, "log format to use")
 	revisionsFlag(MigrateApplyCmd.Flags())
@@ -292,7 +294,6 @@ func init() {
 	MigrateApplyCmd.Flags().SortFlags = false
 	cobra.CheckErr(MigrateApplyCmd.MarkFlagRequired(migrateFlagURL))
 	MigrateApplyCmd.MarkFlagsMutuallyExclusive(migrateFlagFrom, migrateApplyBaselineVersion)
-	cobra.CheckErr(MigrateApplyCmd.Flags().MarkHidden(migrateFlagDirFormat))
 	cobra.CheckErr(MigrateApplyCmd.Flags().MarkHidden(migrateFlagSchema))
 	// Diff flags.
 	urlFlag(&MigrateFlags.DevURL, migrateFlagDevURL, "", MigrateDiffCmd.Flags())
@@ -344,7 +345,7 @@ func CmdMigrateApplyRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 	// Open the migration directory.
-	dir, err := dir(false)
+	dir, err := dir(MigrateFlags.DirURL, false)
 	if err != nil {
 		return err
 	}
@@ -620,7 +621,15 @@ func CmdMigrateDiffRun(cmd *cobra.Command, args []string) error {
 		defer cobra.CheckErr(unlock())
 	}
 	// Open the migration directory.
-	dir, err := dir(false)
+	u, err := url.Parse(MigrateFlags.DirURL)
+	if err != nil {
+		return err
+	}
+	dir, err := dirURL(u, false)
+	if err != nil {
+		return err
+	}
+	f, err := formatter(u)
 	if err != nil {
 		return err
 	}
@@ -630,10 +639,6 @@ func CmdMigrateDiffRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer desired.Close()
-	f, err := formatter()
-	if err != nil {
-		return err
-	}
 	opts := []migrate.PlannerOption{migrate.PlanFormat(f)}
 	if dev.URL.Schema != "" {
 		// Disable tables qualifier in schema-mode.
@@ -668,7 +673,7 @@ func CmdMigrateDiffRun(cmd *cobra.Command, args []string) error {
 
 // CmdMigrateHashRun is the command executed when running the CLI with 'migrate hash' args.
 func CmdMigrateHashRun(*cobra.Command, []string) error {
-	dir, err := dir(false)
+	dir, err := dir(MigrateFlags.DirURL, false)
 	if err != nil {
 		return err
 	}
@@ -681,17 +686,19 @@ func CmdMigrateHashRun(*cobra.Command, []string) error {
 
 // CmdMigrateImportRun is the command executed when running the CLI with 'migrate import' args.
 func CmdMigrateImportRun(cmd *cobra.Command, _ []string) error {
-	if MigrateFlags.DirFormat == formatAtlas {
-		return fmt.Errorf("cannot import a migration directory already in %q format", formatAtlas)
-	}
-	MigrateFlags.DirURL = MigrateFlags.Import.FromURL
-	src, err := dir(false)
+	p, err := url.Parse(MigrateFlags.Import.FromURL)
 	if err != nil {
 		return err
 	}
-	MigrateFlags.DirFormat = formatAtlas
-	MigrateFlags.DirURL = MigrateFlags.Import.ToURL
-	trgt, err := dir(true)
+	if f := p.Query().Get("format"); f == "" || f == formatAtlas {
+		return fmt.Errorf("cannot import a migration directory already in %q format", formatAtlas)
+	}
+	src, err := dir(MigrateFlags.Import.FromURL, false)
+	if err != nil {
+		return err
+	}
+	MigrateFlags.DirFormat = formatAtlas // remove assignment once the --dir-format flag is removed
+	trgt, err := dir(MigrateFlags.Import.ToURL, true)
 	if err != nil {
 		return err
 	}
@@ -759,11 +766,15 @@ func CmdMigrateImportRun(cmd *cobra.Command, _ []string) error {
 
 // CmdMigrateNewRun is the command executed when running the CLI with 'migrate new' args.
 func CmdMigrateNewRun(_ *cobra.Command, args []string) error {
-	dir, err := dir(true)
+	u, err := url.Parse(MigrateFlags.DirURL)
 	if err != nil {
 		return err
 	}
-	f, err := formatter()
+	dir, err := dirURL(u, true)
+	if err != nil {
+		return err
+	}
+	f, err := formatter(u)
 	if err != nil {
 		return err
 	}
@@ -776,7 +787,7 @@ func CmdMigrateNewRun(_ *cobra.Command, args []string) error {
 
 // CmdMigrateSetRun is the command executed when running the CLI with 'migrate set' args.
 func CmdMigrateSetRun(cmd *cobra.Command, args []string) error {
-	dir, err := dir(false)
+	dir, err := dir(MigrateFlags.DirURL, false)
 	if err != nil {
 		return err
 	}
@@ -910,7 +921,7 @@ func CmdMigrateSetRun(cmd *cobra.Command, args []string) error {
 
 // CmdMigrateStatusRun is the command executed when running the CLI with 'migrate status' args.
 func CmdMigrateStatusRun(cmd *cobra.Command, _ []string) error {
-	dir, err := dir(false)
+	dir, err := dir(MigrateFlags.DirURL, false)
 	if err != nil {
 		return err
 	}
@@ -951,7 +962,7 @@ func CmdMigrateValidateRun(cmd *cobra.Command, _ []string) error {
 	}
 	defer dev.Close()
 	// Currently, only our own migration file format is supported.
-	dir, err := dir(false)
+	dir, err := dir(MigrateFlags.DirURL, false)
 	if err != nil {
 		return err
 	}
@@ -977,7 +988,7 @@ func CmdMigrateLintRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	defer dev.Close()
-	dir, err := dir(false)
+	dir, err := dir(MigrateFlags.DirURL, false)
 	if err != nil {
 		return err
 	}
@@ -1049,39 +1060,53 @@ to re-hash the contents and resolve the error
 `)
 }
 
-// dir returns a migrate.Dir to use as migration directory. For now only local directories are supported.
-func dir(create bool) (migrate.Dir, error) {
-	parts := strings.SplitN(MigrateFlags.DirURL, "://", 2)
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid dir url %q", MigrateFlags.DirURL)
+// dir parses u and calls dirURL.
+func dir(u string, create bool) (migrate.Dir, error) {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil, err
 	}
-	if parts[0] != "file" {
-		return nil, fmt.Errorf("unsupported driver %q", parts[0])
+	return dirURL(parsed, create)
+}
+
+// dirURL returns a migrate.Dir to use as migration directory. For now only local directories are supported.
+func dirURL(u *url.URL, create bool) (migrate.Dir, error) {
+	if u.Scheme != "file" {
+		return nil, fmt.Errorf("unsupported driver %q", u.Scheme)
 	}
-	f := func() (migrate.Dir, error) { return migrate.NewLocalDir(parts[1]) }
-	switch MigrateFlags.DirFormat {
+	if !u.Query().Has("format") && MigrateFlags.DirFormat != "" { // remove once --dir-format flag is removed
+		q := u.Query()
+		q.Set("format", MigrateFlags.DirFormat)
+		u.RawQuery = q.Encode()
+	}
+	fn := func() (migrate.Dir, error) { return migrate.NewLocalDir(u.Path) }
+	switch f := u.Query().Get("format"); f {
 	case formatAtlas:
+		// this is the default
 	case formatGolangMigrate:
-		f = func() (migrate.Dir, error) { return sqltool.NewGolangMigrateDir(parts[1]) }
+		fn = func() (migrate.Dir, error) { return sqltool.NewGolangMigrateDir(u.Path) }
 	case formatGoose:
-		f = func() (migrate.Dir, error) { return sqltool.NewGooseDir(parts[1]) }
+		fn = func() (migrate.Dir, error) { return sqltool.NewGooseDir(u.Path) }
 	case formatFlyway:
-		f = func() (migrate.Dir, error) { return sqltool.NewFlywayDir(parts[1]) }
+		fn = func() (migrate.Dir, error) { return sqltool.NewFlywayDir(u.Path) }
 	case formatLiquibase:
-		f = func() (migrate.Dir, error) { return sqltool.NewLiquibaseDir(parts[1]) }
+		fn = func() (migrate.Dir, error) { return sqltool.NewLiquibaseDir(u.Path) }
 	case formatDBMate:
-		f = func() (migrate.Dir, error) { return sqltool.NewDBMateDir(parts[1]) }
+		fn = func() (migrate.Dir, error) { return sqltool.NewDBMateDir(u.Path) }
 	default:
-		return nil, fmt.Errorf("unknown dir format %q", MigrateFlags.DirFormat)
+		return nil, fmt.Errorf("unknown dir format %q", f)
 	}
-	d, err := f()
+	d, err := fn()
 	if create && errors.Is(err, fs.ErrNotExist) {
-		if err := os.MkdirAll(parts[1], 0755); err != nil {
+		if err := os.MkdirAll(u.Path, 0755); err != nil {
 			return nil, err
 		}
-		d, err = f()
+		d, err = fn()
+		if err != nil {
+			return nil, err
+		}
 	}
-	return d, err
+	return d, nil
 }
 
 type target struct {
@@ -1262,8 +1287,8 @@ const (
 	formatDBMate        = "dbmate"
 )
 
-func formatter() (migrate.Formatter, error) {
-	switch MigrateFlags.DirFormat {
+func formatter(u *url.URL) (migrate.Formatter, error) {
+	switch f := u.Query().Get("format"); f {
 	case formatAtlas:
 		return migrate.DefaultFormatter, nil
 	case formatGolangMigrate:
@@ -1277,7 +1302,7 @@ func formatter() (migrate.Formatter, error) {
 	case formatDBMate:
 		return sqltool.DBMateFormatter, nil
 	default:
-		return nil, fmt.Errorf("unknown format %q", MigrateFlags.DirFormat)
+		return nil, fmt.Errorf("unknown format %q", f)
 	}
 }
 

--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -39,13 +39,39 @@ func TestMigrate(t *testing.T) {
 func TestMigrate_Import(t *testing.T) {
 	for _, tool := range []string{"dbmate", "flyway", "golang-migrate", "goose", "liquibase"} {
 		p := t.TempDir()
-		t.Run(tool, func(t *testing.T) {
+		t.Run(tool, func(t *testing.T) { // remove this once --dir-format is removed. Test is kept to ensure BC.
 			path := filepath.FromSlash("testdata/import/" + tool)
 			out, err := runCmd(
 				Root, "migrate", "import",
 				"--from", "file://"+path,
 				"--to", "file://"+p,
 				"--dir-format", tool,
+			)
+			require.NoError(t, err)
+			require.Zero(t, out)
+
+			path += "_gold"
+			ex, err := os.ReadDir(path)
+			require.NoError(t, err)
+			ac, err := os.ReadDir(p)
+			require.NoError(t, err)
+			require.Equal(t, len(ex)+1, len(ac)) // sum file
+
+			for i := range ex {
+				e, err := os.ReadFile(filepath.Join(path, ex[i].Name()))
+				require.NoError(t, err)
+				a, err := os.ReadFile(filepath.Join(p, ex[i].Name()))
+				require.NoError(t, err)
+
+				require.Equal(t, string(e), string(a))
+			}
+		})
+		t.Run(tool, func(t *testing.T) {
+			path := filepath.FromSlash("testdata/import/" + tool)
+			out, err := runCmd(
+				Root, "migrate", "import",
+				"--from", fmt.Sprintf("file://%s?format=%s", path, tool),
+				"--to", "file://"+p,
 			)
 			require.NoError(t, err)
 			require.Zero(t, out)
@@ -554,14 +580,14 @@ func TestMigrate_New(t *testing.T) {
 	require.Equal(t, 3, countFiles(t, p))
 
 	p = t.TempDir()
-	s, err = runCmd(Root, "migrate", "new", "goose", "--dir", "file://"+p, "--dir-format", formatGoose)
+	s, err = runCmd(Root, "migrate", "new", "goose", "--dir", "file://"+p+"?format="+formatGoose)
 	require.Zero(t, s)
 	require.NoError(t, err)
 	require.FileExists(t, filepath.Join(p, v+"_goose.sql"))
 	require.Equal(t, 2, countFiles(t, p))
 
 	p = t.TempDir()
-	s, err = runCmd(Root, "migrate", "new", "flyway", "--dir", "file://"+p, "--dir-format", formatFlyway)
+	s, err = runCmd(Root, "migrate", "new", "flyway", "--dir", "file://"+p+"?format="+formatFlyway)
 	require.Zero(t, s)
 	require.NoError(t, err)
 	require.FileExists(t, filepath.Join(p, fmt.Sprintf("V%s__%s.sql", v, formatFlyway)))
@@ -569,14 +595,14 @@ func TestMigrate_New(t *testing.T) {
 	require.Equal(t, 3, countFiles(t, p))
 
 	p = t.TempDir()
-	s, err = runCmd(Root, "migrate", "new", "liquibase", "--dir", "file://"+p, "--dir-format", formatLiquibase)
+	s, err = runCmd(Root, "migrate", "new", "liquibase", "--dir", "file://"+p+"?format="+formatLiquibase)
 	require.Zero(t, s)
 	require.NoError(t, err)
 	require.FileExists(t, filepath.Join(p, v+"_liquibase.sql"))
 	require.Equal(t, 2, countFiles(t, p))
 
 	p = t.TempDir()
-	s, err = runCmd(Root, "migrate", "new", "dbmate", "--dir", "file://"+p, "--dir-format", formatDBMate)
+	s, err = runCmd(Root, "migrate", "new", "dbmate", "--dir", "file://"+p+"?format="+formatDBMate)
 	require.Zero(t, s)
 	require.NoError(t, err)
 	require.FileExists(t, filepath.Join(p, v+"_dbmate.sql"))
@@ -592,8 +618,7 @@ func TestMigrate_New(t *testing.T) {
 
 func TestMigrate_Validate(t *testing.T) {
 	// Without re-playing.
-	MigrateFlags.DevURL = ""         // global flags are set from other tests ...
-	MigrateFlags.DirFormat = "atlas" // global flags are set from other tests ...
+	MigrateFlags.DevURL = "" // global flags are set from other tests ...
 	s, err := runCmd(Root, "migrate", "validate", "--dir", "file://testdata/mysql")
 	require.Zero(t, s)
 	require.NoError(t, err)
@@ -701,8 +726,7 @@ func TestMigrate_Lint(t *testing.T) {
 	require.NoError(t, os.Rename(filepath.Join(p, "2.sql"), filepath.Join(p, "1.down.sql")))
 	s, err = runCmd(
 		Root, "migrate", "lint",
-		"--dir", "file://"+p,
-		"--dir-format", "golang-migrate",
+		"--dir", "file://"+p+"?format="+formatGolangMigrate,
 		"--dev-url", openSQLite(t, ""),
 		"--latest", "2",
 		"--log", "{{ range .Files }}{{ .Name }}:{{ len .Reports }}{{ end }}",
@@ -716,8 +740,7 @@ func TestMigrate_Lint(t *testing.T) {
 	require.NoError(t, err)
 	s, err = runCmd(
 		Root, "migrate", "lint",
-		"--dir", "file://"+p,
-		"--dir-format", "golang-migrate",
+		"--dir", "file://"+p+"?format="+formatGolangMigrate,
 		"--dev-url", openSQLite(t, ""),
 		"--latest", "1",
 	)

--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -66,6 +66,7 @@ func TestMigrate_Import(t *testing.T) {
 				require.Equal(t, string(e), string(a))
 			}
 		})
+		p = t.TempDir()
 		t.Run(tool, func(t *testing.T) {
 			path := filepath.FromSlash("testdata/import/" + tool)
 			out, err := runCmd(
@@ -618,7 +619,8 @@ func TestMigrate_New(t *testing.T) {
 
 func TestMigrate_Validate(t *testing.T) {
 	// Without re-playing.
-	MigrateFlags.DevURL = "" // global flags are set from other tests ...
+	MigrateFlags.DevURL = ""         // global flags are set from other tests ...
+	MigrateFlags.DirFormat = "atlas" // global flags are set from other tests ...
 	s, err := runCmd(Root, "migrate", "validate", "--dir", "file://testdata/mysql")
 	require.Zero(t, s)
 	require.NoError(t, err)

--- a/cmd/atlas/internal/cmdapi/schema_test.go
+++ b/cmd/atlas/internal/cmdapi/schema_test.go
@@ -115,6 +115,7 @@ func TestSchema_Clean(t *testing.T) {
 	require.NoError(t, err)
 
 	// Apply migrations onto database.
+	MigrateFlags.Apply.BaselineVersion = ""
 	_, err = runCmd(Root, "migrate", "apply", "--dir", "file://testdata/sqlite", "--url", u)
 	require.NoError(t, err)
 

--- a/doc/md/guides/migration-tools/golang-migrate.md
+++ b/doc/md/guides/migration-tools/golang-migrate.md
@@ -174,11 +174,14 @@ Now, let's use Atlas's `migrate diff` command to plan a migration from the curre
 as it exists in the migrations directory to the desired state that is defined by the `schema.hcl`
 file:
 
-```text
-atlas migrate diff --dir file://migrations --dev-url mysql://root:pass@localhost:3306/dev --to file://schema.hcl --dir-format golang-migrate add_blog_posts 
+```shell
+atlas migrate diff add_blog_posts \
+  --dir "file://migrations?format=golang-migrate" \
+  --dev-url "mysql://root:pass@localhost:3306/dev" \
+  --to "file://schema.hcl" 
 ```
 
-Notice that we used the `dir-format` flag to specify that we're using `golang-migrate` as the directory format.
+Notice that we used the `format` query parameter to specify that we're using `golang-migrate` as the directory format.
 
 Hooray! Two new files were created in the migrations directory:
 ```text {5-6}
@@ -210,8 +213,11 @@ plan a migration from your current migration directory state to an existing sche
 database was available at `mysql://root:pass@some.db.io:3306/db`, a migration to the state
 of that database could be planned by running:
 
-```text
-atlas migrate diff --dir file://migrations --dev-url mysql://root:pass@localhost:3306/dev --to mysql://root:pass@some.db.io:3306/db --dir-format golang-migrate migration_name
+```shell
+atlas migrate diff migration_name \
+  --dir "file://migrations?format=golang-migrate" \
+  --dev-url "mysql://root:pass@localhost:3306/dev" \
+  --to "mysql://root:pass@some.db.io:3306/db"
 ```
 
 ## Conclusion

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -158,7 +158,7 @@ atlas migrate import [flags]
 #### Example
 
 ```
-  atlas migrate import --dir-format liquibase --from file:///path/to/source/directory --to file:///path/to/migration/directory
+  atlas migrate import --from file:///path/to/source/directory?format=liquibase --to file:///path/to/migration/directory
 ```
 #### Flags
 ```

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -49,6 +49,7 @@ atlas migrate
 #### Flags
 ```
       --dir string           select migration directory using URL format (default "file://migrations")
+      --dir-format string    set migration file format (default "atlas")
       --env string           set which env from the project file to use
       --var <name>=<value>   input variables (default [])
 

--- a/doc/md/versioned/diff.mdx
+++ b/doc/md/versioned/diff.mdx
@@ -57,7 +57,7 @@ values={[
 <TabItem value="migration_file">
 
 By default, migration files are named with the following format `{{ now }}_{{ name }}.sql`.
-If you wish to use a different file format, use the `--dir-format` option.
+If you wish to use a different file format, use the `format` query parameter in the directory URL.
 
 ```sql
 -- create "users" table
@@ -184,7 +184,7 @@ values={[
 <TabItem value="migration_file">
 
 By default, migration files are named with the following format `{{ now }}_{{ name }}.sql`.
-If you wish to use a different file format, use the `--dir-format` option.
+If you wish to use a different file format, use the `format` query parameter in the directory URL.
 
 ```sql
 -- create "users" table
@@ -233,15 +233,14 @@ CREATE TABLE `market`.`users` (`id` int NOT NULL, `name` varchar(255) NOT NULL) 
 
 ### Generate migrations with custom formats
 
-Some migration tools use a different file format than the one used by Atlas. Therefore, Atlas provides
-an option named `--dir-format` that allows controlling the format of the migration directory.
+Some migration tools use a different file format than the one used by Atlas. You can control the format of the migration
+directory by passing in the `format` query parameter to the migration directory URL.
 
 ```shell
 atlas migrate diff create_users \
-  --dir "file://migrations" \
+  --dir "file://migrations?format=golang-migrate" \
   --to "file://schema.hcl" \
-  --dev-url "mysql://root:pass@:3306/test" \
-  --dir-format "golang-migrate"
+  --dev-url "mysql://root:pass@:3306/test"
 ```
 
 Run `ls migrations`, and you will notice Atlas created 3 files:

--- a/doc/md/versioned/import.mdx
+++ b/doc/md/versioned/import.mdx
@@ -14,10 +14,10 @@ a convenient command to import existing migration directories of supported tools
 
 ### Flags
 When using `atlas migrate import` to import a migration directory, users must supply multiple parameters:
-* `--from` the [URL](/concepts/url) to the migration directory to import.
+* `--from` the [URL](/concepts/url) to the migration directory to import, the `format` query parameter controls the
+migration directory format, e.g. `file://migrations?format=flyway`. Supported formats are `atlas` (default),
+`golang-migrate`, `goose`, `flyway`, `liquibase` and `dbmate`.
 * `--to` the URL of the migration directory to save imported migration files into, by default it is `file://migrations`.
-* `--dir-format` one of `[golang-migrate, goose, flyway, liquibase, dbmate]` to specifiy the migration file format of the
-migration directory to import.
 
 ### Limitations
 
@@ -174,15 +174,17 @@ CREATE VIEW `users_over_30` AS SELECT * FROM `users` where `age` > 30;
 Import existing `golang-migrate/migrate` migration directory:
 ```shell
 atlas migrate import \
-  --from "file://migrations" \
-  --to "file://atlas-migrations" \
-  -- dir-format "golang-migrate"
+  --from "file://migrations?format=golang-migrate" \
+  --to "file://atlas-migrations"
 ```
 
 Import existing Flyway migration directory:
 ```shell
 atlas migrate import \
-  --from "file://migrations" \
-  --to "file://atlas-migrations" \
-  -- dir-format "flyway"
+  --from "file://migrations?format=flyway" \
+  --to "file://atlas-migrations"
 ```
+
+### Reference
+
+[CLI Command Reference](/cli-reference#atlas-migrate-import)

--- a/internal/integration/testdata/mysql/cli-migrate-diff-format.txt
+++ b/internal/integration/testdata/mysql/cli-migrate-diff-format.txt
@@ -2,6 +2,7 @@ only maria103
 
 mkdir migrations
 
+# old behavior still works
 atlas migrate diff --dev-url URL --to file://1.hcl --dir-format golang-migrate first
 cmpmig 0 golang-migrate/1.down.sql
 cmpmig 1 golang-migrate/1.up.sql
@@ -13,39 +14,50 @@ cmpmig 3 golang-migrate/2.up.sql
 rm migrations
 mkdir migrations
 
-atlas migrate diff --dev-url URL --to file://1.hcl --dir-format goose first
+atlas migrate diff --dev-url URL --to file://1.hcl --dir file://migrations?format=golang-migrate first
+cmpmig 0 golang-migrate/1.down.sql
+cmpmig 1 golang-migrate/1.up.sql
+
+atlas migrate diff --dev-url URL --to file://2.hcl --dir file://migrations?format=golang-migrate second
+cmpmig 2 golang-migrate/2.down.sql
+cmpmig 3 golang-migrate/2.up.sql
+
+rm migrations
+mkdir migrations
+
+atlas migrate diff --dev-url URL --to file://1.hcl --dir file://migrations?format=goose first
 cmpmig 0 goose/1.sql
 
-atlas migrate diff --dev-url URL --to file://2.hcl --dir-format goose second
+atlas migrate diff --dev-url URL --to file://2.hcl --dir file://migrations?format=goose second
 cmpmig 1 goose/2.sql
 
 rm migrations
 mkdir migrations
 
-atlas migrate diff --dev-url URL --to file://1.hcl --dir-format dbmate first
+atlas migrate diff --dev-url URL --to file://1.hcl --dir file://migrations?format=dbmate first
 cmpmig 0 dbmate/1.sql
 
-atlas migrate diff --dev-url URL --to file://2.hcl --dir-format dbmate second
+atlas migrate diff --dev-url URL --to file://2.hcl --dir file://migrations?format=dbmate second
 cmpmig 1 dbmate/2.sql
 
 rm migrations
 mkdir migrations
 
-atlas migrate diff --dev-url URL --to file://1.hcl --dir-format flyway first
+atlas migrate diff --dev-url URL --to file://1.hcl --dir file://migrations?format=flyway first
 cmpmig 0 flyway/U1.sql
 cmpmig 1 flyway/V1.sql
 
-atlas migrate diff --dev-url URL --to file://2.hcl --dir-format flyway second
+atlas migrate diff --dev-url URL --to file://2.hcl --dir file://migrations?format=flyway second
 cmpmig 1 flyway/U2.sql
 cmpmig 3 flyway/V2.sql
 
 rm migrations
 mkdir migrations
 
-atlas migrate diff --dev-url URL --to file://1.hcl --dir-format liquibase first
+atlas migrate diff --dev-url URL --to file://1.hcl --dir file://migrations?format=liquibase first
 cmpmig 0 liquibase/1.sql
 
-atlas migrate diff --dev-url URL --to file://2.hcl --dir-format liquibase second
+atlas migrate diff --dev-url URL --to file://2.hcl --dir file://migrations?format=liquibase second
 cmpmig 1 liquibase/2.sql
 
 -- golang-migrate/1.up.sql --

--- a/sql/migrate/migrate_test.go
+++ b/sql/migrate/migrate_test.go
@@ -147,13 +147,14 @@ func TestPlanner_PlanSchema(t *testing.T) {
 
 func TestExecutor_Replay(t *testing.T) {
 	ctx := context.Background()
-	d, err := migrate.NewLocalDir("testdata/migrate")
+	d, err := migrate.NewLocalDir(filepath.FromSlash("testdata/migrate"))
 	require.NoError(t, err)
 
 	drv := &mockDriver{}
 	ex, err := migrate.NewExecutor(drv, d, migrate.NopRevisionReadWriter{})
 	require.NoError(t, err)
 
+	// No options.
 	_, err = ex.Replay(ctx, migrate.RealmConn(drv, nil))
 	require.NoError(t, err)
 	require.Equal(t, []string{"DROP TABLE IF EXISTS t;", "CREATE TABLE t(c int);"}, drv.executed)
@@ -318,7 +319,7 @@ func TestExecutor(t *testing.T) {
 			OperatorVersion: "op",
 		}
 	)
-	dir, err = migrate.NewLocalDir(filepath.Join("testdata/migrate", "sub"))
+	dir, err = migrate.NewLocalDir(filepath.Join("testdata", "migrate", "sub"))
 	require.NoError(t, err)
 	ex, err = migrate.NewExecutor(drv, dir, rrw, migrate.WithLogger(log), migrate.WithOperatorVersion("op"))
 	require.NoError(t, err)


### PR DESCRIPTION
Migration directory format is now given by a query parameter, e.g. `file://migrations?format=atlas`. Some tests have not been changed to the new behavior since the flag is still working for BC reasons.

Encoding all meta into the query string increases API consistency and also adds the possibility to add more meta without adding more and more flags. E.g. replaying until a specific version could be done by `file://migrations?format=atlas&version=1234`.