### PR TITLE
cmd/atlas: avoid logging errors twice

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -264,7 +264,13 @@ func reportApply(cmd *cobra.Command, flags migrateApplyFlags, r *cmdlog.MigrateA
 			return fmt.Errorf("parse log format: %w", err)
 		}
 	}
-	return f.Execute(cmd.OutOrStdout(), r)
+	if err = f.Execute(cmd.OutOrStdout(), r); err != nil {
+		return fmt.Errorf("execute log template: %w", err)
+	}
+	// In case a custom logging was configured, avoid reporting errors twice.
+	// For example, printing error lines may break parsing the JSON output.
+	cmd.SilenceErrors = flags.logFormat != ""
+	return nil
 }
 
 type migrateDiffFlags struct {

--- a/cmd/atlas/internal/cmdapi/project.go
+++ b/cmd/atlas/internal/cmdapi/project.go
@@ -223,15 +223,14 @@ func LoadEnv(name string, opts ...LoadOption) ([]*Env, error) {
 		return nil, fmt.Errorf("unsupported project file driver %q", u.Scheme)
 	}
 	path := filepath.Join(u.Host, u.Path)
-	b, err := os.ReadFile(path)
-	if err != nil {
+	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
 			err = fmt.Errorf("project file %q was not found: %w", path, err)
 		}
 		return nil, err
 	}
 	project := &Project{Lint: &Lint{}}
-	if err := hclState.EvalBytes(b, project, cfg.inputVals); err != nil {
+	if err := hclState.EvalFiles([]string{path}, project, cfg.inputVals); err != nil {
 		return nil, err
 	}
 	envs := make(map[string][]*Env)

--- a/cmd/atlas/internal/cmdlog/cmdlog.go
+++ b/cmd/atlas/internal/cmdlog/cmdlog.go
@@ -317,6 +317,24 @@ func (a *MigrateApply) CountStmts() (n int) {
 }
 
 // MarshalJSON implements json.Marshaler.
+func (a *MigrateApply) MarshalJSON() ([]byte, error) {
+	type Alias MigrateApply
+	var v struct {
+		*Alias
+		Message string `json:"Message,omitempty"`
+	}
+	v.Alias = (*Alias)(a)
+	switch {
+	case a.Error != "":
+	case len(v.Applied) == 0:
+		v.Message = "No migration files to execute"
+	default:
+		v.Message = fmt.Sprintf("Migrated to version %s from %s (%d migrations in total)", v.Target, v.Current, len(v.Pending))
+	}
+	return json.Marshal(v)
+}
+
+// MarshalJSON implements json.Marshaler.
 func (f *AppliedFile) MarshalJSON() ([]byte, error) {
 	type local struct {
 		Name        string     `json:"Name,omitempty"`


### PR DESCRIPTION
From:
![image](https://user-images.githubusercontent.com/7413593/205483790-0eaaac53-71fb-471b-97dd-e8f560b78811.png)

To:

![image](https://user-images.githubusercontent.com/7413593/205483808-20649761-031b-42fa-a074-e19064fdfb72.png)

The `exit status 1` comes from `go run`. Ignore it.