### PR TITLE
sql/postgres: clean enums on table drop

### DIFF
--- a/sql/postgres/migrate_test.go
+++ b/sql/postgres/migrate_test.go
@@ -793,6 +793,81 @@ func TestPlanChanges(t *testing.T) {
 		},
 		{
 			changes: []schema.Change{
+				&schema.DropTable{
+					T: schema.NewTable("users").
+						SetSchema(schema.New("public")).
+						AddColumns(
+							schema.NewEnumColumn("state", schema.EnumName("state"), schema.EnumValues("on", "off")),
+							schema.NewEnumColumn("status", schema.EnumName("status"), schema.EnumValues("on", "off")),
+						),
+				},
+			},
+			mock: func(m mock) {
+				m.ExpectQuery(sqltest.Escape("SELECT * FROM pg_type t JOIN pg_namespace n on t.typnamespace = n.oid WHERE t.typname = $1 AND t.typtype = 'e' AND n.nspname = $2 ")).
+					WithArgs("state", "public").
+					WillReturnRows(sqlmock.NewRows([]string{"name"}))
+				m.ExpectQuery(sqltest.Escape("SELECT * FROM pg_type t JOIN pg_namespace n on t.typnamespace = n.oid WHERE t.typname = $1 AND t.typtype = 'e' AND n.nspname = $2 ")).
+					WithArgs("status", "public").
+					WillReturnRows(sqlmock.NewRows([]string{"name"}))
+			},
+			wantPlan: &migrate.Plan{
+				Reversible:    true,
+				Transactional: true,
+				Changes: []*migrate.Change{
+					{Cmd: `DROP TABLE "public"."users"`, Reverse: `CREATE TABLE "public"."users" ("state" "public"."state" NOT NULL, "status" "public"."status" NOT NULL)`},
+					{Cmd: `DROP TYPE "public"."state"`, Reverse: `CREATE TYPE "public"."state" AS ENUM ('on', 'off')`},
+					{Cmd: `DROP TYPE "public"."status"`, Reverse: `CREATE TYPE "public"."status" AS ENUM ('on', 'off')`},
+				},
+			},
+		},
+		{
+			changes: func() []schema.Change {
+				s := schema.New("public").
+					AddTables(
+						schema.NewTable("t1").
+							AddColumns(
+								schema.NewEnumColumn("state", schema.EnumName("state"), schema.EnumValues("on", "off")),
+							),
+						schema.NewTable("t2").
+							AddColumns(
+								schema.NewEnumColumn("state", schema.EnumName("state"), schema.EnumValues("on", "off")),
+							),
+					)
+				return []schema.Change{
+					&schema.DropTable{
+						T: s.Tables[0],
+					},
+					&schema.DropTable{
+						T: s.Tables[1],
+					},
+				}
+			}(),
+			mock: func(m mock) {
+				m.ExpectQuery(sqltest.Escape("SELECT * FROM pg_type t JOIN pg_namespace n on t.typnamespace = n.oid WHERE t.typname = $1 AND t.typtype = 'e' AND n.nspname = $2 ")).
+					WithArgs("state", "public").
+					WillReturnRows(sqlmock.NewRows([]string{"name"}).AddRow("state"))
+				m.ExpectQuery(sqltest.Escape("SELECT * FROM pg_type t JOIN pg_namespace n on t.typnamespace = n.oid WHERE t.typname = $1 AND t.typtype = 'e' AND n.nspname = $2 ")).
+					WithArgs("state", "public").
+					WillReturnRows(sqlmock.NewRows([]string{"name"}).AddRow("state"))
+			},
+			wantPlan: &migrate.Plan{
+				Reversible:    true,
+				Transactional: true,
+				Changes: []*migrate.Change{
+					{
+						Cmd:     `DROP TABLE "public"."t1"`,
+						Reverse: `CREATE TABLE "public"."t1" ("state" "public"."state" NOT NULL)`,
+					},
+					{
+						Cmd:     `DROP TABLE "public"."t2"`,
+						Reverse: `CREATE TABLE "public"."t2" ("state" "public"."state" NOT NULL)`,
+					},
+					{Cmd: `DROP TYPE "public"."state"`, Reverse: `CREATE TYPE "public"."state" AS ENUM ('on', 'off')`},
+				},
+			},
+		},
+		{
+			changes: []schema.Change{
 				func() schema.Change {
 					users := schema.NewTable("users").
 						SetSchema(schema.New("public")).


### PR DESCRIPTION
Reusing the dev-database (from both loading and diff), will cause the enum to not be created on diff. Fixed https://github.com/ariga/atlas/issues/1503.