### PR TITLE
cmd/atlas: add --log=sql to allow dumping sql schema on inspection

### DIFF
--- a/cmd/atlas/internal/cmdapi/schema.go
+++ b/cmd/atlas/internal/cmdapi/schema.go
@@ -461,14 +461,14 @@ func schemaInspectRun(cmd *cobra.Command, _ []string, flags schemaInspectFlags) 
 	})
 	format := cmdlog.SchemaInspectTemplate
 	if v := flags.logFormat; v != "" {
-		if format, err = template.New("format").Funcs(cmdlog.ApplyTemplateFuncs).Parse(v); err != nil {
+		if format, err = template.New("format").Funcs(cmdlog.InspectTemplateFuncs).Parse(v); err != nil {
 			return fmt.Errorf("parse log format: %w", err)
 		}
 	}
 	return format.Execute(cmd.OutOrStdout(), &cmdlog.SchemaInspect{
-		Marshaler: client.Marshaler,
-		Realm:     s,
-		Error:     err,
+		Client: client,
+		Realm:  s,
+		Error:  err,
 	})
 }
 


### PR DESCRIPTION
<img width="1789" alt="image" src="https://user-images.githubusercontent.com/7413593/209147263-b5413d0b-dc70-4070-9101-3caea984e346.png">
