### PR TITLE
cmd/atlas/internal/docker: allow custom images in docker driver

### DIFF
--- a/doc/md/concepts/dev.mdx
+++ b/doc/md/concepts/dev.mdx
@@ -21,11 +21,29 @@ a special [docker driver](concepts/url.mdx).
 
 ```shell
 # When working on a single database schema.
---dev-url "docker://mysql/8/schema"
+--dev-url "docker://mysql/8/dev"
 
 # When working on multiple database schemas.
 --dev-url "docker://mysql/8"
 ```
+
+To work with a custom Docker image, use one of the following formats:
+
+```shell
+# When working on a single database schema.
+docker+mysql://org/image/dev
+docker+mysql://user/image:tag/dev
+# For local/official images, leave host empty or use "_".
+docker+mysql:///local/dev
+docker+mysql://_/mariadb:latest/dev
+
+# When working on multiple database schemas.
+docker+mysql://local
+docker+mysql://org/image
+docker+mysql://user/image:tag
+docker+mysql://_/mariadb:latest
+```
+
 </TabItem>
 <TabItem value="mariadb" label="MariaDB">
 
@@ -35,6 +53,23 @@ a special [docker driver](concepts/url.mdx).
 
 # When working on multiple database schemas.
 --dev-url "docker://maria/latest"
+```
+
+To work with a custom Docker image, use one of the following formats:
+
+```shell
+# When working on a single database schema.
+docker+maria://org/image/dev
+docker+maria://user/image:tag/dev
+# For local/official images, leave host empty or use "_".
+docker+maria:///local/dev
+docker+maria://_/mysql:latest/dev
+
+# When working on multiple database schemas.
+docker+maria://local
+docker+maria://org/image
+docker+maria://user/image:tag
+docker+maria://_/mariadb:latest
 ```
 
 </TabItem>
@@ -47,6 +82,22 @@ a special [docker driver](concepts/url.mdx).
 
 # When working on multiple database schemas.
 --dev-url "docker://postgres/15/dev"
+```
+
+To work with a custom Docker image, use one of the following formats:
+
+```shell
+# When working on a single database schema.
+docker+postgres://org/image/dev?search_path=public
+docker+postgres://ghcr.io/namespace/image:tag/dev?search_path=public
+# For local/official images, leave host empty or use "_".
+docker+postgres://_/local/dev?search_path=public
+docker+postgres://_/official:latest/dev?search_path=public
+
+# When working on multiple database schemas.
+docker+postgres://org/image/dev
+# Default database is "postgres".
+docker+postgres://org/image:tag
 ```
 
 </TabItem>


### PR DESCRIPTION
Fixed https://github.com/ariga/atlas/issues/1678
- Support custom docker images
- Remove the implicit "docker pull" 


For example:

```shell
$ atlas schema inspect \
  -u file://schema.sql \
  --dev-url "docker+postgres://ankane/pgvector/dev"

table "t" {
  schema = schema.public
  column "c" {
    null = true
    type = integer
  }
}
schema "public" {
  comment = "standard public schema"
}
```
```shell
$ atlas schema inspect \
  -u file://schema.sql \
  --dev-url "docker+postgres://ankane/pgvector/dev?search_path=public" \
  --format="{{ sql . \"  \" }}"

-- Create "t" table
CREATE TABLE "t" (
  "c" integer NULL
);
```
