### PR TITLE
sql/postgres: drop tables with CASCADE on cleanup

### DIFF
--- a/sql/postgres/inspect.go
+++ b/sql/postgres/inspect.go
@@ -871,6 +871,12 @@ type (
 		C     *schema.Column
 		Attrs []schema.Attr
 	}
+
+	// Cascade describes that a CASCADE clause should be added to the DROP [TABLE|SCHEMA]
+	// operation. Note, this clause is automatically added to DROP SCHEMA by the planner.
+	Cascade struct {
+		schema.Clause
+	}
 )
 
 // IsUnique reports if the type is unique constraint.

--- a/sql/postgres/migrate.go
+++ b/sql/postgres/migrate.go
@@ -225,6 +225,9 @@ func (s *state) dropTable(ctx context.Context, drop *schema.DropTable) error {
 		b.P("IF EXISTS")
 	}
 	b.Table(drop.T)
+	if sqlx.Has(drop.Extra, &Cascade{}) {
+		b.P("CASCADE")
+	}
 	cmd.main = &migrate.Change{
 		Cmd:     b.String(),
 		Source:  drop,

--- a/sql/postgres/migrate_test.go
+++ b/sql/postgres/migrate_test.go
@@ -328,6 +328,7 @@ func TestPlanChanges(t *testing.T) {
 		{
 			changes: []schema.Change{
 				&schema.DropTable{T: schema.NewTable("posts").AddColumns(schema.NewIntColumn("id", "int"))},
+				&schema.DropTable{T: schema.NewTable("users").AddColumns(schema.NewIntColumn("id", "int")), Extra: []schema.Clause{&Cascade{}}},
 			},
 			wantPlan: &migrate.Plan{
 				Reversible:    true,
@@ -336,6 +337,10 @@ func TestPlanChanges(t *testing.T) {
 					{
 						Cmd:     `DROP TABLE "posts"`,
 						Reverse: `CREATE TABLE "posts" ("id" integer NOT NULL)`,
+					},
+					{
+						Cmd:     `DROP TABLE "users" CASCADE`,
+						Reverse: `CREATE TABLE "users" ("id" integer NOT NULL)`,
 					},
 				},
 			},


### PR DESCRIPTION
In case other resources like views were created in the migration, replay will fail