### PR TITLE
Build arm64 mysql and mariadb Docker images

### DIFF
--- a/.github/workflows/cd-docker-push-mysql_oss.yaml
+++ b/.github/workflows/cd-docker-push-mysql_oss.yaml
@@ -14,7 +14,23 @@ jobs:
   push-docker:
     strategy:
       matrix:
-        dialect: [ "mysql:latest", "mysql:5.6", "mysql:5.6.35", "mysql:5.7", "mysql:5.7.26", "mysql:8", "mariadb:latest", "mariadb:10.2", "mariadb:10.2.32", "mariadb:10.3", "mariadb:10.3.13", "mariadb:10.7"]
+        include:
+          - dialect: mysql:latest
+          - dialect: mysql:5.6
+            platforms: linux/amd64
+          - dialect: mysql:5.6.35
+            platforms: linux/amd64
+          - dialect: mysql:5.7
+            platforms: linux/amd64
+          - dialect: mysql:5.7.26
+            platforms: linux/amd64
+          - dialect: mysql:8
+          - dialect: mariadb:latest
+          - dialect: mariadb:10.2
+          - dialect: mariadb:10.2.32
+          - dialect: mariadb:10.3
+          - dialect: mariadb:10.3.13
+          - dialect: mariadb:10.7
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -30,5 +46,6 @@ jobs:
           file: ./.github/ops/mysql/Dockerfile
           push: true
           tags: arigaio/${{ matrix.dialect }}
-          build-args:
+          platforms: ${{ matrix.platforms || 'linux/amd64,linux/arm64' }}
+          build-args: |
             DIALECT=${{ matrix.dialect }}

--- a/.github/workflows/cd-docker-push-mysql_oss.yaml
+++ b/.github/workflows/cd-docker-push-mysql_oss.yaml
@@ -39,6 +39,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Build & Push ${{ matrix.dialect }} Docker Image
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Closes #1997 

This PR builds `arm64` Docker images for mysql and mariadb, excluding the mysql image versions that don't have an upstream arm64 base image.