### PR TITLE
cmd/atlas/internal/cmdapi/migrate: set dir value from env in migrate command

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -1446,6 +1446,9 @@ func migrateFlagsFromEnv(cmd *cobra.Command, _ []string) error {
 	if err := maySetFlag(cmd, migrateFlagDevURL, activeEnv.DevURL); err != nil {
 		return err
 	}
+	if err := maySetFlag(cmd, migrateFlagDir, activeEnv.Migration.Dir); err != nil {
+		return err
+	}
 	if err := maySetFlag(cmd, migrateFlagDirFormat, activeEnv.Migration.Format); err != nil {
 		return err
 	}


### PR DESCRIPTION
According to this [guide](https://atlasgo.io/atlas-schema/projects#projects-with-versioned-migrations), `dir` can be set from a project file, but it seems not to work.