### PR TITLE
Add support for postgis in --dev-url

### DIFF
--- a/cmd/atlas/internal/docker/docker_test.go
+++ b/cmd/atlas/internal/docker/docker_test.go
@@ -99,4 +99,16 @@ func TestFromURL(t *testing.T) {
 		Port:     "5432",
 		Out:      io.Discard,
 	}, cfg)
+
+	u, err = url.Parse("docker://postgis/14-3.4")
+	require.NoError(t, err)
+	cfg, err = FromURL(u)
+	require.NoError(t, err)
+	require.Equal(t, &Config{
+		Image:    "postgis/postgis:14-3.4",
+		Database: "postgres",
+		Env:      []string{"POSTGRES_PASSWORD=pass"},
+		Port:     "5432",
+		Out:      io.Discard,
+	}, cfg)
 }


### PR DESCRIPTION
Postgis is a commonly used GIS extension for Postgres and ships with its own published Docker images. Everything about Atlas works except for image name parsing for the Postgis images. This PR adds support for Postgis in the URL scheme.