### PR TITLE
sql/migrate: skip non-standard #-based comments inside parens

### DIFF
--- a/sql/migrate/testdata/lex/6_skip_comment.sql
+++ b/sql/migrate/testdata/lex/6_skip_comment.sql
@@ -24,3 +24,10 @@ CREATE TABLE t5(
     /* comment */
     -- comment
 ) ENGINE=InnoDB;
+
+# MySQL comment.
+CREATE INDEX "i" ON "s"."t" (((c #>> '{a,b,c}'::text[])));
+
+SELECT * FROM (
+  SELECT * FROM t1 # comment
+);

--- a/sql/migrate/testdata/lex/6_skip_comment.sql.golden
+++ b/sql/migrate/testdata/lex/6_skip_comment.sql.golden
@@ -15,3 +15,9 @@ CREATE TABLE t5(
     /* comment */
     -- comment
 ) ENGINE=InnoDB;
+-- end --
+CREATE INDEX "i" ON "s"."t" (((c #>> '{a,b,c}'::text[])));
+-- end --
+SELECT * FROM (
+  SELECT * FROM t1 # comment
+);


### PR DESCRIPTION
Next steps are two make the lexer driver-aware and move its config to the drivers