### PR TITLE
sql/spanner: Add initial ARRAY type handling

### DIFF
--- a/internal/integration/spanner_test.go
+++ b/internal/integration/spanner_test.go
@@ -171,6 +171,24 @@ func TestSpanner_ColumnInt(t *testing.T) {
 	})
 }
 
+func TestSpanner_ColumnArray(t *testing.T) {
+	stRun(t, func(t *spannerTest) {
+		usersT := t.users()
+		t.dropTables(usersT.Name)
+		t.migrate(&schema.AddTable{T: usersT})
+
+		// Add column.
+		usersT.Columns = append(
+			usersT.Columns,
+			&schema.Column{Name: "a", Type: &schema.ColumnType{Raw: "ARRAY<INT64>", Type: &spanner.ArrayType{Type: &schema.IntegerType{T: "INT64"}, T: "ARRAY<INT64>"}, Null: true}},
+		)
+		changes := t.diff(t.loadUsers(), usersT)
+		require.Len(t, changes, 1)
+		t.migrate(&schema.ModifyTable{T: usersT, Changes: changes})
+		ensureNoChange(t, usersT)
+	})
+}
+
 func TestSpanner_HCL(t *testing.T) {
 	full := `
 schema "default" {

--- a/sql/spanner/convert.go
+++ b/sql/spanner/convert.go
@@ -17,6 +17,8 @@ import (
 func FormatType(t schema.Type) (string, error) {
 	var f string
 	switch t := t.(type) {
+	case *ArrayType:
+		f = t.T
 	case *schema.BoolType:
 		f = t.T
 	case *schema.EnumType:
@@ -94,7 +96,7 @@ func ParseType(c string) (schema.Type, error) {
 			T: TypeDate,
 		}, nil
 	case TypeBool:
-		return &schema.TimeType{
+		return &schema.BoolType{
 			T: TypeBool,
 		}, nil
 	default:

--- a/sql/spanner/inspect.go
+++ b/sql/spanner/inspect.go
@@ -27,6 +27,9 @@ const defaultSchemaNameAlias = "default"
 // sizedTypeRe parses spanner types such as "STRING(50)" or "BYTES(MAX)".
 var sizedTypeRe = regexp.MustCompile(`(\w+)(?:\((-?\d+|MAX)\))?`)
 
+// arrayTypeRe parses spanner types such as "ARRAY<STRING(50)>" or "ARRAY<BYTES>".
+var arrayTypeRe = regexp.MustCompile(`ARRAY<(.*)>`)
+
 // InspectRealm returns schema descriptions of all resources in the given realm.
 func (i *inspect) InspectRealm(ctx context.Context, opts *schema.InspectRealmOption) (*schema.Realm, error) {
 	schemas, err := i.schemas(ctx, opts)
@@ -213,6 +216,19 @@ func columnType(spannerType string) (schema.Type, error) {
 
 	col := &columnDesc{}
 	spannerType = strings.TrimSpace(strings.ToUpper(spannerType))
+
+	// ARRAY type handling.
+	if strings.HasPrefix(spannerType, "ARRAY<") {
+		parts := arrayTypeRe.FindStringSubmatch(spannerType)
+		inner, err := columnType(parts[1])
+		if err != nil {
+			return nil, err
+		}
+		return &ArrayType{
+			Type: inner,
+			T:    spannerType,
+		}, nil
+	}
 
 	// Split up type into, base type, size, and other modifiers.
 	m := removeEmptyStrings(sizedTypeRe.FindStringSubmatch(spannerType))
@@ -517,6 +533,7 @@ type (
 	Nullable struct {
 		schema.Attr
 	}
+
 	// MaxSize flags whether a column is of size "MAX" as opposed to a discreet int sizing.
 	MaxSize struct {
 		schema.Attr
@@ -532,6 +549,14 @@ type (
 	IndexPredicate struct {
 		schema.Attr
 		P string
+	}
+
+	// ArrayType defines an array type.
+	// https://cloud.google.com/spanner/docs/reference/standard-sql/data-types#array_type
+	// Note that it is invalid to have an array of array types.
+	ArrayType struct {
+		schema.Type        // Underlying items type (e.g. INT64)
+		T           string // Formatted type (e.g. ARRAY<INT64>).
 	}
 )
 

--- a/sql/spanner/inspect.go
+++ b/sql/spanner/inspect.go
@@ -218,7 +218,7 @@ func columnType(spannerType string) (schema.Type, error) {
 	spannerType = strings.TrimSpace(strings.ToUpper(spannerType))
 
 	// ARRAY type handling.
-	if strings.HasPrefix(spannerType, "ARRAY<") {
+	if arrayTypeRe.MatchString(spannerType) {
 		parts := arrayTypeRe.FindStringSubmatch(spannerType)
 		inner, err := columnType(parts[1])
 		if err != nil {


### PR DESCRIPTION
This adds initial ARRAY type support to the spanner driver.