### PR TITLE
sql/internal/sqlx: support cross-schema refs with same names

### DIFF
--- a/internal/integration/postgres_test.go
+++ b/internal/integration/postgres_test.go
@@ -559,11 +559,37 @@ func TestPostgres_HCL_ForeignKeyCrossSchema(t *testing.T) {
     on_delete   = NO_ACTION
   }
 }
+table "financial" "t" {
+  schema = schema.financial
+  column "t_id" {
+    null = false
+    type = uuid
+  }
+  primary_key {
+    columns = [column.t_id]
+  }
+  foreign_key "fk_t_id" {
+    columns     = [column.t_id]
+    ref_columns = [table.users.t.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+}
 table "financial" "users" {
   schema = schema.financial
   column "id" {
     null = false
     type = serial
+  }
+}
+table "users" "t" {
+  schema = schema.users
+  column "id" {
+    null = false
+    type = uuid
+  }
+  primary_key {
+    columns = [column.id]
   }
 }
 table "users" "users" {

--- a/sql/internal/sqlx/sqlx.go
+++ b/sql/internal/sqlx/sqlx.go
@@ -114,11 +114,14 @@ func SchemaFKs(s *schema.Schema, rows *sql.Rows) error {
 				OnUpdate: schema.ReferenceOption(updateRule),
 			}
 			switch {
-			case refTable == table:
-			case tSchema == refSchema:
+			// Self reference.
+			case tSchema == refSchema && refTable == table:
+			// Reference to the same schema.
+			case tSchema == refSchema && refTable != table:
 				if fk.RefTable, ok = s.Table(refTable); !ok {
 					fk.RefTable = &schema.Table{Name: refTable, Schema: s}
 				}
+			// Reference to an external schema.
 			case tSchema != refSchema:
 				fk.RefTable = &schema.Table{Name: refTable, Schema: &schema.Schema{Name: refSchema}}
 			}


### PR DESCRIPTION
Fixed #1973 