### PR TITLE
sql/postgres: make index storage check continue

### DIFF
--- a/sql/postgres/inspect.go
+++ b/sql/postgres/inspect.go
@@ -1024,7 +1024,7 @@ func newIndexStorage(opts string) (*IndexStorageParams, error) {
 	for _, p := range strings.Split(strings.Trim(opts, "{}"), ",") {
 		kv := strings.Split(p, "=")
 		if len(kv) != 2 {
-			return nil, fmt.Errorf("invalid index storage parameter: %s", p)
+			continue
 		}
 		switch kv[0] {
 		case "autosummarize":


### PR DESCRIPTION
Fixes #1472 I have no idea if this causes issues downstream, but it seems to fix the immediate issue I have with Atlas. Looking at the logic itself, I don't see a good reason to fail the param parsing though; non-kvp-pairs in storage params doesn't indicate a bad state, as evidenced by our use case. They just aren't the specific params that are trying to be parsed.