### PR TITLE
sql/migrate: ensure consistency of NotCleanError

### DIFF
--- a/cmd/atlas/go.mod
+++ b/cmd/atlas/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	ariga.io/atlas v0.9.0
-	entgo.io/ent v0.11.5-0.20221123165602-b6a475f066c4
+	entgo.io/ent v0.11.8-0.20230210122553-349b95097887
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220816024939-bc8df83d7b9d
 	github.com/auxten/postgresql-parser v1.0.1
 	github.com/fatih/color v1.13.0

--- a/cmd/atlas/go.mod
+++ b/cmd/atlas/go.mod
@@ -3,12 +3,12 @@ module ariga.io/atlas/cmd/atlas
 go 1.18
 
 require (
-	ariga.io/atlas v0.9.0
+	ariga.io/atlas v0.9.1-0.20230119145809-92243f7c55cb
 	entgo.io/ent v0.11.8-0.20230210122553-349b95097887
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220816024939-bc8df83d7b9d
 	github.com/auxten/postgresql-parser v1.0.1
 	github.com/fatih/color v1.13.0
-	github.com/go-sql-driver/mysql v1.6.0
+	github.com/go-sql-driver/mysql v1.7.0
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/lib/pq v1.10.7
 	github.com/manifoldco/promptui v0.9.0

--- a/cmd/atlas/go.sum
+++ b/cmd/atlas/go.sum
@@ -87,8 +87,8 @@ contrib.go.opencensus.io/exporter/aws v0.0.0-20200617204711-c478e41e60e9/go.mod 
 contrib.go.opencensus.io/exporter/stackdriver v0.13.13/go.mod h1:5pSSGY0Bhuk7waTHuDf4aQ8D2DrhgETRo9fy6k3Xlzc=
 contrib.go.opencensus.io/integrations/ocsql v0.1.7/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-entgo.io/ent v0.11.5-0.20221123165602-b6a475f066c4 h1:1xgAKKKKYqDiO/iPSS5apQdVAF5gre688hddRUBynck=
-entgo.io/ent v0.11.5-0.20221123165602-b6a475f066c4/go.mod h1:DEp/AdGCik6aD4vjN7eNNjaDInJqJAo01D0ohn7IacE=
+entgo.io/ent v0.11.8-0.20230210122553-349b95097887 h1:/f7/xMDpKilOFi4bjddKPWLDegDCGjXwm/PEXeZmgt8=
+entgo.io/ent v0.11.8-0.20230210122553-349b95097887/go.mod h1:ericBi6Q8l3wBH1wEIDfKxw7rcQEuRPyBfbIzjtxJ18=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/azure-amqp-common-go/v3 v3.2.3/go.mod h1:7rPmbSfszeovxGfc5fSAXE4ehlXQZHpMja2OtxC2Tas=

--- a/cmd/atlas/go.sum
+++ b/cmd/atlas/go.sum
@@ -4,6 +4,7 @@ ariga.io/atlas v0.8.4-0.20221128070800-1ce9c6ac2c02 h1:OvAZ24R0xneE3I8UR3bqCyiMA
 ariga.io/atlas v0.8.4-0.20221128070800-1ce9c6ac2c02/go.mod h1:T230JFcENj4ZZzMkZrXFDSkv+2kXkUgpJ5FQQ5hMcKU=
 ariga.io/atlas v0.9.0 h1:q0JMtqyA3X1YWtPcn+E/kVPwLDslb+jAC8Ejl/vW6d0=
 ariga.io/atlas v0.9.0/go.mod h1:T230JFcENj4ZZzMkZrXFDSkv+2kXkUgpJ5FQQ5hMcKU=
+ariga.io/atlas v0.9.1-0.20230119145809-92243f7c55cb/go.mod h1:T230JFcENj4ZZzMkZrXFDSkv+2kXkUgpJ5FQQ5hMcKU=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 bazil.org/fuse v0.0.0-20200407214033-5883e5a4b512/go.mod h1:FbcW6z/2VytnFDhZfumh8Ss8zxHE6qpMP5sHTRe0EaM=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -645,6 +646,7 @@ github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48/go.mod h1:dZGr
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=

--- a/cmd/atlas/go.work.sum
+++ b/cmd/atlas/go.work.sum
@@ -41,6 +41,7 @@ github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3 h1:t8FVkw33L+wilf2
 github.com/gin-gonic/gin v1.4.0 h1:3tMoCCfM7ppqsR0ptz/wi1impNpT7/9wQtMZ8lr1mCQ=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab h1:xveKWz2iaueeTaUgdetzel+U7exyigDYBryyVfV/rZk=
+github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah2I+gwHF8xmJWRjooY+5248k6m4A0=
 github.com/gobwas/pool v0.2.0 h1:QEmUOlnSjWtnpRGHF3SauEiOsy82Cup83Vf2LcMlnc8=
 github.com/gobwas/ws v1.0.2 h1:CoAavW/wd/kulfZmSIBt6p24n4j7tHgNVCjsfHVNUbo=
@@ -80,7 +81,6 @@ github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/labstack/echo/v4 v4.1.11 h1:z0BZoArY4FqdpUEl+wlHp4hnr/oSR6MTmQmv8OHSoww=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
-github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
 github.com/mattn/goveralls v0.0.2 h1:7eJB6EqsPhRVxvwEXGnqdO2sJI0PTsrWoTMXEk9/OQc=
 github.com/mediocregopher/mediocre-go-lib v0.0.0-20181029021733-cb65787f37ed h1:3dQJqqDouawQgl3gBE1PNHKFkJYGEuFb1DbSlaxdosE=
 github.com/mediocregopher/radix/v3 v3.3.0 h1:oacPXPKHJg0hcngVVrdtTnfGJiS+PtwoQwTBZGFlV4k=

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -390,7 +390,7 @@ func migrateDiffRun(cmd *cobra.Command, args []string, flags migrateDiffFlags) e
 		}
 		return pl.Plan(cmd.Context(), name, desired.StateReader)
 	}()
