### PR TITLE
cmd/atlas: add --amend to 'migrate new' and 'migrate diff' 

### DIFF
--- a/cmd/atlas/internal/cmdapi/cmdapi.go
+++ b/cmd/atlas/internal/cmdapi/cmdapi.go
@@ -178,6 +178,7 @@ func (v *Vars) Type() string {
 
 const (
 	flagAllowDirty     = "allow-dirty"
+	flagAmend          = "amend"
 	flagAutoApprove    = "auto-approve"
 	flagBaseline       = "baseline"
 	flagConfig         = "config"

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -14,6 +14,7 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -646,7 +647,11 @@ func migrateLintRun(cmd *cobra.Command, _ []string, flags migrateLintFlags) erro
 	return err
 }
 
-type migrateNewFlags struct{ dirURL, dirFormat string }
+type migrateNewFlags struct {
+	amend     bool
+	dirURL    string
+	dirFormat string
+}
 
 // migrateNewCmd represents the 'atlas migrate new' subcommand.
 func migrateNewCmd() *cobra.Command {
@@ -675,6 +680,7 @@ func migrateNewCmd() *cobra.Command {
 	cmd.Flags().SortFlags = false
 	addFlagDirURL(cmd.Flags(), &flags.dirURL)
 	addFlagDirFormat(cmd.Flags(), &flags.dirFormat)
+	cmd.Flags().BoolVarP(&flags.amend, flagAmend, "", false, "edit the created migration file(s)")
 	return cmd
 }
 
@@ -686,6 +692,9 @@ func migrateNewRun(_ *cobra.Command, args []string, flags migrateNewFlags) error
 	dir, err := dirURL(u, true)
 	if err != nil {
 		return err
+	}
+	if flags.amend {
+		dir = &editDir{dir}
 	}
 	f, err := formatter(u)
 	if err != nil {
@@ -1575,6 +1584,43 @@ func migrateEnvsRun[F any](run func(*cobra.Command, []string, F) error, cmd *cob
 		w.Reset()
 	}
 	return nil
+}
+
+type editDir struct{ migrate.Dir }
+
+// WriteFile implements the migrate.Dir.WriteFile method.
+func (d *editDir) WriteFile(name string, b []byte) (err error) {
+	if name != migrate.HashFileName {
+		if b, err = edit(name, b); err != nil {
+			return err
+		}
+	}
+	return d.Dir.WriteFile(name, b)
+}
+
+// edit allows editing the file content using editor.
+func edit(name string, src []byte) ([]byte, error) {
+	path := filepath.Join(os.TempDir(), name)
+	if err := os.WriteFile(path, src, 0644); err != nil {
+		return nil, fmt.Errorf("write source content to temp file: %w", err)
+	}
+	defer os.Remove(path)
+	editor := "vi"
+	if e := os.Getenv("EDITOR"); e != "" {
+		editor = e
+	}
+	cmd := exec.Command("sh", "-c", editor+" "+path)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("exec edit: %w", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read edited temp file: %w", err)
+	}
+	return b, nil
 }
 
 type (

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -268,6 +268,7 @@ func reportApply(cmd *cobra.Command, flags migrateApplyFlags, r *cmdmigrate.Appl
 }
 
 type migrateDiffFlags struct {
+	amend             bool
 	desiredURLs       []string
 	dirURL, dirFormat string
 	devURL            string
@@ -315,6 +316,7 @@ directory state to the desired schema. The desired state can be another connecte
 	addFlagSchemas(cmd.Flags(), &flags.schemas)
 	addFlagLockTimeout(cmd.Flags(), &flags.lockTimeout)
 	cmd.Flags().StringVar(&flags.qualifier, flagQualifier, "", "qualify tables with custom qualifier when working on a single schema")
+	cmd.Flags().BoolVarP(&flags.amend, flagAmend, "", false, "edit the generated migration file(s)")
 	cobra.CheckErr(cmd.MarkFlagRequired(flagTo))
 	cobra.CheckErr(cmd.MarkFlagRequired(flagDevURL))
 	return cmd
@@ -344,6 +346,9 @@ func migrateDiffRun(cmd *cobra.Command, args []string, flags migrateDiffFlags) e
 	dir, err := dirURL(u, false)
 	if err != nil {
 		return err
+	}
+	if flags.amend {
+		dir = &editDir{dir}
 	}
 	f, err := formatter(u)
 	if err != nil {

--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -826,6 +826,20 @@ func TestMigrate_New(t *testing.T) {
 	s, err = runCmd(migrateNewCmd(), "--dir", "file://testdata/mysql")
 	require.NotZero(t, s)
 	require.Error(t, err)
+
+	t.Run("Amend", func(t *testing.T) {
+		p := t.TempDir()
+		require.NoError(t, os.Setenv("EDITOR", "echo 'contents' >"))
+		t.Cleanup(func() { require.NoError(t, os.Unsetenv("EDITOR")) })
+		s, err = runCmd(migrateNewCmd(), "--dir", "file://"+p, "--amend")
+		files, err := os.ReadDir(p)
+		require.NoError(t, err)
+		require.Len(t, files, 2)
+		b, err := os.ReadFile(filepath.Join(p, files[0].Name()))
+		require.NoError(t, err)
+		require.Equal(t, "contents\n", string(b))
+		require.Equal(t, "atlas.sum", files[1].Name())
+	})
 }
 
 func TestMigrate_Validate(t *testing.T) {

--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -749,6 +749,34 @@ func TestMigrate_Diff(t *testing.T) {
 	)
 	require.True(t, strings.HasPrefix(s, "Error: acquiring database lock: "+errLock.Error()))
 	require.ErrorIs(t, err, errLock)
+
+	t.Run("Amend", func(t *testing.T) {
+		p := t.TempDir()
+		require.NoError(t, os.Setenv("EDITOR", "echo '-- Comment' >>"))
+		t.Cleanup(func() { require.NoError(t, os.Unsetenv("EDITOR")) })
+		args := []string{
+			"--amend",
+			"--dir", "file://" + p,
+			"--dev-url", openSQLite(t, ""),
+			"--to", to,
+		}
+		_, err := runCmd(migrateDiffCmd(), args...)
+		files, err := os.ReadDir(p)
+		require.NoError(t, err)
+		require.Len(t, files, 2)
+		b, err := os.ReadFile(filepath.Join(p, files[0].Name()))
+		require.NoError(t, err)
+		require.Contains(t, string(b), "CREATE")
+		require.True(t, strings.HasSuffix(string(b), "-- Comment\n"))
+		require.Equal(t, "atlas.sum", files[1].Name())
+
+		// Second run will have no effect.
+		_, err = runCmd(migrateDiffCmd(), args...)
+		require.NoError(t, err)
+		files, err = os.ReadDir(p)
+		require.NoError(t, err)
+		require.Len(t, files, 2)
+	})
 }
 
 func TestMigrate_StatusJSON(t *testing.T) {

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -130,6 +130,7 @@ directory state to the desired schema. The desired state can be another connecte
   -s, --schema strings            set schema names
       --lock-timeout duration     set how long to wait for the database lock (default 10s)
       --qualifier string          qualify tables with custom qualifier when working on a single schema
+      --amend                     edit the generated migration file(s)
 
 ```
 
@@ -234,6 +235,7 @@ atlas migrate new [flags] [name]
 ```
       --dir string          select migration directory using URL format (default "file://migrations")
       --dir-format string   select migration file format (default "atlas")
+      --amend               edit the created migration file(s)
 
 ```
 


### PR DESCRIPTION
If I need to choose between `--interactive`/`-i` and `--amend`, I prefer the latter. Because the command is not really interactive and just gives you the option to amend/edit the files after they were created.