### PR TITLE
schemahcl: limit type variables scope to specific location

### DIFF
--- a/internal/integration/hclsqlspec/hclsqlspec_test.go
+++ b/internal/integration/hclsqlspec/hclsqlspec_test.go
@@ -347,7 +347,7 @@ table "accounts" {
 	require.NoError(t, err)
 }
 
-var hcl = schemahcl.New(schemahcl.WithTypes(postgres.TypeRegistry.Specs()))
+var hcl = schemahcl.New(schemahcl.WithTypes("table.column.type", postgres.TypeRegistry.Specs()))
 
 func TestMarshalTopLevel(t *testing.T) {
 	c := &sqlspec.Schema{

--- a/schemahcl/stdlib.go
+++ b/schemahcl/stdlib.go
@@ -161,6 +161,9 @@ func stdFuncs() map[string]function.Function {
 		"urlsetpath":      urlSetPathFunc,
 		"values":          stdlib.ValuesFunc,
 		"zipmap":          stdlib.ZipmapFunc,
+		// A patch from the past. Should be moved
+		// to specific scopes in the future.
+		"sql": rawExprImpl(),
 	}
 }
 

--- a/sql/mysql/sqlspec.go
+++ b/sql/mysql/sqlspec.go
@@ -78,7 +78,7 @@ func MarshalSpec(v any, marshaler schemahcl.Marshaler) ([]byte, error) {
 
 var (
 	hclState = schemahcl.New(
-		schemahcl.WithTypes(TypeRegistry.Specs()),
+		schemahcl.WithTypes("table.column.type", TypeRegistry.Specs()),
 		schemahcl.WithScopedEnums("table.index.type", IndexTypeBTree, IndexTypeHash, IndexTypeFullText, IndexTypeSpatial),
 		schemahcl.WithScopedEnums("table.primary_key.type", IndexTypeBTree, IndexTypeHash, IndexTypeFullText, IndexTypeSpatial),
 		schemahcl.WithScopedEnums("table.column.as.type", stored, persistent, virtual),

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -117,7 +117,7 @@ func MarshalSpec(v any, marshaler schemahcl.Marshaler) ([]byte, error) {
 
 var (
 	hclState = schemahcl.New(
-		schemahcl.WithTypes(TypeRegistry.Specs()),
+		schemahcl.WithTypes("table.column.type", TypeRegistry.Specs()),
 		schemahcl.WithScopedEnums("table.index.type", IndexTypeBTree, IndexTypeBRIN, IndexTypeHash, IndexTypeGIN, IndexTypeGiST, "GiST", IndexTypeSPGiST, "SPGiST"),
 		schemahcl.WithScopedEnums("table.partition.type", PartitionTypeRange, PartitionTypeList, PartitionTypeHash),
 		schemahcl.WithScopedEnums("table.column.identity.generated", GeneratedTypeAlways, GeneratedTypeByDefault),

--- a/sql/sqlite/sqlspec.go
+++ b/sql/sqlite/sqlspec.go
@@ -201,7 +201,7 @@ var TypeRegistry = schemahcl.NewRegistry(
 
 var (
 	hclState = schemahcl.New(
-		schemahcl.WithTypes(TypeRegistry.Specs()),
+		schemahcl.WithTypes("table.column.type", TypeRegistry.Specs()),
 		schemahcl.WithScopedEnums("table.column.as.type", stored, virtual),
 		schemahcl.WithScopedEnums("table.foreign_key.on_update", specutil.ReferenceVars...),
 		schemahcl.WithScopedEnums("table.foreign_key.on_delete", specutil.ReferenceVars...),


### PR DESCRIPTION
Limiting the variable's scope to specific attributes provides type-safety to the schema. i.e., Eval fails on "parsing" and not on the decoding stage, which improves the error reporting. 

From:
```
Error: schemahcl: failed reading spec as *postgres.doc: set field "type": converting cty.Value to *schemahcl.Type: incorrect type type
```

To:
```
Error: schema1.hcl:6,12-18: Unknown column.type; There is no type named "string".
```