### PR TITLE
sql/sqlclient: improve url/opener error

### DIFF
--- a/doc/website/docusaurus.config.js
+++ b/doc/website/docusaurus.config.js
@@ -194,6 +194,10 @@ module.exports = {
             to: '/guides/ddl',
             from: '/knowledge/ddl',
           },
+          {
+            to: '/concepts/url',
+            from: '/url',
+          },
         ],
       },
     ],

--- a/sql/sqlclient/client.go
+++ b/sql/sqlclient/client.go
@@ -199,9 +199,12 @@ func OpenURL(ctx context.Context, u *url.URL, opts ...OpenOption) (*Client, erro
 			return nil, err
 		}
 	}
+	if u.Scheme == "" {
+		return nil, errors.New("sql/sqlclient: missing driver. See: https://atlasgo.io/url")
+	}
 	v, ok := drivers.Load(u.Scheme)
 	if !ok {
-		return nil, fmt.Errorf("sql/sqlclient: no opener was registered with name %q", u.Scheme)
+		return nil, fmt.Errorf("sql/sqlclient: unknown driver %q. See: https://atlasgo.io/url", u.Scheme)
 	}
 	drv := v.(*driver)
 	// If there is a schema given and the driver allows to change the schema for the url, do it.

--- a/sql/sqlclient/client_test.go
+++ b/sql/sqlclient/client_test.go
@@ -57,7 +57,16 @@ func TestRegisterOpen(t *testing.T) {
 	require.Equal(t, "schema", c.URL.Schema)
 
 	c1, err = sqlclient.Open(context.Background(), "postgres://:3306")
-	require.EqualError(t, err, `sql/sqlclient: no opener was registered with name "postgres"`)
+	require.EqualError(t, err, `sql/sqlclient: unknown driver "postgres". See: https://atlasgo.io/url`)
+}
+
+func TestOpen_Errors(t *testing.T) {
+	c, err := sqlclient.Open(context.Background(), "missing")
+	require.EqualError(t, err, `sql/sqlclient: missing driver. See: https://atlasgo.io/url`)
+	require.Nil(t, c)
+	c, err = sqlclient.Open(context.Background(), "unknown://")
+	require.EqualError(t, err, `sql/sqlclient: unknown driver "unknown". See: https://atlasgo.io/url`)
+	require.Nil(t, c)
 }
 
 func TestClient_AddClosers(t *testing.T) {


### PR DESCRIPTION
Replaced this error: `Error: sql/sqlclient: no opener was registered with name ""` with a helpful one. 