### PR TITLE
cmd/atlas/internal: pass configured client to context setter

### DIFF
--- a/cmd/atlas/internal/cmdapi/cmdapi_oss.go
+++ b/cmd/atlas/internal/cmdapi/cmdapi_oss.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"text/template"
 
+	"ariga.io/atlas/cmd/atlas/internal/cloudapi"
 	cmdmigrate "ariga.io/atlas/cmd/atlas/internal/migrate"
 	"ariga.io/atlas/cmd/atlas/internal/migratelint"
 	"ariga.io/atlas/sql/migrate"
@@ -125,6 +126,6 @@ func promptApply(cmd *cobra.Command,
 }
 
 // withTokenContext allows attaching token to the context.
-func withTokenContext(ctx context.Context, _ string) (context.Context, error) {
+func withTokenContext(ctx context.Context, _ string, _ *cloudapi.Client) (context.Context, error) {
 	return ctx, nil
 }

--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -802,6 +802,8 @@ func TestMigrate_ApplyCloudReport(t *testing.T) {
 			}
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&m))
 			switch {
+			case strings.Contains(m.Query, "query") && strings.Contains(m.Query, "bot"):
+				fmt.Fprintln(w, `{"data": {"me":{ "name": "a8m", "org": "graph"}}}`)
 			case strings.Contains(m.Query, "query"):
 				// Checksum before archiving.
 				hf, err := dir.Checksum()
@@ -1001,6 +1003,8 @@ func TestMigrate_ApplyCloudReportSet(t *testing.T) {
 			}
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&m))
 			switch {
+			case strings.Contains(m.Query, "query") && strings.Contains(m.Query, "bot"):
+				fmt.Fprintln(w, `{"data": {"me":{ "name": "a8m", "org": "graph"}}}`)
 			case strings.Contains(m.Query, "query"):
 				// Checksum before archiving.
 				hf, err := dir.Checksum()

--- a/cmd/atlas/internal/cmdapi/project.go
+++ b/cmd/atlas/internal/cmdapi/project.go
@@ -357,8 +357,8 @@ func EnvByName(cmd *cobra.Command, name string, opts ...LoadOption) (*Project, [
 	}
 	// The project token predates 'atlas login' command. If exists,
 	// attach it to the context to indicate the user is authenticated.
-	if t := project.cfg.Token; t != "" {
-		ctx, err := withTokenContext(cmd.Context(), t)
+	if project.cfg.Token != "" && project.cfg.Client != nil {
+		ctx, err := withTokenContext(cmd.Context(), project.cfg.Token, project.cfg.Client)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
The `url` is an optional parameter of the `cloud` block, making it possible to configure the target server.