### PR TITLE
cmd/atlas: pass correct command context to log templates

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -195,7 +195,7 @@ func migrateApplyRun(cmd *cobra.Command, args []string, flags migrateApplyFlags,
 		return err
 	}
 	// Setup reporting info.
-	report := cmdlog.NewMigrateApply(client, dir)
+	report := cmdlog.NewMigrateApply(ctx, client, dir)
 	mr.Init(client, report, mrrw)
 	// If cloud reporting is enabled, and we cannot obtain the current
 	// target identifier, abort and report it to the user.
@@ -1115,7 +1115,7 @@ func migrateSetRun(cmd *cobra.Command, args []string, flags migrateSetFlags) (re
 	default:
 		return fmt.Errorf("accepts 1 arg(s), received %d", n)
 	}
-	log := &cmdlog.MigrateSet{}
+	log := &cmdlog.MigrateSet{Context: ctx}
 	for _, r := range revs {
 		// Check all existing revisions and ensure they precede the given version. If we encounter a partially
 		// applied revision, or one with errors, mark them "fixed".

--- a/cmd/atlas/internal/cmdapi/schema.go
+++ b/cmd/atlas/internal/cmdapi/schema.go
@@ -204,7 +204,7 @@ func schemaApplyRun(cmd *cobra.Command, flags schemaApplyFlags, env *Env) error 
 		} else {
 			cause = &cmdlog.StmtError{Text: err.Error()}
 		}
-		err1 := format.Execute(out, cmdlog.NewSchemaApply(cmdlog.NewEnv(client, nil), plan.Changes[:applied], plan.Changes[applied:], cause))
+		err1 := format.Execute(out, cmdlog.NewSchemaApply(ctx, cmdlog.NewEnv(client, nil), plan.Changes[:applied], plan.Changes[applied:], cause))
 		return errors.Join(err, err1)
 	default:
 		switch err := summary(cmd, client, changes, format); {
@@ -417,6 +417,7 @@ func schemaDiffRun(cmd *cobra.Command, _ []string, flags schemaDiffFlags, env *E
 	}
 	return format.Execute(cmd.OutOrStdout(), &cmdlog.SchemaDiff{
 		Client:  c,
+		Context: ctx,
 		From:    diff.from,
 		To:      diff.to,
 		Changes: diff.changes,
@@ -521,8 +522,9 @@ func schemaInspectRun(cmd *cobra.Command, _ []string, flags schemaInspectFlags) 
 		return err
 	}
 	return format.Execute(cmd.OutOrStdout(), &cmdlog.SchemaInspect{
-		Client: client,
-		Realm:  s,
+		Client:  client,
+		Context: ctx,
+		Realm:   s,
 	})
 }
 
@@ -693,7 +695,7 @@ func summary(cmd *cobra.Command, c *sqlclient.Client, changes []schema.Change, t
 	}
 	return t.Execute(
 		cmd.OutOrStdout(),
-		cmdlog.NewSchemaPlan(cmdlog.NewEnv(c, nil), p.Changes, nil),
+		cmdlog.NewSchemaPlan(cmd.Context(), cmdlog.NewEnv(c, nil), p.Changes, nil),
 	)
 }
 


### PR DESCRIPTION
Avoid using context background in templates 