### PR TITLE
make a string lower before doing the string comparison

### DIFF
--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -449,6 +449,8 @@ func ExprValue(expr schema.Expr) (cty.Value, error) {
 				return cty.NilVal, err
 			}
 			return cty.StringVal(s), nil
+		case strings.ToLower(x.V) == "true", strings.ToLower(x.V) == "false":
+			return cty.BoolVal(strings.ToLower(x.V) == "true"), nil
 		case x.V == "true", x.V == "false":
 			return cty.BoolVal(x.V == "true"), nil
 		case strings.Contains(x.V, "."):

--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -451,8 +451,6 @@ func ExprValue(expr schema.Expr) (cty.Value, error) {
 			return cty.StringVal(s), nil
 		case strings.ToLower(x.V) == "true", strings.ToLower(x.V) == "false":
 			return cty.BoolVal(strings.ToLower(x.V) == "true"), nil
-		case x.V == "true", x.V == "false":
-			return cty.BoolVal(x.V == "true"), nil
 		case strings.Contains(x.V, "."):
 			f, err := strconv.ParseFloat(x.V, 64)
 			if err != nil {


### PR DESCRIPTION
I recently installed pocketbase https://pocketbase.io and was trying to use atlas to inspect the sqlite schema that is generated. 

Running `atlas schema inspect --url sqlite://pb_data/data.db` triggered the following error:

```bash
Error: template: inspect:1:43: executing "inspect" at <$.MarshalHCL>: error calling MarshalHCL: specutil: failed converting schema to spec: unsupported literal value "FALSE"
```

Looking at the code I could see that a string comparison was happening and it was expecting a boolean column to be in lowercase. Taking a look at the schema that pocketable created showed an uppercase `FALSE`.

```sql
-- cat ./pb_data/data.db 
...
                         Andexsqlite_autoindex__params_2_params
 Andexsqlite_autoindex__params_1_params
                                       �]%%�}table_collections_collectionCREATE TABLE `_collections` (
                                `id`         TEXT PRIMARY KEY NOT NULL,
                                `system`     BOOLEAN DEFAULT FALSE NOT NULL,
                                `type`       TEXT DEFAULT "base" NOT NULL,
                                `name`       TEXT UNIQUE NOT NULL,
                                `schema`     JSON DEFAULT "[]" NOT NULL,
 ...
 ```

----

Console output before my change showing the error:

```bash
gitpod /workspace/atlas (master) $ ls pb_data
ls: cannot access 'pb_data': No such file or directory
gitpod /workspace/atlas (master) $ ./pocketbase serve --dir pb_data
2023/03/10 12:04:22 Server started at http://127.0.0.1:8090
 ➜ REST API: http://127.0.0.1:8090/api/
 ➜ Admin UI: http://127.0.0.1:8090/_/
^Cgitpod /workspace/atlas (master) $ ls pb_data
data.db  logs.db
gitpod /workspace/atlas (master) $ go run cmd/atlas/main.go schema inspect --url sqlite://pb_data/data.db 
Error: template: inspect:1:43: executing "inspect" at <$.MarshalHCL>: error calling MarshalHCL: specutil: failed converting schema to spec: unsupported literal value "FALSE"
exit status 1
gitpod /workspace/atlas (master) $ 
```


After my change all is good and a hcl file generated:


```bash
gitpod /workspace/atlas (master) $ ls pb_data
ls: cannot access 'pb_data': No such file or directory
gitpod /workspace/atlas (master) $ ./pocketbase serve --dir pb_data
2023/03/10 12:05:37 Server started at http://127.0.0.1:8090
 ➜ REST API: http://127.0.0.1:8090/api/
 ➜ Admin UI: http://127.0.0.1:8090/_/
^Cgitpod /workspace/atlas (master) $ ls pb_data
data.db  logs.db
gitpod /workspace/atlas (master) $ go run cmd/atlas/main.go schema inspect --url sqlite://pb_data/data.db 
table "_migrations" {
  schema = schema.main
  column "file" {
    null = false
    type = varchar(255)
  }
...
```