### PR TITLE
Bumps Go version to 1.19 due to url.JoinPath

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ariga.io/atlas
 
-go 1.18
+go 1.19
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
Running under `1.18` causes the following error:

```
internal/cmdapi/vercheck/vercheck.go:72:23: undefined: url.JoinPath
```