### PR TITLE
sql/spanner: fix change ordering

### DIFF
--- a/internal/integration/spanner_test.go
+++ b/internal/integration/spanner_test.go
@@ -67,8 +67,8 @@ func TestSpanner_AddDropTable(t *testing.T) {
 		t.dropIndexes("idx_author_id", "idx_id_author_id_unique")
 
 		t.migrate(
-			&schema.AddTable{T: usersT},
 			&schema.AddTable{T: postsT},
+			&schema.AddTable{T: usersT},
 		)
 		ensureNoChange(t, usersT, postsT)
 		t.migrate(

--- a/sql/spanner/migrate.go
+++ b/sql/spanner/migrate.go
@@ -61,7 +61,11 @@ type state struct {
 // Exec executes the changes on the database. An error is returned
 // if one of the operations fail, or a change is not supported.
 func (s *state) plan(ctx context.Context, changes []schema.Change) (err error) {
-	for _, c := range changes {
+	planned, err := sqlx.DetachCycles(changes)
+	if err != nil {
+		return err
+	}
+	for _, c := range planned {
 		switch c := c.(type) {
 		case *schema.AddTable:
 			err = s.addTable(ctx, c)


### PR DESCRIPTION
sql/spanner was missing a call to `sqlx.DetachCycles` which performs a topological sort of the changes to order them correctly.