### PR TITLE
sql/spanner: Add initial parsing and diffing implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,6 +573,7 @@ jobs:
           SPANNER_EMULATOR_HOST: localhost:9010
         ports:
           - 9010:9010
+          - 9020:9020
         
     steps:
       - uses: actions/checkout@v2.3.4

--- a/internal/ci/main.go
+++ b/internal/ci/main.go
@@ -165,7 +165,7 @@ var (
 			Version: "spanner",
 			Image:   "gcr.io/cloud-spanner-emulator/emulator:1.4.6",
 			Regex:   "Spanner",
-			Ports:   []string{"9010:9010"},
+			Ports:   []string{"9010:9010", "9020:9020"},
 			Env:     []string{"SPANNER_EMULATOR_HOST: localhost:9010"},
 			RawSetup: `
       - uses: 'google-github-actions/setup-gcloud@v0'

--- a/sql/spanner/sqlspec.go
+++ b/sql/spanner/sqlspec.go
@@ -145,6 +145,7 @@ func columnTypeSpec(t schema.Type) (*sqlspec.Column, error) {
 
 // TypeRegistry contains the supported TypeSpecs for the spanner driver.
 var TypeRegistry = schemahcl.NewRegistry(
+	schemahcl.WithParser(ParseType),
 	schemahcl.WithSpecs(
 		schemahcl.NewTypeSpec(TypeString, schemahcl.WithAttributes(schemahcl.SizeTypeAttr(false))),
 		schemahcl.NewTypeSpec(TypeBytes, schemahcl.WithAttributes(schemahcl.SizeTypeAttr(false))),

--- a/sql/spanner/sqlspec.go
+++ b/sql/spanner/sqlspec.go
@@ -145,6 +145,7 @@ func columnTypeSpec(t schema.Type) (*sqlspec.Column, error) {
 
 // TypeRegistry contains the supported TypeSpecs for the spanner driver.
 var TypeRegistry = schemahcl.NewRegistry(
+	schemahcl.WithFormatter(FormatType),
 	schemahcl.WithParser(ParseType),
 	schemahcl.WithSpecs(
 		schemahcl.NewTypeSpec(TypeString, schemahcl.WithAttributes(schemahcl.SizeTypeAttr(false))),


### PR DESCRIPTION
This adds a minimal implementation of parsing and diffing to close the HCL->SQL loop.