### PR TITLE
Fix generation of initialized DB in Dockerfile

### DIFF
--- a/.github/ops/mysql/Dockerfile
+++ b/.github/ops/mysql/Dockerfile
@@ -7,9 +7,8 @@ ENV MYSQL_ROOT_PASSWORD=pass
 
 # Remove the last line of the entry point script, leaving the initialization code but omitting actually starting the db.
 RUN sed -i 's/exec "$@"/echo "not running $@"/' /usr/local/bin/docker-entrypoint.sh
-RUN mkdir -p /initialized-db && chown -R mysql:mysql /initialized-db
-RUN /usr/local/bin/docker-entrypoint.sh ${SERVER} --datadir /initialized-db
+RUN /usr/local/bin/docker-entrypoint.sh ${SERVER}
 
 FROM $DIALECT
 
-COPY --from=builder ./initialized-db /var/lib/mysql/
+COPY --from=builder /var/lib/mysql /var/lib/mysql


### PR DESCRIPTION
Followup to #2003.

I was able to get this to work through some trial and error at https://github.com/jacobwgillespie/atlas-dockerfile-repro. Rather than overriding the `datadir`, which for some reason isn't working as expected when building in GitHub Actions, this PR updates the Dockerfile to just run the server once, then copy `/var/lib/mysql` to the final image.

This is successfully building at the test repo above.

cc @giautm 