### PR TITLE
sql/postgres: expose UnmarshalText for parsing operator classes

### DIFF
--- a/sql/postgres/inspect_test.go
+++ b/sql/postgres/inspect_test.go
@@ -674,6 +674,19 @@ public
 	}(), realm)
 }
 
+func TestIndexOpClass_UnmarshalText(t *testing.T) {
+	var op IndexOpClass
+	require.NoError(t, op.UnmarshalText([]byte("int4_ops")))
+	require.EqualValues(t, IndexOpClass{Name: "int4_ops"}, op)
+
+	op = IndexOpClass{}
+	require.NoError(t, op.UnmarshalText([]byte("")))
+	require.EqualValues(t, IndexOpClass{}, op)
+
+	require.NoError(t, op.UnmarshalText([]byte("int4_ops(siglen=1)")))
+	require.EqualValues(t, IndexOpClass{Name: "int4_ops", Params: []struct{ N, V string }{{"siglen", "1"}}}, op)
+}
+
 type mock struct {
 	sqlmock.Sqlmock
 }


### PR DESCRIPTION
Will be used by Ent index annnotations