### PR TITLE
schema/inspect: support inspect for non-database resource

### DIFF
--- a/cmd/atlas/internal/cmdapi/schema.go
+++ b/cmd/atlas/internal/cmdapi/schema.go
@@ -470,10 +470,6 @@ func schemaInspectRun(cmd *cobra.Command, _ []string, flags schemaInspectFlags) 
 		return err
 	}
 	defer r.Close()
-	s, err := r.ReadState(ctx)
-	if err != nil {
-		return err
-	}
 	client, ok := r.Closer.(*sqlclient.Client)
 	if !ok && dev != nil {
 		client = dev
@@ -484,6 +480,7 @@ func schemaInspectRun(cmd *cobra.Command, _ []string, flags schemaInspectFlags) 
 			return fmt.Errorf("parse log format: %w", err)
 		}
 	}
+	s, err := r.ReadState(ctx)
 	return format.Execute(cmd.OutOrStdout(), &cmdlog.SchemaInspect{
 		Client: client,
 		Realm:  s,

--- a/cmd/atlas/internal/cmdapi/schema.go
+++ b/cmd/atlas/internal/cmdapi/schema.go
@@ -470,13 +470,13 @@ func schemaInspectRun(cmd *cobra.Command, _ []string, flags schemaInspectFlags) 
 		return err
 	}
 	defer r.Close()
-	client, ok := r.Closer.(*sqlclient.Client)
-	if !ok && dev != nil {
-		client = dev
-	}
 	s, err := r.ReadState(ctx)
 	if err != nil {
 		return err
+	}
+	client, ok := r.Closer.(*sqlclient.Client)
+	if !ok && dev != nil {
+		client = dev
 	}
 	format := cmdlog.SchemaInspectTemplate
 	if v := flags.logFormat; v != "" {

--- a/cmd/atlas/internal/cmdapi/schema.go
+++ b/cmd/atlas/internal/cmdapi/schema.go
@@ -466,6 +466,10 @@ func schemaInspectRun(cmd *cobra.Command, _ []string, flags schemaInspectFlags) 
 		schemas: flags.schemas,
 		exclude: flags.exclude,
 	})
