### PR TITLE
cmd/atlas: do not pass error to inspect template

### DIFF
--- a/cmd/atlas/internal/cmdapi/schema.go
+++ b/cmd/atlas/internal/cmdapi/schema.go
@@ -515,10 +515,12 @@ func schemaInspectRun(cmd *cobra.Command, _ []string, flags schemaInspectFlags) 
 		}
 	}
 	s, err := r.ReadState(ctx)
+	if err != nil {
+		return err
+	}
 	return format.Execute(cmd.OutOrStdout(), &cmdlog.SchemaInspect{
 		Client: client,
 		Realm:  s,
-		Error:  err,
 	})
 }
 

--- a/cmd/atlas/internal/cmdlog/cmdlog.go
+++ b/cmd/atlas/internal/cmdlog/cmdlog.go
@@ -524,7 +524,6 @@ func (c Changes) MarshalJSON() ([]byte, error) {
 type SchemaInspect struct {
 	*sqlclient.Client `json:"-"`
 	Realm             *schema.Realm `json:"Schema,omitempty"` // Inspected realm.
-	Error             error         `json:"Error,omitempty"`  // General error that occurred during inspection.
 }
 
 var (
@@ -537,7 +536,7 @@ var (
 	// SchemaInspectTemplate holds the default template of the 'schema inspect' command.
 	SchemaInspectTemplate = template.Must(template.New("inspect").
 				Funcs(InspectTemplateFuncs).
-				Parse(`{{ with .Error }}{{ .Error }}{{ else }}{{ $.MarshalHCL }}{{ end }}`))
+				Parse(`{{ $.MarshalHCL }}`))
 )
 
 // MarshalHCL returns the default HCL representation of the schema.
@@ -552,9 +551,6 @@ func (s *SchemaInspect) MarshalHCL() (string, error) {
 
 // MarshalJSON implements json.Marshaler.
 func (s *SchemaInspect) MarshalJSON() ([]byte, error) {
-	if s.Error != nil {
-		return json.Marshal(struct{ Error string }{s.Error.Error()})
-	}
 	type (
 		Column struct {
 			Name string `json:"name"`
@@ -657,9 +653,6 @@ func (s *SchemaInspect) MarshalSQL(indent ...string) (string, error) {
 }
 
 func sqlInspect(report *SchemaInspect, indent ...string) (string, error) {
-	if report.Error != nil {
-		return report.Error.Error(), nil
-	}
 	var changes schema.Changes
 	for _, s := range report.Realm.Schemas {
 		// Generate commands for creating the schemas on realm-mode.

--- a/cmd/atlas/internal/cmdlog/cmdlog_test.go
+++ b/cmd/atlas/internal/cmdlog/cmdlog_test.go
@@ -8,8 +8,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
-	"io"
 	"testing"
 	"text/template"
 
@@ -19,6 +17,7 @@ import (
 	"ariga.io/atlas/sql/sqlclient"
 	_ "ariga.io/atlas/sql/sqlite"
 
+	"github.com/fatih/color"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 )
@@ -96,11 +95,6 @@ func TestSchemaInspect_MarshalJSON(t *testing.T) {
     }
   ]
 }`, string(ident))
-
-	report = &cmdlog.SchemaInspect{Error: io.EOF}
-	b, err = report.MarshalJSON()
-	require.NoError(t, err)
-	require.Equal(t, `{"Error":"EOF"}`, string(b))
 }
 
 func TestSchemaInspect_MarshalSQL(t *testing.T) {
@@ -148,9 +142,6 @@ func TestSchemaInspect_EncodeSQL(t *testing.T) {
 	)
 	require.NoError(t, tmpl.Execute(&b, &cmdlog.SchemaInspect{Client: client, Realm: realm}))
 	require.Equal(t, "-- Create \"users\" table\nCREATE TABLE `users` (`id` int NOT NULL, `name` text NOT NULL);\n", b.String())
-	b.Reset()
-	require.NoError(t, tmpl.Execute(&b, &cmdlog.SchemaInspect{Error: errors.New("failure")}))
-	require.Equal(t, "failure", b.String())
 }
 
 func TestSchemaDiff_MarshalSQL(t *testing.T) {
@@ -178,6 +169,7 @@ func TestMigrateSet(t *testing.T) {
 		b   bytes.Buffer
 		log = &cmdlog.MigrateSet{}
 	)
+	color.NoColor = true
 	require.NoError(t, cmdlog.MigrateSetTemplate.Execute(&b, log))
 	require.Empty(t, b.String())
 


### PR DESCRIPTION
Printing errors in templates do not return exit code 1.