### PR TITLE
sql/sqltool: fix flyway invalid order migrations

### DIFF
--- a/sql/sqltool/tool.go
+++ b/sql/sqltool/tool.go
@@ -534,8 +534,8 @@ func (ff *flywayFiles) names() []string {
 	if ff.baseline != "" {
 		names = append(names, ff.baseline)
 	}
-	sort.Strings(ff.versioned)
-	sort.Strings(ff.repeatable)
+	flywaySort(ff.versioned)
+	flywaySort(ff.repeatable)
 	names = append(names, ff.versioned...)
 	names = append(names, ff.repeatable...)
 	return names
@@ -555,6 +555,12 @@ func flywayVersion(path string) string {
 		return ""
 	}
 	return strings.SplitN(strings.TrimSuffix(filepath.Base(path), ".sql"), "__", 2)[0][1:]
+}
+
+func flywaySort(files []string) {
+	sort.Slice(files, func(i, j int) bool {
+		return flywayVersion(files[i]) < flywayVersion(files[j])
+	})
 }
 
 func unexpectedPragmaErr(f migrate.File, line int, pragma string) error {

--- a/sql/sqltool/tool_test.go
+++ b/sql/sqltool/tool_test.go
@@ -360,6 +360,24 @@ func TestChecksum(t *testing.T) {
 			},
 		},
 		{
+			name: "flyway with semver versioning",
+			dir: func() migrate.Dir {
+				fs := fstest.MapFS{
+					"V1__initial.sql":          &fstest.MapFile{Data: []byte("V1__initial")},
+					"V1.7__initial.sql":        &fstest.MapFile{Data: []byte("V1.7__initial")},
+					"V2__second_migration.sql": &fstest.MapFile{Data: []byte("V2__second_migration")},
+					"V3__third_migration.sql":  &fstest.MapFile{Data: []byte("V3__third_migration")},
+				}
+				return &sqltool.FlywayDir{&fs}
+			}(),
+			files: []string{
+				"V1__initial.sql",
+				"V1.7__initial.sql",
+				"V2__second_migration.sql",
+				"V3__third_migration.sql",
+			},
+		},
+		{
 			name: "liquibase",
 			dir: func() migrate.Dir {
 				d, err := sqltool.NewLiquibaseDir("testdata/liquibase")


### PR DESCRIPTION
### Context
Invalid order migration files when sorting with filename
```
V1__.sql
V1.7__.sql
```
after sort
```
V1.7__.sql
V1__.sql
```
