### PR TITLE
doc/md: fixed wrong sample code for gorm guide

### DIFF
--- a/doc/md/guides/orms/gorm.md
+++ b/doc/md/guides/orms/gorm.md
@@ -129,7 +129,7 @@ import (
 )
 
 func main() {
-    stmts, err := gormschema.New("mysql", &models.User{}, &models.Pet{}).Load()
+    stmts, err := gormschema.New("mysql").Load(&models.User{}, &models.Pet{})
     if err != nil {
         fmt.Fprintf(os.Stderr, "failed to load gorm schema: %v\n", err)
         os.Exit(1)


### PR DESCRIPTION
# Background

https://atlasgo.io/guides/orms/gorm has the following sample code:

```go
func main() {
    stmts, err := gormschema.New("mysql", &models.User{}, &models.Pet{}).Load()
    if err != nil {
        fmt.Fprintf(os.Stderr, "failed to load gorm schema: %v\n", err)
        os.Exit(1)
    }
    io.WriteString(os.Stdout, stmts)
}
```

However, the syntax for `gormschema.New` only takes `String` as argument and the provided code would not compile.

# Fix

Changed sample code contents to match https://github.com/ariga/atlas-provider-gorm README
 