### PR TITLE
cmd/atlas: support for quoted identifiers in concurrent index creation

### DIFF
--- a/cmd/atlas/internal/sqlparse/pgparse/pgparse.go
+++ b/cmd/atlas/internal/sqlparse/pgparse/pgparse.go
@@ -6,6 +6,7 @@ package pgparse
 
 import (
 	"fmt"
+	"strconv"
 
 	"ariga.io/atlas/cmd/atlas/internal/sqlparse/parseutil"
 	"ariga.io/atlas/sql/migrate"
@@ -104,7 +105,11 @@ func (p *Parser) FixChange(_ migrate.Driver, s string, changes schema.Changes) (
 		if err != nil {
 			return nil, err
 		}
-		i := schema.Changes(modify.Changes).IndexAddIndex(stmt.Name.String())
+		name := stmt.Name.String()
+		if uname, err := strconv.Unquote(name); err == nil {
+			name = uname
+		}
+		i := schema.Changes(modify.Changes).IndexAddIndex(name)
 		if i == -1 {
 			return nil, fmt.Errorf("AddIndex %q command not found", stmt.Name)
 		}

--- a/cmd/atlas/internal/sqlparse/pgparse/pgparse_test.go
+++ b/cmd/atlas/internal/sqlparse/pgparse/pgparse_test.go
@@ -185,6 +185,23 @@ func TestFixChange_CreateIndexCon(t *testing.T) {
 		},
 		changes,
 	)
+	// Support quoted identifiers.
+	changes, err = p.FixChange(
+		nil,
+		`CREATE INDEX CONCURRENTLY "i1" ON t1 (c1)`,
+		schema.Changes{
+			&schema.ModifyTable{
+				T: schema.NewTable("t1"),
+				Changes: schema.Changes{
+					&schema.AddIndex{I: schema.NewIndex("i1")},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	m, ok := changes[0].(*schema.ModifyTable)
+	require.True(t, ok)
+	require.Equal(t, &postgres.Concurrently{}, m.Changes[0].(*schema.AddIndex).Extra[0])
 }
 
 func TestFixChange_RenameTable(t *testing.T) {


### PR DESCRIPTION
Fixed https://github.com/ariga/atlas/issues/1851