### PR TITLE
blog: fixed authors for the post

### DIFF
--- a/doc/website/blog/2022-11-17-terraform-v040.md
+++ b/doc/website/blog/2022-11-17-terraform-v040.md
@@ -1,6 +1,6 @@
 ---
 title: "Atlas Terraform Provider v0.4.0: HashiCorp partnerships, versioned migrations and more" 
-author: giautm
+authors: giautm
 tags: [terraform, versioned-migrations, release]
 ---
 

--- a/doc/website/blog/authors.yml
+++ b/doc/website/blog/authors.yml
@@ -26,3 +26,5 @@ giautm:
   title: Software Engineer
   url: "https://github.com/giautm"
   image_url: "https://avatars.githubusercontent.com/u/12751435?v=4"
+  twitter: giau_tm
+


### PR DESCRIPTION
The name doesn't render correctly due to typo

<img width="321" alt="Screenshot 2022-11-17 at 22 49 23" src="https://user-images.githubusercontent.com/12751435/202493114-bc66819c-0dc9-471c-bff0-3b909dfc14ec.png">
