### PR TITLE
cmd/atlas: remove short form for --to flag

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -314,7 +314,7 @@ directory state to the desired schema. The desired state can be another connecte
 		}
 	)
 	cmd.Flags().SortFlags = false
-	addFlagURLs(cmd.Flags(), &flags.desiredURLs, flagTo)
+	addFlagURLs(cmd.Flags(), &flags.desiredURLs, flagTo, "")
 	addFlagDevURL(cmd.Flags(), &flags.devURL)
 	addFlagDirURL(cmd.Flags(), &flags.dirURL)
 	addFlagDirFormat(cmd.Flags(), &flags.dirFormat)

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -122,7 +122,7 @@ directory state to the desired schema. The desired state can be another connecte
 ```
 #### Flags
 ```
-  -u, --to strings                [driver://username:password@address/dbname?param=value] select a resource using the URL format
+      --to strings                [driver://username:password@address/dbname?param=value] select a resource using the URL format
       --dev-url string            [driver://username:password@address/dbname?param=value] select a dev database using the URL format
       --dir string                select migration directory using URL format (default "file://migrations")
       --dir-format string         select migration file format (default "atlas")


### PR DESCRIPTION
`atlas migrate diff -u` does not make sense. 