### PR TITLE
docs: use correct gitops link

### DIFF
--- a/doc/md/guides/deploying/k8s-argo.md
+++ b/doc/md/guides/deploying/k8s-argo.md
@@ -4,7 +4,7 @@ title: Deploying to Kubernetes with the Atlas Operator and Argo CD
 slug: /guides/deploying/k8s-argo
 ---
 
-[GitOps](https://www.gitops.tech/) is a software development and deployment methodology that uses Git as the central repository
+[GitOps](https://opengitops.dev/) is a software development and deployment methodology that uses Git as the central repository
 for both code and infrastructure configurations, enabling automated and auditable deployments.
 
 [ArgoCD](https://argoproj.github.io/cd/) is a Kubernetes-native continuous delivery tool that implements GitOps principles.

--- a/doc/md/guides/deploying/k8s-flux.md
+++ b/doc/md/guides/deploying/k8s-flux.md
@@ -4,7 +4,7 @@ title: Deploying to Kubernetes with the Atlas Operator and Flux CD
 slug: /guides/deploying/k8s-flux
 ---
 
-[GitOps](https://www.gitops.tech/) is a software development and deployment methodology that uses Git as the central repository
+[GitOps](https://opengitops.dev/) is a software development and deployment methodology that uses Git as the central repository
 for both code and infrastructure configurations, enabling automated and auditable deployments.
 
 [FluxCD](https://fluxcd.io/) is a Continuous Delivery tool that implements GitOps principles. It uses a declarative approach


### PR DESCRIPTION
gitops.tech is just a landing page for a commercial book

The correct page of the gitops working group is opengitops.dev