### PR TITLE
schemahcl: fix panic in Type method

### DIFF
--- a/schemahcl/types.go
+++ b/schemahcl/types.go
@@ -266,6 +266,9 @@ func (r *TypeRegistry) Specs() []*TypeSpec {
 
 // Type converts a *schemahcl.Type into a schema.Type.
 func (r *TypeRegistry) Type(typ *Type, extra []*Attr) (schema.Type, error) {
+	if typ == nil {
+		return nil, errors.New("specutil: nil type")
+	}
 	typeSpec, ok := r.findT(typ.T)
 	if !ok {
 		return r.parser(typ.T)

--- a/sql/internal/spectest/spectest.go
+++ b/sql/internal/spectest/spectest.go
@@ -24,6 +24,8 @@ func RegistrySanityTest(t *testing.T, registry *schemahcl.TypeRegistry, skip []s
 			continue
 		}
 		t.Run(ts.Name, func(t *testing.T) {
+			_, err := registry.Type(nil, nil)
+			require.EqualError(t, err, "specutil: nil type")
 			spec := dummyType(t, ts)
 			styp, err := registry.Type(spec, nil)
 			require.NoError(t, err)


### PR DESCRIPTION
I encountered  nil pointer deference panic when using `mysql.EvalHCLBytes` func,
see  relevant stack trace part.