### PR TITLE
doc/md: fix small typo in eula url

### DIFF
--- a/doc/md/getting-started/getting-started.mdx
+++ b/doc/md/getting-started/getting-started.mdx
@@ -26,7 +26,7 @@ and by utilizing Atlas, they can plan, lint, and apply the necessary migrations 
 <InstallationInstructions />
 
 The default binaries distributed in official releases are released under the
-[Atlas EULA](https://ariga.io/legal/atlas/eila). If you would like obtain a copy of Atlas
+[Atlas EULA](https://ariga.io/legal/atlas/eula). If you would like obtain a copy of Atlas
 Community Edition (under an Apache 2 license) follow the instructions [here](/community-edition).
 
 ### Start a local database container


### PR DESCRIPTION
This PR fixes a small typo in the EULA url in the getting-started page.