### PR TITLE
.github/ops/mysql: fix Dockerfile builds, fix mariadb:latest

### DIFF
--- a/.github/ops/mysql/Dockerfile
+++ b/.github/ops/mysql/Dockerfile
@@ -2,11 +2,12 @@ ARG DIALECT=mysql:8.0
 
 FROM $DIALECT as builder
 
+ARG SERVER=mysqld
 ENV MYSQL_ROOT_PASSWORD=pass
 
 # Remove the last line of the entry point script, leaving the initialization code but omitting actually starting the db.
-RUN ["sed", "-i", "s/exec \"$@\"/echo \"not running $@\"/", "/usr/local/bin/docker-entrypoint.sh"]
-RUN ["/usr/local/bin/docker-entrypoint.sh", "mysqld", "--datadir", "/initialized-db"]
+RUN sed -i 's/exec "$@"/echo "not running $@"/' /usr/local/bin/docker-entrypoint.sh
+RUN /usr/local/bin/docker-entrypoint.sh ${SERVER} --datadir /initialized-db
 
 FROM $DIALECT
 

--- a/.github/workflows/cd-docker-push-mysql_oss.yaml
+++ b/.github/workflows/cd-docker-push-mysql_oss.yaml
@@ -3,7 +3,7 @@ on:
   push:
     paths:
       - .github/ops/mysql/**
-      - .github/workflows/cd-push-docker-mysql.yaml
+      - .github/workflows/cd-docker-push-mysql_oss.yaml
     branches:
       - master
   schedule:
@@ -26,6 +26,7 @@ jobs:
             platforms: linux/amd64
           - dialect: mysql:8
           - dialect: mariadb:latest
+            build-args: SERVER=mariadbd
           - dialect: mariadb:10.2
           - dialect: mariadb:10.2.32
           - dialect: mariadb:10.3
@@ -53,3 +54,4 @@ jobs:
           platforms: ${{ matrix.platforms || 'linux/amd64,linux/arm64' }}
           build-args: |
             DIALECT=${{ matrix.dialect }}
+            ${{ matrix.build-args }}


### PR DESCRIPTION
Followup from #1998, this fixes two issues with the current workflow:

1. The workflow filename has changed, so builds aren't triggered on merge anymore
2. The `mariadb:latest` image does not have `mysqld`, so this adds a new build arg to override to `mariadbd` for that image build. This unblocks the regular cron builds.