### PR TITLE
cmd/atlas/internal/cmdapi: schema diff works with statereaders

### DIFF
--- a/cmd/atlas/internal/cmdapi/cmdapi.go
+++ b/cmd/atlas/internal/cmdapi/cmdapi.go
@@ -2,8 +2,7 @@
 // This source code is licensed under the Apache 2.0 license found
 // in the LICENSE file in the root directory of this source tree.
 
-// Package cmdapi holds the atlas commands used to build
-// an atlas distribution.
+// Package cmdapi holds the atlas commands used to build an atlas distribution.
 package cmdapi
 
 import (
@@ -26,16 +25,14 @@ var (
 
 	// GlobalFlags contains flags common to many Atlas sub-commands.
 	GlobalFlags struct {
-		// SelectedEnv contains the environment selected from the active
-		// project via the --env flag.
+		// SelectedEnv contains the environment selected from the active project via the --env flag.
 		SelectedEnv string
-		// Vars contains the input variables passed from the CLI to
-		// Atlas DDL or project files.
+		// Vars contains the input variables passed from the CLI to Atlas DDL or project files.
 		Vars Vars
 	}
 
-	// version holds Atlas version. When built with cloud packages
-	// should be set by build flag. "-X 'ariga.io/atlas/cmd/atlas/internal/cmdapi.version=${version}'"
+	// version holds Atlas version. When built with cloud packages should be set by build flag
+	// "-X 'ariga.io/atlas/cmd/atlas/internal/cmdapi.version=${version}'"
 	version string
 
 	// schemaCmd represents the subcommand 'atlas version'.
@@ -48,8 +45,8 @@ var (
 		},
 	}
 
-	// license holds Atlas license. When built with cloud packages
-	// should be set by build flag. "-X 'ariga.io/atlas/cmd/atlas/internal/cmdapi.license=${license}'"
+	// license holds Atlas license. When built with cloud packages should be set by build flag
+	// "-X 'ariga.io/atlas/cmd/atlas/internal/cmdapi.license=${license}'"
 	license = `LICENSE
 Atlas is licensed under Apache 2.0 as found in https://github.com/ariga/atlas/blob/master/LICENSE.`
 	licenseCmd = &cobra.Command{

--- a/cmd/atlas/internal/cmdapi/diff.go
+++ b/cmd/atlas/internal/cmdapi/diff.go
@@ -203,9 +203,7 @@ func stateReader(ctx context.Context, config *stateReaderConfig) (*stateReadClos
 		switch {
 		case hcl:
 			return hclStateReader(ctx, config, parsed)
-		case !sql:
-			return nil, fmt.Errorf("%q contains neither SQL nor HCL files", path)
-		default:
+		case sql:
 			dir, err := dirURL(parsed[0], false)
 			if err != nil {
 				return nil, err
@@ -227,6 +225,8 @@ func stateReader(ctx context.Context, config *stateReaderConfig) (*stateReadClos
 				StateReader: migrate.Realm(sr),
 				Schema:      config.dev.URL.Schema,
 			}, nil
+		default:
+			return nil, fmt.Errorf("%q contains neither SQL nor HCL files", path)
 		}
 	default:
 		// All other schemes are database (or docker) connections.

--- a/cmd/atlas/internal/cmdapi/diff.go
+++ b/cmd/atlas/internal/cmdapi/diff.go
@@ -5,9 +5,16 @@
 package cmdapi
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 
+	"ariga.io/atlas/sql/migrate"
 	"ariga.io/atlas/sql/schema"
 	"ariga.io/atlas/sql/sqlclient"
 
@@ -17,85 +24,295 @@ import (
 type diffCmdOpts struct {
 	fromURL string
 	toURL   string
+	devURL  string
 }
 
-// newDiffCmd returns a new *cobra.Command that runs cmdDiffRun with the given flags and mux.
+// newDiffCmd returns a new *cobra.Command that runs cmdDiffRun with the given flags.
 func newDiffCmd() *cobra.Command {
 	var opts diffCmdOpts
 	cmd := &cobra.Command{
 		Use:   "diff",
 		Short: "Calculate and print the diff between two schemas.",
-		Long: `'atlas schema diff' connects to two given databases, inspects
-them, calculates the difference in their schemas, and prints a plan of
-SQL statements to migrate the "from" database to the schema of the "to" database.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmdDiffRun(cmd, &opts)
+		Long: `'atlas schema diff' reads the state of two given schema definitions, 
+calculates the difference in their schemas, and prints a plan of
+SQL statements to migrate the "from" database to the schema of the "to" database.
+The database states can be read from a connected database, an HCL project or a migration directory.`,
+		Example: `  atlas schema diff --from mysql://user:pass@localhost:3306/test --to file://schema.hcl
+  atlas schema diff --from mysql://user:pass@localhost:3306 --to file://schema_1.hcl --to file://schema_2.hcl
+  atlas schema diff --from mysql://user:pass@localhost:3306 --to file://migrations`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmdDiffRun(cmd, &opts)
 		},
 	}
 	cmd.Flags().StringVarP(&opts.fromURL, "from", "", "", "[driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format")
 	cmd.Flags().StringVarP(&opts.toURL, "to", "", "", "[driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format")
+	cmd.Flags().StringVarP(&opts.devURL, "dev-url", "", "", "[driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format")
 	cobra.CheckErr(cmd.MarkFlagRequired("from"))
 	cobra.CheckErr(cmd.MarkFlagRequired("to"))
 	return cmd
 }
 
 func init() {
-	diffCmd := newDiffCmd()
-	schemaCmd.AddCommand(diffCmd)
+	schemaCmd.AddCommand(newDiffCmd())
 }
 
 // cmdDiffRun connects to the given databases, and prints an SQL plan to get from
 // the "from" schema to the "to" schema.
-func cmdDiffRun(cmd *cobra.Command, flags *diffCmdOpts) {
-	ctx := cmd.Context()
-	fromC, err := sqlclient.Open(cmd.Context(), flags.fromURL)
-	cobra.CheckErr(err)
-	defer fromC.Close()
-	toC, err := sqlclient.Open(cmd.Context(), flags.toURL)
-	cobra.CheckErr(err)
-	defer toC.Close()
-	fromS := fromC.URL.Schema
-	toS := toC.URL.Schema
+func cmdDiffRun(cmd *cobra.Command, flags *diffCmdOpts) error {
+	var (
+		ctx = cmd.Context()
+		c   *sqlclient.Client
+	)
+	// We need a driver for diffing and planning. If given, dev database has precedence.
+	if flags.devURL != "" {
+		var err error
+		c, err = sqlclient.Open(ctx, flags.devURL)
+		if err != nil {
+			return err
+		}
+		defer c.Close()
+	}
+	from, err := stateReader(ctx, &stateReaderConfig{urls: []string{flags.fromURL}, dev: c})
+	if err != nil {
+		return err
+	}
+	defer from.Close()
+	to, err := stateReader(ctx, &stateReaderConfig{urls: []string{flags.toURL}, dev: c})
+	if err != nil {
+		return err
+	}
+	defer to.Close()
+	if c == nil {
+		var ok bool
+		c, ok = from.Closer.(*sqlclient.Client)
+		if !ok {
+			c, ok = to.Closer.(*sqlclient.Client)
+			if !ok {
+				// There is no driver to diff. We need a dev-database.
+				cobra.CheckErr(errors.New(
+					"neither --from nor --to provides a database connection, please provide one by passing in a --dev-url",
+				))
+			}
+		}
+	}
+	current, err := from.ReadState(ctx)
+	if err != nil {
+		return err
+	}
+	desired, err := to.ReadState(ctx)
+	if err != nil {
+		return err
+	}
 	var diff []schema.Change
 	switch {
-	case fromS == "" && toS == "":
-		// compare realm.
-		fromRealm, err := fromC.InspectRealm(ctx, nil)
-		cobra.CheckErr(err)
-		toRealm, err := toC.InspectRealm(ctx, nil)
-		cobra.CheckErr(err)
-		diff, err = toC.RealmDiff(fromRealm, toRealm)
-		cobra.CheckErr(err)
-	case fromS == "":
-		cobra.CheckErr(fmt.Errorf("cannot diff schema %q with a database connection", fromS))
-	case toS == "":
-		cobra.CheckErr(fmt.Errorf("cannot diff database connection with a schema %q", toS))
-	default:
-		// compare schemas.
-		fromSchema, err := fromC.InspectSchema(ctx, fromS, nil)
-		cobra.CheckErr(err)
-		toSchema, err := toC.InspectSchema(ctx, toS, nil)
-		cobra.CheckErr(err)
-		// SchemaDiff checks for name equality which is irrelevant in the case
-		// the user wants to compare their contents, if the names are different
-		// we reset them to allow the comparison.
-		if fromS != toS {
-			toSchema.Name = ""
-			fromSchema.Name = ""
+	// compare realm
+	case from.Schema == "" && to.Schema == "":
+		diff, err = c.RealmDiff(current, desired)
+		if err != nil {
+			return err
 		}
-		diff, err = toC.SchemaDiff(fromSchema, toSchema)
-		cobra.CheckErr(err)
+	case from.Schema == "":
+		cobra.CheckErr(fmt.Errorf("cannot diff schema %q with a database connection", from.Schema))
+	case to.Schema == "":
+		cobra.CheckErr(fmt.Errorf("cannot diff database connection with a schema %q", to.Schema))
+	default:
+		// SchemaDiff checks for name equality which is irrelevant in the case
+		// the user wants to compare their contents, reset them to allow the comparison.
+		current.Schemas[0].Name, desired.Schemas[0].Name = "", ""
+		diff, err = c.SchemaDiff(current.Schemas[0], desired.Schemas[0])
+		if err != nil {
+			return err
+		}
 	}
-	p, err := toC.PlanChanges(ctx, "plan", diff)
-	cobra.CheckErr(err)
+	p, err := c.PlanChanges(ctx, "plan", diff)
+	if err != nil {
+		return err
+	}
 	if len(p.Changes) == 0 {
 		cmd.Println("Schemas are synced, no changes to be made.")
-		return
+		return nil
 	}
 	for _, c := range p.Changes {
 		if c.Comment != "" {
 			cmd.Println("--", strings.ToUpper(c.Comment[:1])+c.Comment[1:])
 		}
 		cmd.Println(c.Cmd)
+	}
+	return nil
+}
+
+type (
+	// stateReadCloser is a migrate.StateReader with an optional io.Closer.
+	stateReadCloser struct {
+		migrate.StateReader
+		io.Closer        // optional close function
+		Schema    string // in case we work on a single schema
+	}
+	// stateReaderConfig is given to stateReader.
+	stateReaderConfig struct {
+		urls    []string          // urls to create a migrate.StateReader from
+		dev     *sqlclient.Client // dev database connection
+		schemas []string          // schemas to work on
+	}
+)
+
+// stateReader returns a migrate.StateReader that reads the state from the given urls.
+func stateReader(ctx context.Context, config *stateReaderConfig) (*stateReadCloser, error) {
+	scheme, err := selectScheme(config.urls)
+	if err != nil {
+		return nil, err
+	}
+	parsed := make([]*url.URL, len(config.urls))
+	for i, u := range config.urls {
+		parsed[i], err = url.Parse(u)
+		if err != nil {
+			return nil, err
+		}
+	}
+	switch scheme {
+	// "file" scheme is valid for both migration directory and HCL paths.
+	case "file":
+		if len(config.urls) > 1 {
+			// Consider urls being HCL paths.
+			return hclStateReader(ctx, config, parsed)
+		}
+		path := filepath.Join(parsed[0].Host, parsed[0].Path)
+		fi, err := os.Stat(path)
+		if err != nil {
+			return nil, err
+		}
+		if !fi.IsDir() {
+			// If there is only one url given, and it is a file, consider it an HCL path.
+			return hclStateReader(ctx, config, parsed)
+		}
+		files, err := os.ReadDir(path)
+		if err != nil {
+			return nil, err
+		}
+		// Check all files, if we find both HCL and SQL files, abort. Otherwise, proceed accordingly.
+		var hcl, sql bool
+		for _, f := range files {
+			if f.IsDir() {
+				// skip directories
+			}
+			ext := filepath.Ext(f.Name())
+			switch {
+			case (hcl && ext == ".sql") || (sql && ext == ".hcl"):
+				return nil, fmt.Errorf("ambiguos files: %q contains both SQL and HCL files", path)
+			case ext == ".hcl":
+				hcl = true
+			case ext == ".sql":
+				sql = true
+			}
+			// unknown extension, we don't care
+		}
+		switch {
+		case hcl:
+			return hclStateReader(ctx, config, parsed)
+		case !sql:
+			return nil, fmt.Errorf("%q contains neither SQL nor HCL files", path)
+		default:
+			// Replay the migration directory to read the state.
+			if config.dev == nil {
+				return nil, errors.New("reading migration directory state requires a dev database connection")
+			}
+			dir, err := dirURL(parsed[0], false)
+			if err != nil {
+				return nil, err
+			}
+			ex, err := migrate.NewExecutor(config.dev.Driver, dir, migrate.NopRevisionReadWriter{})
+			if err != nil {
+				return nil, err
+			}
+			sr, err := ex.Replay(ctx, func() migrate.StateReader {
+				if config.dev.URL.Schema != "" {
+					return migrate.SchemaConn(config.dev, "", nil)
+				}
+				return migrate.RealmConn(config.dev, nil)
+			}())
+			if err != nil && !errors.Is(err, migrate.ErrNoPendingFiles) {
+				return nil, fmt.Errorf("replaying the migration directory: %w", err)
+			}
+			return &stateReadCloser{
+				StateReader: migrate.Realm(sr),
+				Schema:      config.dev.URL.Schema,
+			}, nil
+		}
+	default:
+		// All other schemes are database (or docker) connections.
+		c, err := sqlclient.Open(ctx, config.urls[0]) // call to selectScheme already checks for len > 0
+		if err != nil {
+			return nil, err
+		}
+		var sr migrate.StateReader
+		switch c.URL.Schema {
+		case "":
+			sr = migrate.SchemaConn(c.Driver, c.URL.Schema, nil)
+		default:
+			sr = migrate.RealmConn(c.Driver, nil)
+		}
+		return &stateReadCloser{
+			StateReader: sr,
+			Closer:      c,
+			Schema:      c.URL.Schema,
+		}, nil
+	}
+}
+
+// hclStateReadr returns a migrate.StateReader that reads the state from the given HCL paths urls.
+func hclStateReader(ctx context.Context, config *stateReaderConfig, urls []*url.URL) (*stateReadCloser, error) {
+	if config.dev == nil {
+		return nil, errors.New("evaluating HCL files requires a dev database connection")
+	}
+	paths := make([]string, len(urls))
+	for i, u := range urls {
+		paths[i] = u.Path
+	}
+	parser, err := parseHCLPaths(paths...)
+	if err != nil {
+		return nil, err
+	}
+	realm := &schema.Realm{}
+	if err := config.dev.Eval(parser, realm, nil); err != nil {
+		return nil, err
+	}
+	if len(config.schemas) > 0 {
+		// Validate all schemas in file were selected by user.
+		sm := make(map[string]bool, len(config.schemas))
+		for _, s := range config.schemas {
+			sm[s] = true
+		}
+		for _, s := range realm.Schemas {
+			if !sm[s.Name] {
+				return nil, fmt.Errorf("schema %q from paths %q is not requested (all schemas in HCL must be requested)", s.Name, paths)
+			}
+		}
+	}
+	// In case the dev connection is bound to a specific schema, we require the
+	// desired schema to contain only one schema. Thus, executing diff will be
+	// done on the content of these two schema and not the whole realm.
+	if config.dev.URL.Schema != "" && len(realm.Schemas) > 1 {
+		return nil, fmt.Errorf(
+			"cannot use HCL with more than 1 schema when dev-url is limited to schema %q",
+			config.dev.URL.Schema,
+		)
+	}
+	if norm, ok := config.dev.Driver.(schema.Normalizer); ok && len(realm.Schemas) > 0 {
+		realm, err = norm.NormalizeRealm(ctx, realm)
+		if err != nil {
+			return nil, err
+		}
+	}
+	t := &stateReadCloser{StateReader: migrate.Realm(realm), Closer: io.NopCloser(nil)}
+	if len(realm.Schemas) == 1 {
+		t.Schema = realm.Schemas[0].Name
+	}
+	return t, nil
+}
+
+// Close redirects calls to Close to the enclosed io.Closer.
+func (sr *stateReadCloser) Close() {
+	if sr.Closer != nil {
+		sr.Closer.Close()
 	}
 }

--- a/cmd/atlas/internal/cmdapi/diff.go
+++ b/cmd/atlas/internal/cmdapi/diff.go
@@ -188,9 +188,6 @@ func stateReader(ctx context.Context, config *stateReaderConfig) (*stateReadClos
 		// Check all files, if we find both HCL and SQL files, abort. Otherwise, proceed accordingly.
 		var hcl, sql bool
 		for _, f := range files {
-			if f.IsDir() {
-				// skip directories
-			}
 			ext := filepath.Ext(f.Name())
 			switch {
 			case hcl && ext == ".sql", sql && ext == ".hcl":
@@ -199,8 +196,9 @@ func stateReader(ctx context.Context, config *stateReaderConfig) (*stateReadClos
 				hcl = true
 			case ext == ".sql":
 				sql = true
+			default:
+				// unknown extension, we don't care
 			}
-			// unknown extension, we don't care
 		}
 		switch {
 		case hcl:

--- a/cmd/atlas/internal/cmdapi/diff.go
+++ b/cmd/atlas/internal/cmdapi/diff.go
@@ -47,6 +47,7 @@ The database states can be read from a connected database, an HCL project or a m
 	cmd.Flags().StringVarP(&opts.fromURL, "from", "", "", "[driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format")
 	cmd.Flags().StringVarP(&opts.toURL, "to", "", "", "[driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format")
 	cmd.Flags().StringVarP(&opts.devURL, "dev-url", "", "", "[driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format")
+	cmd.Flags().SortFlags = false
 	cobra.CheckErr(cmd.MarkFlagRequired("from"))
 	cobra.CheckErr(cmd.MarkFlagRequired("to"))
 	return cmd

--- a/cmd/atlas/internal/cmdapi/diff.go
+++ b/cmd/atlas/internal/cmdapi/diff.go
@@ -303,7 +303,7 @@ func hclStateReader(ctx context.Context, config *stateReaderConfig, urls []*url.
 			return nil, err
 		}
 	}
-	t := &stateReadCloser{StateReader: migrate.Realm(realm), Closer: io.NopCloser(nil)}
+	t := &stateReadCloser{StateReader: migrate.Realm(realm)}
 	if len(realm.Schemas) == 1 {
 		t.Schema = realm.Schemas[0].Name
 	}

--- a/cmd/atlas/internal/cmdapi/diff.go
+++ b/cmd/atlas/internal/cmdapi/diff.go
@@ -247,9 +247,9 @@ func stateReader(ctx context.Context, config *stateReaderConfig) (*stateReadClos
 		var sr migrate.StateReader
 		switch c.URL.Schema {
 		case "":
-			sr = migrate.SchemaConn(c.Driver, c.URL.Schema, nil)
-		default:
 			sr = migrate.RealmConn(c.Driver, nil)
+		default:
+			sr = migrate.SchemaConn(c.Driver, c.URL.Schema, nil)
 		}
 		return &stateReadCloser{
 			StateReader: sr,

--- a/cmd/atlas/internal/cmdapi/diff_test.go
+++ b/cmd/atlas/internal/cmdapi/diff_test.go
@@ -45,7 +45,7 @@ func TestCmdSchemaDiff(t *testing.T) {
 		"--from", "file://testdata/sqlite",
 		"--to", openSQLite(t, ""),
 	)
-	require.EqualError(t, err, "reading migration directory state requires a dev database connection")
+	require.EqualError(t, err, "--dev-url cannot be empty")
 
 	// Desired state from migration directory.
 	s, err = runCmd(

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -140,7 +140,7 @@ If run with the "--dry-run" flag, atlas will not execute any SQL.`,
 		Long: `'atlas migrate diff' uses the dev-database to re-run all migration files in the migration directory, compares
 it to a given desired state and create a new migration file containing SQL statements to migrate the migration
 directory state to the desired schema. The desired state can be another connected database or an HCL file.`,
-		Example: `  atlas migrate diff --dev-url mysql://user:pass@localhost:3306/dev --to file://atlas.hcl
+		Example: `  atlas migrate diff --dev-url mysql://user:pass@localhost:3306/dev --to file://schema.hcl
   atlas migrate diff --dev-url mysql://user:pass@localhost:3306/dev --to file://atlas.hcl add_users_table
   atlas migrate diff --dev-url mysql://user:pass@localhost:3306/dev --to mysql://user:pass@localhost:3306/dbname
   atlas migrate diff --env dev`,
@@ -1103,7 +1103,7 @@ func dirURL(u *url.URL, create bool) (migrate.Dir, error) {
 	}
 	fn := func() (migrate.Dir, error) { return migrate.NewLocalDir(path) }
 	switch f := u.Query().Get("format"); f {
-	case formatAtlas:
+	case "", formatAtlas:
 		// this is the default
 	case formatGolangMigrate:
 		fn = func() (migrate.Dir, error) { return sqltool.NewGolangMigrateDir(path) }
@@ -1245,7 +1245,7 @@ func to(ctx context.Context, dev *sqlclient.Client) (*target, error) {
 func selectScheme(urls []string) (string, error) {
 	var scheme string
 	if len(urls) == 0 {
-		return "", errors.New("at least one --to url is required")
+		return "", errors.New("at least one url is required")
 	}
 	for _, url := range urls {
 		parts := strings.SplitN(url, "://", 2)

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -114,7 +114,7 @@ directory state to the desired schema. The desired state can be another connecte
 #### Example
 
 ```
-  atlas migrate diff --dev-url mysql://user:pass@localhost:3306/dev --to file://atlas.hcl
+  atlas migrate diff --dev-url mysql://user:pass@localhost:3306/dev --to file://schema.hcl
   atlas migrate diff --dev-url mysql://user:pass@localhost:3306/dev --to file://atlas.hcl add_users_table
   atlas migrate diff --dev-url mysql://user:pass@localhost:3306/dev --to mysql://user:pass@localhost:3306/dbname
   atlas migrate diff --env dev
@@ -405,14 +405,23 @@ atlas schema diff [flags]
 ```
 
 #### Details
-'atlas schema diff' connects to two given databases, inspects
-them, calculates the difference in their schemas, and prints a plan of
+'atlas schema diff' reads the state of two given schema definitions, 
+calculates the difference in their schemas, and prints a plan of
 SQL statements to migrate the "from" database to the schema of the "to" database.
+The database states can be read from a connected database, an HCL project or a migration directory.
 
+#### Example
+
+```
+  atlas schema diff --from mysql://user:pass@localhost:3306/test --to file://schema.hcl
+  atlas schema diff --from mysql://user:pass@localhost:3306 --to file://schema_1.hcl --to file://schema_2.hcl
+  atlas schema diff --from mysql://user:pass@localhost:3306 --to file://migrations
+```
 #### Flags
 ```
-      --from string   [driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format
-      --to string     [driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format
+      --dev-url string   [driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format
+      --from string      [driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format
+      --to string        [driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format
 
 ```
 

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -419,9 +419,9 @@ The database states can be read from a connected database, an HCL project or a m
 ```
 #### Flags
 ```
-      --dev-url string   [driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format
       --from string      [driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format
       --to string        [driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format
+      --dev-url string   [driver://username:password@protocol(address)/dbname?param=value] select a database using the URL format
 
 ```
 


### PR DESCRIPTION
This is the first PR in a series of PRs to enable all schema and migrate commands to work with `migrate.StateReader` to enable the CLI to read and diff states between every supported state definitions (currently HCL, migration directory and database connection).

As a second goal the PR's aim to increase the amount of code shared between `schema` and  `migrate` commands and refactor the code structure to increase readability and reduce global state (which is incredibly painful when unit testing).