### PR TITLE
Remove executable bits in `os.WriteFile`

### DIFF
--- a/cmd/atlas/internal/cmdapi/vercheck/vercheck.go
+++ b/cmd/atlas/internal/cmdapi/vercheck/vercheck.go
@@ -100,7 +100,7 @@ func (v *VerChecker) Check(ver string) (*Payload, error) {
 		if err := os.MkdirAll(filepath.Dir(v.statePath), os.ModePerm); err != nil {
 			return nil, err
 		}
-		if err := os.WriteFile(v.statePath, st, os.ModePerm); err != nil {
+		if err := os.WriteFile(v.statePath, st, 0666); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/atlas/internal/cmdapi/vercheck/vercheck_test.go
+++ b/cmd/atlas/internal/cmdapi/vercheck/vercheck_test.go
@@ -82,7 +82,7 @@ func TestState(t *testing.T) {
 			t.Cleanup(srv.Close)
 			path := filepath.Join(t.TempDir(), "release.json")
 			if tt.state != "" {
-				err := os.WriteFile(path, []byte(tt.state), os.ModePerm)
+				err := os.WriteFile(path, []byte(tt.state), 0666)
 				require.NoError(t, err)
 			}
 			vc := New(srv.URL, path)


### PR DESCRIPTION
I've changed the file mode passed to `os.WriteFile` from 0777 to 0666.
That is, I've removed the executable bits, which are unnecessary and may lead to undesirable consequences.