### PR TITLE
sql/mysql: compare table names with `strings.EqualFold`

### DIFF
--- a/sql/mysql/diff.go
+++ b/sql/mysql/diff.go
@@ -245,7 +245,7 @@ func (d *diff) FindTable(s *schema.Schema, name string) (*schema.Table, error) {
 	case 1, 2:
 		var matches []*schema.Table
 		for _, t := range s.Tables {
-			if strings.ToLower(name) == strings.ToLower(t.Name) {
+			if strings.EqualFold(name, t.Name) {
 				matches = append(matches, t)
 			}
 		}


### PR DESCRIPTION
Comparing two strings to the same case with `strings.ToLower` is more computational expensive than `strings.EqualFold`.

Sample benchmark:

```go
func BenchmarkToLower(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if strings.ToLower("FOOBAR") != strings.ToLower("foobar") {
			b.Fail()
		}
	}
}

func BenchmarkEqualFold(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if !strings.EqualFold("FOOBAR", "foobar") {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: ariga.io/atlas/sql/mysql
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkToLower-16      	 8139050	       126.4 ns/op	       8 B/op	       1 allocs/op
BenchmarkEqualFold-16    	149047072	         7.822 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	ariga.io/atlas/sql/mysql	3.174s
```