### PR TITLE
feat/Table Inheritance (Mixins)

### DIFF
--- a/doc/md/atlas-schema/hcl.mdx
+++ b/doc/md/atlas-schema/hcl.mdx
@@ -207,6 +207,59 @@ table "b" "users" {
 }
 ```
 
+## Mixin
+
+In order to avoid code duplication, Atlas supports mixins. A mixin is a set of table properties that can be included in
+other tables. Mixins are defined using the `mixin` block, and they can be included in other tables using the `embed`
+statement.
+
+```hcl
+schema "a" {}
+
+table "a" "users" {
+  schema = schema.a
+  embed = mixin.base
+}
+
+mixin "base" {
+  column "id" {
+    type = int
+  }
+  column "created_at" {
+    type = timestamp
+    default = now()
+  }
+}
+```
+
+Multiple Mixins can be embedded in a table.
+
+```hcl
+schema "a" {}
+
+table "a" "users" {
+  schema = schema.a
+  embed = [mixin.base, mixin.deletable]
+}
+
+mixin "base" {
+  column "id" {
+    type = int
+  }
+  column "created_at" {
+    type = timestamp
+    default = now()
+  }
+}
+
+mixin "deletable" {
+  column "deleted_at" {
+    type = timestamp
+    null = true
+  }
+}
+```
+
 ## View
 
 A `view` is a virtual table in the database, defined by a statement that queries rows from one or more existing

--- a/schemahcl/context.go
+++ b/schemahcl/context.go
@@ -399,12 +399,14 @@ const (
 	BlockData     = "data"
 	BlockLocals   = "locals"
 	BlockVariable = "variable"
+	BlockMixin    = "mixin"
 	RefData       = "data"
 	RefVar        = "var"
 	RefLocal      = "local"
 	AttrName      = "name"
 	forEachAttr   = "for_each"
 	eachRef       = "each"
+	embedAttr     = "embed"
 )
 
 // Variables represents the dynamic variables used in a body.

--- a/schemahcl/mixin.go
+++ b/schemahcl/mixin.go
@@ -31,7 +31,6 @@ func (s *State) applyMixin(b *hclsyntax.Block, mixins map[string]*hclsyntax.Bloc
 		if err := mergeBlocks(b, mixin); err != nil {
 			return err
 		}
-		mergeAttributes(b, mixin)
 	}
 
 	delete(b.Body.Attributes, embedAttr)
@@ -136,12 +135,4 @@ func mergeAttributeValue(existingBlock *hclsyntax.Block, k string, valuesToAdd *
 		return nil
 	}
 	return fmt.Errorf("schemahcl: failed to merge attributes: %w", errors.New("invalid source attribute type"))
-}
-
-func mergeAttributes(b *hclsyntax.Block, mixin *hclsyntax.Block) {
-	for k, v := range mixin.Body.Attributes {
-		if _, ok := b.Body.Attributes[k]; !ok {
-			b.Body.Attributes[k] = v
-		}
-	}
 }

--- a/schemahcl/mixin.go
+++ b/schemahcl/mixin.go
@@ -1,0 +1,147 @@
+package schemahcl
+
+import (
+	"errors"
+	"fmt"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (s *State) applyMixin(b *hclsyntax.Block, mixins map[string]*hclsyntax.Block) error {
+	if b.Body == nil || b.Body.Attributes == nil {
+		return nil
+	}
+
+	embedAttribute, ok := b.Body.Attributes[embedAttr]
+	if !ok {
+		return nil
+	}
+
+	mixinsToApply, err := getMixinNames(embedAttribute)
+	if err != nil {
+		return err
+	}
+
+	for _, mixinName := range mixinsToApply {
+		mixin, ok := mixins[mixinName]
+		if !ok {
+			return nil
+		}
+
+		if err := mergeBlocks(b, mixin); err != nil {
+			return err
+		}
+		mergeAttributes(b, mixin)
+	}
+
+	delete(b.Body.Attributes, embedAttr)
+	return nil
+}
+
+func getMixinNames(embedAttribute *hclsyntax.Attribute) ([]string, error) {
+	if expr, ok := embedAttribute.Expr.(*hclsyntax.ScopeTraversalExpr); ok {
+		return []string{expr.Traversal[1].(hcl.TraverseAttr).Name}, nil
+	} else if expr, ok := embedAttribute.Expr.(*hclsyntax.TupleConsExpr); ok {
+		names := make([]string, 0, len(expr.Exprs))
+		for _, expression := range expr.Exprs {
+			if expr, ok := expression.(*hclsyntax.ScopeTraversalExpr); ok {
+				names = append(names, expr.Traversal[1].(hcl.TraverseAttr).Name)
+			}
+		}
+		return names, nil
+	}
+
+	return nil, fmt.Errorf("schemahcl: failed to get mixin names: %w", errors.New("invalid mixin attribute type"))
+}
+
+func mergeBlocks(b *hclsyntax.Block, mixin *hclsyntax.Block) error {
+	for _, blk := range mixin.Body.Blocks {
+		switch blk.Type {
+		case "column":
+			b.Body.Blocks = append(b.Body.Blocks, blk)
+		default:
+			err := mergeSingleBlock(b, blk)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func mergeSingleBlock(b *hclsyntax.Block, blk *hclsyntax.Block) error {
+	existingBlock := getExistingBlock(b, blk.Type)
+
+	if existingBlock == nil {
+		b.Body.Blocks = append(b.Body.Blocks, blk)
+		return nil
+	}
+
+	return mergeAttributesOfBlock(existingBlock, blk)
+}
+
+func getExistingBlock(b *hclsyntax.Block, blkType string) *hclsyntax.Block {
+	for _, block := range b.Body.Blocks {
+		if block.Type == blkType {
+			return block
+		}
+	}
+	return nil
+}
+
+func mergeAttributesOfBlock(existingBlock, blk *hclsyntax.Block) error {
+	for k, v := range blk.Body.Attributes {
+		if _, ok := existingBlock.Body.Attributes[k]; !ok {
+			existingBlock.Body.Attributes[k] = v
+			continue
+		}
+
+		valuesToAdd, err := getValuesToAdd(v)
+		if err != nil {
+			return err
+		}
+
+		if err := mergeAttributeValue(existingBlock, k, valuesToAdd); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getValuesToAdd(v *hclsyntax.Attribute) (*hclsyntax.TupleConsExpr, error) {
+	if vTuple, ok := v.Expr.(*hclsyntax.TupleConsExpr); ok {
+		return vTuple, nil
+	} else if vSingle, ok := v.Expr.(*hclsyntax.ScopeTraversalExpr); ok {
+		return &hclsyntax.TupleConsExpr{
+			Exprs:     []hclsyntax.Expression{vSingle},
+			SrcRange:  vSingle.SrcRange,
+			OpenRange: vSingle.SrcRange,
+		}, nil
+	}
+	return nil, fmt.Errorf("schemahcl: failed to merge attributes: %w", errors.New("invalid mixin attribute type"))
+}
+
+func mergeAttributeValue(existingBlock *hclsyntax.Block, k string, valuesToAdd *hclsyntax.TupleConsExpr) error {
+	attr := existingBlock.Body.Attributes[k]
+	if attrTuple, ok := attr.Expr.(*hclsyntax.TupleConsExpr); ok {
+		attr.Expr.(*hclsyntax.TupleConsExpr).Exprs = append(attrTuple.Exprs, valuesToAdd.Exprs...)
+		return nil
+	} else if attrSingle, ok := attr.Expr.(*hclsyntax.ScopeTraversalExpr); ok {
+		attr.Expr = &hclsyntax.TupleConsExpr{
+			Exprs:     []hclsyntax.Expression{attrSingle},
+			SrcRange:  attrSingle.SrcRange,
+			OpenRange: attrSingle.SrcRange,
+		}
+		attr.Expr.(*hclsyntax.TupleConsExpr).Exprs = append(attrTuple.Exprs, valuesToAdd.Exprs...)
+		return nil
+	}
+	return fmt.Errorf("schemahcl: failed to merge attributes: %w", errors.New("invalid source attribute type"))
+}
+
+func mergeAttributes(b *hclsyntax.Block, mixin *hclsyntax.Block) {
+	for k, v := range mixin.Body.Attributes {
+		if _, ok := b.Body.Attributes[k]; !ok {
+			b.Body.Attributes[k] = v
+		}
+	}
+}

--- a/schemahcl/schemahcl.go
+++ b/schemahcl/schemahcl.go
@@ -281,6 +281,7 @@ func (s *State) Eval(parsed *hclparse.Parser, v any, input map[string]cty.Value)
 			return err
 		}
 		blocks := make(hclsyntax.Blocks, 0, len(body.Blocks))
+		mixins := make(map[string]*hclsyntax.Block)
 		for _, b := range body.Blocks {
 			switch {
 			// Variable blocks are not reachable by reference.
@@ -293,11 +294,20 @@ func (s *State) Eval(parsed *hclparse.Parser, v any, input map[string]cty.Value)
 					return err
 				}
 				blocks = append(blocks, nb...)
+			case b.Type == BlockMixin:
+				mixins[b.Labels[len(b.Labels)-1]] = b
 			default:
 				blocks = append(blocks, b)
 			}
+		}
+		for _, b := range blocks {
+			err := s.applyMixin(b, mixins)
+			if err != nil {
+				return err
+			}
 			reg.child(extractDef(b, reg))
 		}
+
 		body.Blocks = blocks
 		allBlocks = append(allBlocks, blocks...)
 	}


### PR DESCRIPTION
Fixes #1317. 

Mixins are implemented as a new block to the HCL schema, and when parsed are merged with the tables which embed them.

Example Schema:
```hcl
schema "a" {}

table "a" "users" {
  schema = schema.a
  embed = mixin.base
}

mixin "base" {
  column "id" {
    type = int
  }
  column "created_at" {
    type = timestamp
    default = now()
  }
}
```
Is exactly equivalent to:
```hcl
schema "a" {}

table "a" "users" {
  schema = schema.a
  column "id" {
    type = int
  }
  column "created_at" {
    type = timestamp
    default = now()
  }
}
```

---
DISCUSSION: with this change, we've introduced a HCL-only abstraction as Mixins are not represented in the database. Thereby if a user applied this diff, and then inspected the database the generated hcl will be different. Is this acceptable? Or should we store mixins in an atlas table (e.g. `atlas_mixins`), so on Inspect we can retrieve the user's configured mixins?