+	if err != nil {
+		return err
+	}
+	defer r.Close()
 	client, ok := r.Closer.(*sqlclient.Client)
 	if !ok && dev != nil {
 		client = dev

--- a/cmd/atlas/internal/cmdapi/schema_test.go
+++ b/cmd/atlas/internal/cmdapi/schema_test.go
@@ -592,28 +592,6 @@ func TestSchema_InspectLog(t *testing.T) {
 	require.Equal(t, `{"schemas":[{"name":"main","tables":[{"name":"t1","columns":[{"name":"id","type":"INTEGER","null":true}],"primary_key":{"parts":[{"column":"id"}]}},{"name":"t2","columns":[{"name":"name","type":"TEXT","null":true}]}]}]}`, s)
 }
 
-func TestSchema_InspectFile(t *testing.T) {
-	p := filepath.Join(t.TempDir(), "schema.sql")
-	os.WriteFile(p, []byte(`create table t1 (id integer primary key);create table t2 (name text);`), 0600)
-	db := openSQLite(t, "")
-	cmd := schemaCmd()
-	cmd.AddCommand(schemaInspectCmd())
-	s, err := runCmd(
-		cmd, "inspect",
-		"-u", "file://"+p,
-		"--dev-url", db,
-		"--format", "{{ sql . }}",
-	)
-	require.NoError(t, err)
-	require.Equal(t, strings.Join([]string{
-		`-- Create "t1" table`,
-		"CREATE TABLE `t1` (`id` integer NULL, PRIMARY KEY (`id`));",
-		`-- Create "t2" table`,
-		"CREATE TABLE `t2` (`name` text NULL);",
-		"",
-	}, "\n"), s)
-}
-
 func TestFmt(t *testing.T) {
 	for _, tt := range []struct {
 		name          string

--- a/cmd/atlas/internal/cmdapi/schema_test.go
+++ b/cmd/atlas/internal/cmdapi/schema_test.go
@@ -592,6 +592,28 @@ func TestSchema_InspectLog(t *testing.T) {
 	require.Equal(t, `{"schemas":[{"name":"main","tables":[{"name":"t1","columns":[{"name":"id","type":"INTEGER","null":true}],"primary_key":{"parts":[{"column":"id"}]}},{"name":"t2","columns":[{"name":"name","type":"TEXT","null":true}]}]}]}`, s)
 }
 
+func TestSchema_InspectFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "schema.sql")
+	os.WriteFile(p, []byte(`create table t1 (id integer primary key);create table t2 (name text);`), 0600)
+	db := openSQLite(t, "")
+	cmd := schemaCmd()
+	cmd.AddCommand(schemaInspectCmd())
+	s, err := runCmd(
+		cmd, "inspect",
+		"-u", "file://"+p,
+		"--dev-url", db,
+		"--format", "{{ sql . }}",
+	)
+	require.NoError(t, err)
+	require.Equal(t, strings.Join([]string{
+		`-- Create "t1" table`,
+		"CREATE TABLE `t1` (`id` integer NULL, PRIMARY KEY (`id`));",
+		`-- Create "t2" table`,
+		"CREATE TABLE `t2` (`name` text NULL);",
+		"",
+	}, "\n"), s)
+}
+
 func TestFmt(t *testing.T) {
 	for _, tt := range []struct {
 		name          string

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -516,6 +516,7 @@ flag.
 #### Flags
 ```
   -u, --url string        [driver://username:password@address/dbname?param=value] select a resource using the URL format
+      --dev-url string    [driver://username:password@address/dbname?param=value] select a dev database using the URL format
   -s, --schema strings    set schema names
       --exclude strings   list of glob patterns used to filter resources from applying
       --format string     Go template to use to format the output

--- a/internal/integration/testdata/mysql/cli-inspect-file.txt
+++ b/internal/integration/testdata/mysql/cli-inspect-file.txt
@@ -1,0 +1,38 @@
+only mysql8
+
+# inspect without dev-db will failed
+! atlas schema inspect -u file://a.sql
+stderr 'Error: --dev-url cannot be empty'
+
+# inspect file to HCL
+atlas schema inspect -u file://a.sql --dev-url URL > inspected.hcl
+cmp inspected.hcl script_cli_inspect.hcl
+
+# inspect file to SQL
+atlas schema inspect -u file://a.sql --dev-url URL --format '{{ sql . }}' > inspected.sql
+cmp inspected.sql script_cli_inspect.sql
+
+-- a.sql --
+create table users (
+  id int NOT NULL,
+  PRIMARY KEY (id)
+)
+
+-- script_cli_inspect.hcl --
+table "users" {
+  schema = schema.script_cli_inspect_file
+  column "id" {
+    null = false
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+schema "script_cli_inspect_file" {
+  charset = "utf8mb4"
+  collate = "utf8mb4_0900_ai_ci"
+}
+-- script_cli_inspect.sql --
+-- Create "users" table
+CREATE TABLE `users` (`id` int NOT NULL, PRIMARY KEY (`id`)) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

--- a/internal/integration/testdata/postgres/cli-inspect-file.txt
+++ b/internal/integration/testdata/postgres/cli-inspect-file.txt
@@ -1,0 +1,34 @@
+# inspect without dev-db will failed
+! atlas schema inspect -u file://a.sql
+stderr 'Error: --dev-url cannot be empty'
+
+# inspect file to HCL
+atlas schema inspect -u file://a.sql --dev-url URL > inspected.hcl
+cmp inspected.hcl script_cli_inspect.hcl
+
+# inspect file to SQL
+atlas schema inspect -u file://a.sql --dev-url URL --format '{{ sql . }}' > inspected.sql
+cmp inspected.sql script_cli_inspect.sql
+
+-- a.sql --
+create table users (
+  id int NOT NULL,
+  PRIMARY KEY (id)
+)
+
+-- script_cli_inspect.hcl --
+table "users" {
+  schema = schema.script_cli_inspect_file
+  column "id" {
+    null = false
+    type = integer
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+schema "script_cli_inspect_file" {
+}
+-- script_cli_inspect.sql --
+-- Create "users" table
+CREATE TABLE "users" ("id" integer NOT NULL, PRIMARY KEY ("id"));

--- a/internal/integration/testdata/postgres/cli-inspect.txt
+++ b/internal/integration/testdata/postgres/cli-inspect.txt
@@ -1,0 +1,92 @@
+apply 1.hcl
+
+# test url flag
+atlas schema inspect -u URL > inspected.hcl
+cmp inspected.hcl script_cli_inspect.hcl
+
+# test exclude flag on table.
+atlas schema inspect -u URL --exclude "users" > inspected.hcl
+cmp inspected.hcl notable.hcl
+
+# test exclude flag on column.
+atlas schema inspect -u URL --exclude "*.[ab]*" > inspected.hcl
+cmp inspected.hcl id.hcl
+
+# test exclude flag on column.
+atlas schema inspect -u URL --exclude "*.*" > inspected.hcl
+cmp inspected.hcl nocolumn.hcl
+
+
+-- 1.hcl --
+table "users" {
+  schema = schema.$db
+  column "id" {
+    null = false
+    type = int
+  }
+  column "a" {
+    null = false
+    type = int
+  }
+  column "b" {
+    null = false
+    type = int
+  }
+  column "ab" {
+    null = false
+    type = int
+  }
+  column "ac" {
+    null = false
+    type = int4
+  }
+}
+schema "$db" {
+}
+
+-- script_cli_inspect.hcl --
+table "users" {
+  schema = schema.script_cli_inspect
+  column "id" {
+    null = false
+    type = integer
+  }
+  column "a" {
+    null = false
+    type = integer
+  }
+  column "b" {
+    null = false
+    type = integer
+  }
+  column "ab" {
+    null = false
+    type = integer
+  }
+  column "ac" {
+    null = false
+    type = integer
+  }
+}
+schema "script_cli_inspect" {
+}
+-- empty.hcl --
+-- notable.hcl --
+schema "script_cli_inspect" {
+}
+-- id.hcl --
+table "users" {
+  schema = schema.script_cli_inspect
+  column "id" {
+    null = false
+    type = integer
+  }
+}
+schema "script_cli_inspect" {
+}
+-- nocolumn.hcl --
+table "users" {
+  schema = schema.script_cli_inspect
+}
+schema "script_cli_inspect" {
+}

--- a/internal/integration/testdata/postgres/cli-migrate-apply.txt
+++ b/internal/integration/testdata/postgres/cli-migrate-apply.txt
@@ -54,18 +54,18 @@ stderr 'unknown tx-mode "invalid"'
 
 ! atlas migrate apply --url URL --revisions-schema $db --tx-mode all
 stderr 'executing statement "THIS IS A FAILING STATEMENT;" from version "4"'
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions
+atlas schema inspect --url URL --exclude atlas_schema_revisions
 cmp stdout empty.hcl
 
 # Apply one migration, after rolling everything back, the first revision must still exist.
 atlas migrate apply --url URL --revisions-schema $db 1
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions --exclude $db.users
+atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users
 cmp stdout empty.hcl
 cmpshow users users_1.sql
 
 ! atlas migrate apply --url URL --revisions-schema $db --tx-mode all
 stderr 'executing statement "THIS IS A FAILING STATEMENT;" from version "4"'
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions --exclude $db.users
+atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users
 cmp stdout empty.hcl
 
 # If the broken migration is gone, we can apply everything without any problems.
@@ -75,7 +75,7 @@ atlas migrate hash
 atlas migrate apply --url URL --revisions-schema $db
 cmpshow users users.sql
 cmpshow pets pets.sql
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions --exclude $db.users --exclude $db.pets
+atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users --exclude pets
 cmp stdout empty.hcl
 
 clearSchema
@@ -87,12 +87,12 @@ atlas migrate hash
 
 ! atlas migrate apply --url URL --revisions-schema $db --tx-mode file
 stderr 'executing statement "THIS IS A FAILING STATEMENT;" from version "4"'
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions
+atlas schema inspect --url URL --exclude atlas_schema_revisions
 cmpshow users users.sql
 cmpshow pets pets.sql
 
 # Table "broken" does not exist since we rolled back that migration.
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions --exclude $db.users --exclude $db.pets
+atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users --exclude pets
 cmp stdout empty.hcl
 
 # If the broken migration is gone, we can apply everything without any problems.
@@ -102,7 +102,7 @@ atlas migrate hash
 atlas migrate apply --url URL --revisions-schema $db
 cmpshow users users.sql
 cmpshow pets pets.sql
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions --exclude $db.users --exclude $db.pets
+atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users --exclude pets
 cmp stdout empty.hcl
 
 clearSchema
@@ -114,12 +114,12 @@ atlas migrate hash
 
 ! atlas migrate apply --url URL --revisions-schema $db --tx-mode none
 stderr 'executing statement "THIS IS A FAILING STATEMENT;" from version "4"'
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions
+atlas schema inspect --url URL --exclude atlas_schema_revisions
 cmpshow users users.sql
 cmpshow pets pets.sql
 
 # Table "broken" does exist since we do not have transactions.
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions --exclude $db.users --exclude $db.pets
+atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users --exclude pets
 cmp stdout broken.hcl
 
 -- migrations/1_first.sql --

--- a/internal/integration/testdata/sqlite/cli-inspect.txt
+++ b/internal/integration/testdata/sqlite/cli-inspect.txt
@@ -4,20 +4,16 @@ apply 1.hcl
 atlas schema inspect -u URL > inspected.hcl
 cmp inspected.hcl 1.hcl
 
-# test exclude flag on schema.
-atlas schema inspect -u URL --exclude "main" > inspected.hcl
-cmp inspected.hcl empty.hcl
-
 # test exclude flag on table.
-atlas schema inspect -u URL --exclude "*.users" > inspected.hcl
+atlas schema inspect -u URL --exclude "users" > inspected.hcl
 cmp inspected.hcl notable.hcl
 
 # test exclude flag on column.
-atlas schema inspect -u URL --exclude "main.*.[ab]*" > inspected.hcl
+atlas schema inspect -u URL --exclude "*.[ab]*" > inspected.hcl
 cmp inspected.hcl id.hcl
 
 # test exclude flag on column.
-atlas schema inspect -u URL --exclude "*.*.*" > inspected.hcl
+atlas schema inspect -u URL --exclude "*.*" > inspected.hcl
 cmp inspected.hcl nocolumn.hcl
 
 

--- a/internal/integration/testdata/sqlite/cli-migrate-apply.txt
+++ b/internal/integration/testdata/sqlite/cli-migrate-apply.txt
@@ -48,18 +48,18 @@ stderr 'unknown tx-mode "invalid"'
 
 ! atlas migrate apply --url URL --tx-mode all
 stderr 'executing statement "THIS IS A FAILING STATEMENT;" from version "3"'
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions
+atlas schema inspect --url URL --exclude atlas_schema_revisions
 cmp stdout empty.hcl
 
 # Apply one migration, after rolling everything back, the first revision must still exist.
 atlas migrate apply --url URL 1
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions --exclude $db.users
+atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users
 cmp stdout empty.hcl
 cmpshow users users.sql
 
 ! atlas migrate apply --url URL --tx-mode all
 stderr 'executing statement "THIS IS A FAILING STATEMENT;" from version "3"'
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions --exclude $db.users
+atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users
 cmp stdout empty.hcl
 
 # If the broken migration is gone, we can apply everything without any problems.
@@ -69,7 +69,7 @@ atlas migrate hash
 atlas migrate apply --url URL --revisions-schema $db
 cmpshow users users.sql
 cmpshow pets pets.sql
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions --exclude $db.users --exclude $db.pets
+atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users --exclude pets
 cmp stdout empty.hcl
 
 clearSchema
@@ -81,12 +81,12 @@ atlas migrate hash
 
 ! atlas migrate apply --url URL --tx-mode file
 stderr 'executing statement "THIS IS A FAILING STATEMENT;" from version "3"'
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions
+atlas schema inspect --url URL --exclude atlas_schema_revisions
 cmpshow users users.sql
 cmpshow pets pets.sql
 
 # Table "broken" does not exist since we rolled back that migration.
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions --exclude $db.users --exclude $db.pets
+atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users --exclude pets
 cmp stdout empty.hcl
 
 # If the broken migration is gone, we can apply everything without any problems.
@@ -96,7 +96,7 @@ atlas migrate hash
 atlas migrate apply --url URL --revisions-schema $db
 cmpshow users users.sql
 cmpshow pets pets.sql
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions --exclude $db.users --exclude $db.pets
+atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users --exclude pets
 cmp stdout empty.hcl
 
 clearSchema
@@ -108,12 +108,12 @@ atlas migrate hash
 
 ! atlas migrate apply --url URL --tx-mode none
 stderr 'executing statement "THIS IS A FAILING STATEMENT;" from version "3"'
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions
+atlas schema inspect --url URL --exclude atlas_schema_revisions
 cmpshow users users.sql
 cmpshow pets pets.sql
 
 # Table "broken" does exist since we do not have transactions.
-atlas schema inspect --url URL --exclude $db.atlas_schema_revisions --exclude $db.users --exclude $db.pets
+atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users --exclude pets
 cmp stdout broken.hcl
 
 -- migrations/1_first.sql --


### PR DESCRIPTION
This PR updates the `atlas schema inspect` command to support other resources: sql-file, hcl-file, and Ent's schema. When you do inspect those resources, you need to provide a dev-DB for Atlas to replay changes on it.

With an unexpected side effect, to fix what we believe to be a bug with the inspect command. The `--exclude` flag when used with schema connection can only exclude sub-resources such as: table, column, index, ... and no longer exclude the current schema.

Those commands are invalid
```shell
atlas schema inspect -u "mysql://user:pass@localhost:3306/dbname" --exclude=dbname
atlas schema inspect -u "mysql://user:pass@localhost:3306/dbname" --exclude=dbname.*
atlas schema inspect -u "mysql://user:pass@localhost:3306/dbname" --exclude=dbname.table1
```

Need to update to this:
```shell
atlas schema inspect -u "mysql://user:pass@localhost:3306/dbname" --exclude=*
atlas schema inspect -u "mysql://user:pass@localhost:3306/dbname" --exclude=table1
```

For connection to realm, the exclude flag doesn't affect by this PR. So the bellow command still working fine.
```shell
atlas schema inspect -u "mysql://user:pass@localhost:3306" --exclude=dbname
```