### PR TITLE
Update image.md

### DIFF
--- a/doc/md/guides/deploying/image.md
+++ b/doc/md/guides/deploying/image.md
@@ -74,7 +74,7 @@ To verify Atlas can find your migrations directory and that its [integrity](/con
 is intact run:
 
 ```text
-docker run --rm migrations my-image migrate validate 
+docker run --rm my-image migrate validate 
 ```
 
 If no issues are found, no errors will be printed out.


### PR DESCRIPTION
docs: update docker command to match the format of docker run 
 IMAGE [COMMAND]

The `migrations` before the image name might be a typo. It didn't work for me and I can't find any documentation that helps me understand what it might be doing.