### PR TITLE
Fix Typo in PostgresSQL Migration: NULL LAST to NULLS LAST

### DIFF
--- a/sql/postgres/migrate.go
+++ b/sql/postgres/migrate.go
@@ -1015,11 +1015,11 @@ func (s *state) partAttrs(b *sqlx.Builder, idx *schema.Index, p *schema.IndexPar
 			// Defaults when DESC is specified.
 			case p.Desc && attr.NullsFirst:
 			case p.Desc && attr.NullsLast:
-				b.P("NULL LAST")
+				b.P("NULLS LAST")
 			// Defaults when DESC is not specified.
 			case !p.Desc && attr.NullsLast:
 			case !p.Desc && attr.NullsFirst:
-				b.P("NULL FIRST")
+				b.P("NULLS FIRST")
 			}
 		// Handled above.
 		case *IndexOpClass, *schema.Collation:


### PR DESCRIPTION
This pull request addresses a typo found in the Atlas SQL migration framework. The keywords `NULL LAST` and `NULL FIRST` was incorrectly used, which should have been `NULLS LAST` and `NULLS FIRST` respectively.