### PR TITLE
sql: add support for materialized views in sqlspec

### DIFF
--- a/sql/schema/dsl.go
+++ b/sql/schema/dsl.go
@@ -231,6 +231,12 @@ func NewView(name, def string) *View {
 	return &View{Name: name, Def: def}
 }
 
+// NewMaterializedView creates a new materialized View.
+func NewMaterializedView(name, def string) *View {
+	return NewView(name, def).
+		SetMaterialized(true)
+}
+
 // SetSchema sets the schema (named-database) of the view.
 func (v *View) SetSchema(s *Schema) *View {
 	v.Schema = s

--- a/sql/sqlspec/sqlspec.go
+++ b/sql/sqlspec/sqlspec.go
@@ -120,6 +120,7 @@ func (v *View) SchemaRef() *schemahcl.Ref { return v.Schema }
 
 func init() {
 	schemahcl.Register("view", &View{})
+	schemahcl.Register("materialized", &View{})
 	schemahcl.Register("table", &Table{})
 	schemahcl.Register("schema", &Schema{})
 }


### PR DESCRIPTION
Adding another type to HCL, `materialized`. The reason we don't use `view` is that, in different databases (PostgreSQL, MSSQL, DB2, etc.), these two don't have the same set of attributes and we want our LSP to enforce type safety without executing custom logic.