### PR TITLE
sql/sqlclient: remove DSN from the JSON output

### DIFF
--- a/internal/integration/testdata/mysql/cli-migrate-apply.txt
+++ b/internal/integration/testdata/mysql/cli-migrate-apply.txt
@@ -50,7 +50,6 @@ validJSON stdout
 stdout '"Driver":"mysql"'
 stdout '"Scheme":"mysql"'
 stdout '"Dir":"migrations"'
-stdout '"DSN":"root'
 stdout '"Target":"3"'
 stdout '"Pending":\[{"Name":"1_first.sql","Version":"1","Description":"first"},{"Name":"2_second.sql","Version":"2","Description":"second"},{"Name":"3_third.sql","Version":"3","Description":"third"}\]'
 stdout '"Applied":\["CREATE TABLE `users` \(`id` bigint NOT NULL AUTO_INCREMENT, `age` bigint NOT NULL, `name` varchar\(255\) NOT NULL, PRIMARY KEY \(`id`\)\) CHARSET utf8mb4 COLLATE utf8mb4_bin;"\]'

--- a/sql/sqlclient/client.go
+++ b/sql/sqlclient/client.go
@@ -62,7 +62,7 @@ type (
 		*url.URL
 
 		// The DSN used for opening the connection.
-		DSN string
+		DSN string `json:"-"`
 
 		// The Schema this client is connected to.
 		Schema string


### PR DESCRIPTION
DSN contains the credential for connection to the database, should not print to the JSON log