### PR TITLE
Don't fail all Docker image builds on single failure, pre-create initialized-db

### DIFF
--- a/.github/ops/mysql/Dockerfile
+++ b/.github/ops/mysql/Dockerfile
@@ -7,6 +7,7 @@ ENV MYSQL_ROOT_PASSWORD=pass
 
 # Remove the last line of the entry point script, leaving the initialization code but omitting actually starting the db.
 RUN sed -i 's/exec "$@"/echo "not running $@"/' /usr/local/bin/docker-entrypoint.sh
+RUN mkdir -p /initialized-db && chown -R mysql:mysql /initialized-db
 RUN /usr/local/bin/docker-entrypoint.sh ${SERVER} --datadir /initialized-db
 
 FROM $DIALECT

--- a/.github/workflows/cd-docker-push-mysql_oss.yaml
+++ b/.github/workflows/cd-docker-push-mysql_oss.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   push-docker:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - dialect: mysql:latest


### PR DESCRIPTION
Third time's the charm maybe 🙂 

Followup to #2001, this fixes two more issues:

1. Pre-create the `initialized-db` dir with the correct user
2. Don't fail all builds if a single one fails

cc @giautm 