-	var cerr migrate.NotCleanError
+	var cerr *migrate.NotCleanError
 	switch {
 	case errors.Is(err, migrate.ErrNoPlan):
 		cmd.Println("The migration directory is synced with the desired state, no changes to be made")

--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -747,7 +747,7 @@ func TestMigrate_Diff(t *testing.T) {
 		"--dev-url", openSQLite(t, "create table t (c int);"),
 		"--to", to,
 	)
-	require.ErrorAs(t, err, &migrate.NotCleanError{})
+	require.ErrorAs(t, err, new(*migrate.NotCleanError))
 	require.ErrorContains(t, err, "found table \"t\"")
 
 	// Works (on empty directory).

--- a/cmd/atlas/internal/lint/lint_test.go
+++ b/cmd/atlas/internal/lint/lint_test.go
@@ -180,7 +180,7 @@ func TestDevLoader_LoadChanges(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_, err = l.LoadChanges(ctx, base, files)
-	require.ErrorAs(t, err, &migrate.NotCleanError{})
+	require.ErrorAs(t, err, new(*migrate.NotCleanError))
 }
 
 type testDir struct {

--- a/internal/integration/go.mod
+++ b/internal/integration/go.mod
@@ -8,7 +8,7 @@ replace ariga.io/atlas/cmd/atlas => ../../cmd/atlas
 
 require (
 	ariga.io/atlas v0.9.0
-	entgo.io/ent v0.11.8-0.20230210122553-349b95097887
+	entgo.io/ent v0.11.5-0.20221123165602-b6a475f066c4
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/lib/pq v1.10.7

--- a/internal/integration/go.mod
+++ b/internal/integration/go.mod
@@ -7,9 +7,9 @@ replace ariga.io/atlas => ../../
 replace ariga.io/atlas/cmd/atlas => ../../cmd/atlas
 
 require (
-	ariga.io/atlas v0.9.0
-	entgo.io/ent v0.11.5-0.20221123165602-b6a475f066c4
-	github.com/go-sql-driver/mysql v1.6.0
+	ariga.io/atlas v0.9.1-0.20230119145809-92243f7c55cb
+	entgo.io/ent v0.11.8-0.20230210122553-349b95097887
+	github.com/go-sql-driver/mysql v1.7.0
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/lib/pq v1.10.7
 	github.com/mattn/go-sqlite3 v1.14.16

--- a/internal/integration/go.mod
+++ b/internal/integration/go.mod
@@ -8,7 +8,7 @@ replace ariga.io/atlas/cmd/atlas => ../../cmd/atlas
 
 require (
 	ariga.io/atlas v0.9.0
-	entgo.io/ent v0.11.5-0.20221123165602-b6a475f066c4
+	entgo.io/ent v0.11.8-0.20230210122553-349b95097887
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/lib/pq v1.10.7

--- a/internal/integration/go.sum
+++ b/internal/integration/go.sum
@@ -82,6 +82,8 @@ contrib.go.opencensus.io/integrations/ocsql v0.1.7/go.mod h1:8DsSdjz3F+APR+0z0Wk
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 entgo.io/ent v0.11.5-0.20221123165602-b6a475f066c4 h1:1xgAKKKKYqDiO/iPSS5apQdVAF5gre688hddRUBynck=
 entgo.io/ent v0.11.5-0.20221123165602-b6a475f066c4/go.mod h1:DEp/AdGCik6aD4vjN7eNNjaDInJqJAo01D0ohn7IacE=
+entgo.io/ent v0.11.8-0.20230210122553-349b95097887 h1:/f7/xMDpKilOFi4bjddKPWLDegDCGjXwm/PEXeZmgt8=
+entgo.io/ent v0.11.8-0.20230210122553-349b95097887/go.mod h1:ericBi6Q8l3wBH1wEIDfKxw7rcQEuRPyBfbIzjtxJ18=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/azure-amqp-common-go/v3 v3.2.3/go.mod h1:7rPmbSfszeovxGfc5fSAXE4ehlXQZHpMja2OtxC2Tas=
@@ -636,6 +638,8 @@ github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48/go.mod h1:dZGr
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
+github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=

--- a/internal/integration/go.sum
+++ b/internal/integration/go.sum
@@ -80,8 +80,8 @@ contrib.go.opencensus.io/exporter/aws v0.0.0-20200617204711-c478e41e60e9/go.mod 
 contrib.go.opencensus.io/exporter/stackdriver v0.13.13/go.mod h1:5pSSGY0Bhuk7waTHuDf4aQ8D2DrhgETRo9fy6k3Xlzc=
 contrib.go.opencensus.io/integrations/ocsql v0.1.7/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-entgo.io/ent v0.11.5-0.20221123165602-b6a475f066c4 h1:1xgAKKKKYqDiO/iPSS5apQdVAF5gre688hddRUBynck=
-entgo.io/ent v0.11.5-0.20221123165602-b6a475f066c4/go.mod h1:DEp/AdGCik6aD4vjN7eNNjaDInJqJAo01D0ohn7IacE=
+entgo.io/ent v0.11.8-0.20230210122553-349b95097887 h1:/f7/xMDpKilOFi4bjddKPWLDegDCGjXwm/PEXeZmgt8=
+entgo.io/ent v0.11.8-0.20230210122553-349b95097887/go.mod h1:ericBi6Q8l3wBH1wEIDfKxw7rcQEuRPyBfbIzjtxJ18=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/azure-amqp-common-go/v3 v3.2.3/go.mod h1:7rPmbSfszeovxGfc5fSAXE4ehlXQZHpMja2OtxC2Tas=

--- a/internal/integration/go.sum
+++ b/internal/integration/go.sum
@@ -80,8 +80,8 @@ contrib.go.opencensus.io/exporter/aws v0.0.0-20200617204711-c478e41e60e9/go.mod 
 contrib.go.opencensus.io/exporter/stackdriver v0.13.13/go.mod h1:5pSSGY0Bhuk7waTHuDf4aQ8D2DrhgETRo9fy6k3Xlzc=
 contrib.go.opencensus.io/integrations/ocsql v0.1.7/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-entgo.io/ent v0.11.8-0.20230210122553-349b95097887 h1:/f7/xMDpKilOFi4bjddKPWLDegDCGjXwm/PEXeZmgt8=
-entgo.io/ent v0.11.8-0.20230210122553-349b95097887/go.mod h1:ericBi6Q8l3wBH1wEIDfKxw7rcQEuRPyBfbIzjtxJ18=
+entgo.io/ent v0.11.5-0.20221123165602-b6a475f066c4 h1:1xgAKKKKYqDiO/iPSS5apQdVAF5gre688hddRUBynck=
+entgo.io/ent v0.11.5-0.20221123165602-b6a475f066c4/go.mod h1:DEp/AdGCik6aD4vjN7eNNjaDInJqJAo01D0ohn7IacE=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/azure-amqp-common-go/v3 v3.2.3/go.mod h1:7rPmbSfszeovxGfc5fSAXE4ehlXQZHpMja2OtxC2Tas=

--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -561,7 +561,7 @@ func TestMySQL_Snapshot(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = drv.(migrate.Snapshoter).Snapshot(context.Background())
-		require.ErrorAs(t, err, &migrate.NotCleanError{})
+		require.ErrorAs(t, err, new(*migrate.NotCleanError))
 
 		r, err := t.driver().InspectRealm(context.Background(), nil)
 		require.NoError(t, err)

--- a/internal/integration/postgres_test.go
+++ b/internal/integration/postgres_test.go
@@ -623,7 +623,7 @@ func TestPostgres_Snapshot(t *testing.T) {
 		drv := client.Driver
 
 		_, err = t.driver().(migrate.Snapshoter).Snapshot(context.Background())
-		require.ErrorAs(t, err, &migrate.NotCleanError{})
+		require.ErrorAs(t, err, new(*migrate.NotCleanError))
 
 		r, err := drv.InspectRealm(context.Background(), nil)
 		require.NoError(t, err)
@@ -721,7 +721,7 @@ table "users" {
 
 func TestPostgres_CLI_MultiSchema(t *testing.T) {
 	h := `
-			schema "public" {	
+			schema "public" {
 			}
 			table "users" {
 				schema = schema.public
@@ -732,7 +732,7 @@ func TestPostgres_CLI_MultiSchema(t *testing.T) {
 					columns = [column.id]
 				}
 			}
-			schema "test2" {	
+			schema "test2" {
 			}
 			table "pets" {
 				schema = schema.test2
@@ -975,7 +975,7 @@ create table atlas_types_sanity
     "tMACAddr8"            macaddr8                    default '08:00:2b:01:02:03:04:05'                null,
     "tCircle"              circle                      default                                          null,
     "tLine"                line                        default                                          null,
-    "tLseg"                lseg                        default                                          null, 
+    "tLseg"                lseg                        default                                          null,
     "tBox"                 box                         default                                          null,
     "tPath"                path                        default                                          null,
     "tPoint"               point                       default                                          null,
@@ -1001,12 +1001,12 @@ create table atlas_types_sanity
     "tSerial4"             serial4                                                                          ,
     "tSerial8"             serial8                                                                          ,
     "tArray"               text[10][10]                 default '{}'                                    null,
-    "tXML"                 xml                          default '<a>foo</a>'                            null,  
+    "tXML"                 xml                          default '<a>foo</a>'                            null,
     "tJSON"                json                         default '{"key":"value"}'                       null,
     "tJSONB"               jsonb                        default '{"key":"value"}'                       null,
     "tUUID"                uuid                         default  'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' null,
     "tMoney"               money                        default  18                                     null,
-    "tInterval"            interval                     default '4 hours'                               null, 
+    "tInterval"            interval                     default '4 hours'                               null,
     "tUserDefined"         address                      default '("ab","cd")'                           null
 );
 `

--- a/sql/migrate/migrate.go
+++ b/sql/migrate/migrate.go
@@ -831,7 +831,7 @@ type (
 	}
 )
 
-func (e NotCleanError) Error() string {
+func (e *NotCleanError) Error() string {
 	return "sql/migrate: connected database is not clean: " + e.Reason
 }
 

--- a/sql/migrate/migrate_test.go
+++ b/sql/migrate/migrate_test.go
@@ -188,8 +188,7 @@ func TestExecutor_Replay(t *testing.T) {
 	drv.dirty = true
 	drv.realm = schema.Realm{Schemas: []*schema.Schema{{Name: "schema"}}}
 	_, err = ex.Replay(ctx, migrate.RealmConn(drv, nil))
-	var cerr *migrate.NotCleanError
-	require.ErrorAs(t, err, &cerr)
+	require.ErrorAs(t, err, new(*migrate.NotCleanError))
 }
 
 func TestExecutor_Pending(t *testing.T) {

--- a/sql/migrate/migrate_test.go
+++ b/sql/migrate/migrate_test.go
@@ -188,7 +188,8 @@ func TestExecutor_Replay(t *testing.T) {
 	drv.dirty = true
 	drv.realm = schema.Realm{Schemas: []*schema.Schema{{Name: "schema"}}}
 	_, err = ex.Replay(ctx, migrate.RealmConn(drv, nil))
-	require.ErrorAs(t, err, &migrate.NotCleanError{})
+	var cerr *migrate.NotCleanError
+	require.ErrorAs(t, err, &cerr)
 }
 
 func TestExecutor_Pending(t *testing.T) {
@@ -592,7 +593,7 @@ func (m *mockDriver) ApplyChanges(_ context.Context, changes []schema.Change, _ 
 
 func (m *mockDriver) Snapshot(context.Context) (migrate.RestoreFunc, error) {
 	if m.dirty {
-		return nil, migrate.NotCleanError{}
+		return nil, &migrate.NotCleanError{}
 	}
 	realm := m.realm
 	return func(context.Context) error {

--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -128,7 +128,7 @@ func (d *Driver) Snapshot(ctx context.Context) (migrate.RestoreFunc, error) {
 	// If a schema was found, it has to have no tables attached to be considered clean.
 	if s != nil {
 		if len(s.Tables) > 0 {
-			return nil, migrate.NotCleanError{Reason: fmt.Sprintf("found table %q in schema %q", s.Tables[0].Name, s.Name)}
+			return nil, &migrate.NotCleanError{Reason: fmt.Sprintf("found table %q in schema %q", s.Tables[0].Name, s.Name)}
 		}
 		return func(ctx context.Context) error {
 			current, err := d.InspectSchema(ctx, s.Name, nil)
@@ -148,7 +148,7 @@ func (d *Driver) Snapshot(ctx context.Context) (migrate.RestoreFunc, error) {
 		return nil, err
 	}
 	if len(realm.Schemas) > 0 {
-		return nil, migrate.NotCleanError{Reason: fmt.Sprintf("found schema %q", realm.Schemas[0].Name)}
+		return nil, &migrate.NotCleanError{Reason: fmt.Sprintf("found schema %q", realm.Schemas[0].Name)}
 	}
 	return func(ctx context.Context) error {
 		current, err := d.InspectRealm(ctx, nil)
@@ -181,13 +181,13 @@ func (d *Driver) CheckClean(ctx context.Context, revT *migrate.TableIdent) error
 	}
 	switch n := len(r.Schemas); {
 	case n > 1:
-		return migrate.NotCleanError{Reason: fmt.Sprintf("found multiple schemas: %d", len(r.Schemas))}
+		return &migrate.NotCleanError{Reason: fmt.Sprintf("found multiple schemas: %d", len(r.Schemas))}
 	case n == 1 && r.Schemas[0].Name != revT.Schema:
-		return migrate.NotCleanError{Reason: fmt.Sprintf("found schema %q", r.Schemas[0].Name)}
+		return &migrate.NotCleanError{Reason: fmt.Sprintf("found schema %q", r.Schemas[0].Name)}
 	case n == 1 && len(r.Schemas[0].Tables) > 1:
-		return migrate.NotCleanError{Reason: fmt.Sprintf("found multiple tables: %d", len(r.Schemas[0].Tables))}
+		return &migrate.NotCleanError{Reason: fmt.Sprintf("found multiple tables: %d", len(r.Schemas[0].Tables))}
 	case n == 1 && len(r.Schemas[0].Tables) == 1 && r.Schemas[0].Tables[0].Name != revT.Name:
-		return migrate.NotCleanError{Reason: fmt.Sprintf("found table %q", r.Schemas[0].Tables[0].Name)}
+		return &migrate.NotCleanError{Reason: fmt.Sprintf("found table %q", r.Schemas[0].Tables[0].Name)}
 	}
 	return nil
 }

--- a/sql/postgres/driver.go
+++ b/sql/postgres/driver.go
@@ -185,7 +185,7 @@ func (d *Driver) Snapshot(ctx context.Context) (migrate.RestoreFunc, error) {
 			return nil, err
 		}
 		if len(s.Tables) > 0 {
-			return nil, migrate.NotCleanError{Reason: fmt.Sprintf("found table %q in connected schema", s.Tables[0].Name)}
+			return nil, &migrate.NotCleanError{Reason: fmt.Sprintf("found table %q in connected schema", s.Tables[0].Name)}
 		}
 		return func(ctx context.Context) error {
 			current, err := d.InspectSchema(ctx, s.Name, nil)
@@ -221,11 +221,11 @@ func (d *Driver) Snapshot(ctx context.Context) (migrate.RestoreFunc, error) {
 	}
 	if s, ok := realm.Schema("public"); len(realm.Schemas) == 1 && ok {
 		if len(s.Tables) > 0 {
-			return nil, migrate.NotCleanError{Reason: fmt.Sprintf("found table %q in schema %q", s.Tables[0].Name, s.Name)}
+			return nil, &migrate.NotCleanError{Reason: fmt.Sprintf("found table %q in schema %q", s.Tables[0].Name, s.Name)}
 		}
 		return restore, nil
 	}
-	return nil, migrate.NotCleanError{Reason: fmt.Sprintf("found schema %q", realm.Schemas[0].Name)}
+	return nil, &migrate.NotCleanError{Reason: fmt.Sprintf("found schema %q", realm.Schemas[0].Name)}
 }
 
 // CheckClean implements migrate.CleanChecker.

--- a/sql/sqlite/driver.go
+++ b/sql/sqlite/driver.go
@@ -96,7 +96,7 @@ func (d *Driver) Snapshot(ctx context.Context) (migrate.RestoreFunc, error) {
 		return nil, err
 	}
 	if !(r == nil || (len(r.Schemas) == 1 && r.Schemas[0].Name == mainFile && len(r.Schemas[0].Tables) == 0)) {
-		return nil, migrate.NotCleanError{Reason: fmt.Sprintf("found table %q", r.Schemas[0].Tables[0].Name)}
+		return nil, &migrate.NotCleanError{Reason: fmt.Sprintf("found table %q", r.Schemas[0].Tables[0].Name)}
 	}
 	return func(ctx context.Context) error {
 		for _, stmt := range []string{
@@ -121,13 +121,13 @@ func (d *Driver) CheckClean(ctx context.Context, revT *migrate.TableIdent) error
 	}
 	switch n := len(r.Schemas); {
 	case n > 1:
-		return migrate.NotCleanError{Reason: fmt.Sprintf("found multiple schemas: %d", len(r.Schemas))}
+		return &migrate.NotCleanError{Reason: fmt.Sprintf("found multiple schemas: %d", len(r.Schemas))}
 	case n == 1 && r.Schemas[0].Name != mainFile:
-		return migrate.NotCleanError{Reason: fmt.Sprintf("found schema %q", r.Schemas[0].Name)}
+		return &migrate.NotCleanError{Reason: fmt.Sprintf("found schema %q", r.Schemas[0].Name)}
 	case n == 1 && len(r.Schemas[0].Tables) > 1:
-		return migrate.NotCleanError{Reason: fmt.Sprintf("found multiple tables: %d", len(r.Schemas[0].Tables))}
+		return &migrate.NotCleanError{Reason: fmt.Sprintf("found multiple tables: %d", len(r.Schemas[0].Tables))}
 	case n == 1 && len(r.Schemas[0].Tables) == 1 && (revT == nil || r.Schemas[0].Tables[0].Name != revT.Name):
-		return migrate.NotCleanError{Reason: fmt.Sprintf("found table %q", r.Schemas[0].Tables[0].Name)}
+		return &migrate.NotCleanError{Reason: fmt.Sprintf("found table %q", r.Schemas[0].Tables[0].Name)}
 	}
 	return nil
 }


### PR DESCRIPTION
Atlas wasn't working for my existing sqlite database.
According to tutorial from https://entgo.io/docs/versioned/upgrade-prod
following error shoud have occured:
```console
Error: sql/migrate: connected database is not clean: found table "atlas_schema_revisions" in schema "db". baseline version or allow-dirty is required
```
but that didn't happen, I saw this one instead:
```console
Error: sql/migrate: connected database is not clean: found multiple tables: 15
```
Googling didn't help, also I couldn't find any issues on github that were mentioning this.
Weird. Time to investigate!

The root of problem showed itself quite promptly in sql/migrate/migrate.go on line 539, `errors.As` was not able match error.

----

Some functions were returning `migrate.NotCleanError` value, some others - pointer. This was the cause of inconsistent error matching behavior.

It is dangerous to use a non-pointer to implement the error interface. Following example probably should give more clues about the issue:
```go
var cerr *NotCleanError
errors.As(NotCleanError{}, &cerr) // false
errors.As(&NotCleanError{}, &cerr) // true
```

With this change it is now impossible to return `NotCleanError` value, but pointer. This also means that stuff like `errors.As(err, &migrate.NotCleanError{})` isn't going to work anymore, which is not a bad thing because `errors.As`'s target argument is supposed be a pointer to a value of the error type:
```go
var cerr *NotCleanError
errors.As(err, &cerr)
```

See https://pkg.go.dev/errors#As and https://go.dev/blog/go1.13-errors for more info. 
Another relevant piece of information that I stumbled upon, that might shed more light, is following stackoverflow answer: https://stackoverflow.com/a/50333850.

----

This breaks ent, more specifically - return on line 729 in dialect/sql/schema/atlas.go becomes invalid:
```diff
-return nil, migrate.NotCleanError{Reason: fmt.Sprintf("found table %q", s.Tables[0].Name)}
+return nil, &migrate.NotCleanError{Reason: fmt.Sprintf("found table %q", s.Tables[0].Name)}
```
Merge of this pr is blocked until this ^ change in ent is made.

----

This pr only includes fix for the specific problem that was encountered, there are couple more error types that might benefit from same change to them.