### PR TITLE
sql/postgres: fix panic in postgres DefaultDiffer func

### DIFF
--- a/sql/postgres/diff.go
+++ b/sql/postgres/diff.go
@@ -21,7 +21,7 @@ import (
 // DefaultDiff provides basic diffing capabilities for PostgreSQL dialects.
 // Note, it is recommended to call Open, create a new Driver and use its Differ
 // when a database connection is available.
-var DefaultDiff schema.Differ = &sqlx.Diff{DiffDriver: &diff{}}
+var DefaultDiff schema.Differ = &sqlx.Diff{DiffDriver: &diff{&conn{ExecQuerier: sqlx.NoRows}}}
 
 // A diff provides a PostgreSQL implementation for sqlx.DiffDriver.
 type diff struct{ *conn }


### PR DESCRIPTION
I encounter panic in row 149
![image](https://github.com/ariga/atlas/assets/63970571/9c38da00-d44c-4051-940f-141b926d81b0)
