### PR TITLE
chore: Use ldflag version in migrate_test.go in NoPendingFiles

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -879,7 +879,7 @@ env {
 			ProjectName:  "example",
 			DirName:      "migrations/v1/mysql",
 			EnvName:      "local",
-			AtlasVersion: "Atlas CLI - development",
+			AtlasVersion: operatorVersion(),
 			StartTime:    report.StartTime,
 			EndTime:      report.EndTime,
 			Files:        []cloudapi.DeployedFileInput{},


### PR DESCRIPTION
fixes https://github.com/ariga/atlas/issues/1709