### PR TITLE
cmd/atlas/internal/cmdapi: support reference env:// attributes

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -645,7 +645,7 @@ func migrateDiffRun(cmd *cobra.Command, args []string, flags migrateDiffFlags, e
 		return maskNoPlan(cmd, err)
 	}
 	// Get a state reader for the desired state.
-	desired, err := stateReader(ctx, &stateReaderConfig{
+	desired, err := stateReader(ctx, env, &stateReaderConfig{
 		urls:    flags.desiredURLs,
 		dev:     dev,
 		client:  dev,

--- a/doc/md/declarative/diff.mdx
+++ b/doc/md/declarative/diff.mdx
@@ -479,6 +479,137 @@ atlas schema diff \
 </TabItem>
 </Tabs>
 
+### Compare external schemas
+
+The `schema diff` command can also be used to compare external schemas defined in data sources, such as ORM schemas,
+with a database, HCL or SQL schemas, or even with other ORM schemas.
+
+<Tabs
+defaultValue="mysql"
+values={[
+{label: 'MySQL', value: 'mysql'},
+{label: 'PostgreSQL', value: 'postgres'},
+{label: 'SQLite', value: 'sqlite'},
+]}>
+<TabItem value="mysql">
+
+```hcl
+data "external_schema" "gorm" {
+  program = [
+    "go", "run", "-mod=mod",
+    "ariga.io/atlas-provider-gorm",
+    "load",
+    "--path", "./path/to/models",
+    "--dialect", "mysql",
+  ]
+}
+
+data "external_schema" "sequelize" {
+  program = [
+    "npx",
+    "@ariga/atlas-provider-sequelize",
+    "load",
+    "--path", "./path/to/models",
+    "--dialect", "mysql",
+  ]
+}
+
+env "drift" {
+  dev = "docker://mysql/8/dev"
+  # Variables defined and available with env:// prefix.
+  gorm       = data.hcl_schema.gorm.url
+  sequelize  = data.hcl_schema.sequelize.url
+}
+```
+
+```shell
+atlas schema diff \
+  --env "drift" \
+  --from "env://gorm" \
+  --to "env://sequelize"
+```
+
+</TabItem>
+<TabItem value="postgres">
+
+```hcl
+data "external_schema" "gorm" {
+  program = [
+    "go", "run", "-mod=mod",
+    "ariga.io/atlas-provider-gorm",
+    "load",
+    "--path", "./path/to/models",
+    "--dialect", "postgres",
+  ]
+}
+
+data "external_schema" "sequelize" {
+  program = [
+    "npx",
+    "@ariga/atlas-provider-sequelize",
+    "load",
+    "--path", "./path/to/models",
+    "--dialect", "postgres",
+  ]
+}
+
+env "drift" {
+  dev = "docker://postgres/15/dev?search_path=public"
+  # Variables defined and available with env:// prefix.
+  gorm       = data.hcl_schema.gorm.url
+  sequelize  = data.hcl_schema.sequelize.url
+}
+```
+
+```shell
+atlas schema diff \
+  --env "drift" \
+  --from "env://gorm" \
+  --to "env://sequelize"
+```
+
+</TabItem>
+<TabItem value="sqlite">
+
+```hcl
+data "external_schema" "gorm" {
+  program = [
+    "go", "run", "-mod=mod",
+    "ariga.io/atlas-provider-gorm",
+    "load",
+    "--path", "./path/to/models",
+    "--dialect", "sqlite",
+  ]
+}
+
+data "external_schema" "sequelize" {
+  program = [
+    "npx",
+    "@ariga/atlas-provider-sequelize",
+    "load",
+    "--path", "./path/to/models",
+    "--dialect", "sqlite",
+  ]
+}
+
+env "drift" {
+  dev = "sqlite://dev?mode=memory"
+  # Variables defined and available with env:// prefix.
+  gorm       = data.hcl_schema.gorm.url
+  sequelize  = data.hcl_schema.sequelize.url
+}
+```
+
+```shell
+atlas schema diff \
+  --env "drift" \
+  --from "env://gorm" \
+  --to "env://sequelize"
+```
+
+</TabItem>
+</Tabs>
+
 ### Indented SQL
 
 The `schema diff` command outputs a list of SQL statements without indentation by default. If you would like to view


### PR DESCRIPTION
Added support for the `env://` scheme, which allows for referencing attributes from the selected/current environment.

```shell
atlas schema diff --env drift --from env://state1 --to env://state2

atlas migrate diff --env dev --to env://state1
```

In the future, we can also add support for something like this `flags` block:

```hcl
env {
  flags {
    schema {
      from = "..."
      to   = "..."
    }
  }
}
```