### PR TITLE
sql/postgres: always create 'public' schemas with IF NOT EXISTS clause

### DIFF
--- a/sql/postgres/migrate_test.go
+++ b/sql/postgres/migrate_test.go
@@ -27,6 +27,7 @@ func TestPlanChanges(t *testing.T) {
 	}{
 		{
 			changes: []schema.Change{
+				&schema.AddSchema{S: schema.New("public")},
 				&schema.AddSchema{S: schema.New("test"), Extra: []schema.Clause{&schema.IfNotExists{}}},
 				&schema.DropSchema{S: schema.New("test"), Extra: []schema.Clause{&schema.IfExists{}}},
 				&schema.DropSchema{S: schema.New("test"), Extra: []schema.Clause{}},
@@ -35,6 +36,10 @@ func TestPlanChanges(t *testing.T) {
 				Reversible:    false,
 				Transactional: true,
 				Changes: []*migrate.Change{
+					{
+						Cmd:     `CREATE SCHEMA IF NOT EXISTS "public"`,
+						Reverse: `DROP SCHEMA "public" CASCADE`,
+					},
 					{
 						Cmd:     `CREATE SCHEMA IF NOT EXISTS "test"`,
 						Reverse: `DROP SCHEMA "test" CASCADE`,


### PR DESCRIPTION
That is because the 'public' schema is automatically created by PostgreSQL in every new database, and running the command with this clause will fail in case the schema already exists.

See: https://discord.com/channels/930720389120794674/1017364262097784892/1059913355504128070