### PR TITLE
Fixes a bug when rendering multi-word types in Mermaid ERDs

### DIFF
--- a/cmd/atlas/internal/cmdlog/cmdlog.go
+++ b/cmd/atlas/internal/cmdlog/cmdlog.go
@@ -318,7 +318,7 @@ Migrating to version {{ cyan .Target }}{{ with .Current }} from {{ cyan . }}{{ e
   {{ yellow "--" }} {{ dec $files }} migrations ok (1 with errors)
   {{ yellow "--" }} {{ dec $stmts }} sql statements ok (1 with errors)
 {{- else }}
-  {{ yellow "--" }} {{ len .Applied }} migrations 
+  {{ yellow "--" }} {{ len .Applied }} migrations
   {{ yellow "--" }} {{ .CountStmts  }} sql statements
 {{- end }}
 {{- end }}
@@ -800,7 +800,13 @@ func mermaid(i *SchemaInspect, _ ...string) (string, error) {
 		b       strings.Builder
 		qualify = len(i.Realm.Schemas) > 1
 		funcs   = template.FuncMap{
-			"formatType": ft.FormatType,
+			"formatType": func(t schema.Type) (string, error) {
+				f, err := ft.FormatType(t)
+				if err != nil {
+					return f, err
+				}
+				return strings.ReplaceAll(f, " ", "_"), err
+			},
 			"tableName": func(t *schema.Table) string {
 				if qualify {
 					return fmt.Sprintf("%[1]s_%[2]s[\"%[1]s.%[2]s\"]", t.Schema.Name, t.Name)

--- a/cmd/atlas/internal/cmdlog/cmdlog_test.go
+++ b/cmd/atlas/internal/cmdlog/cmdlog_test.go
@@ -259,6 +259,25 @@ func TestSchemaInspect_Mermaid(t *testing.T) {
     }
     users |o--o| users : best_friend_id
 `, b.String())
+
+	b.Reset()
+	users.
+		AddColumns(
+			schema.NewFloatColumn("duration", "double precision"),
+		)
+	require.NoError(t, tmpl.Execute(&b, &cmdlog.SchemaInspect{
+		Client: client,
+		Realm:  schema.NewRealm(schema.New("main").AddTables(users)),
+	}))
+	require.Equal(t, `erDiagram
+    users {
+      int id PK
+      text name
+      int best_friend_id FK
+      double_precision duration
+    }
+    users |o--o| users : best_friend_id
+`, b.String())
 }
 
 func TestSchemaDiff_MarshalSQL(t *testing.T) {


### PR DESCRIPTION
# Overview

When using the `{{ mermaid . }}` template with a simple table schema containing a data type that has multiple words, I noticed that the generated Mermaid syntax was broken.

For example, given the MRE `test.sql`:

```sql
-- test.sql --
CREATE TABLE "users" (
  oops DOUBLE PRECISION
)
```

After running:

```shell
atlas schema inspect --url file://test.sql --dev-url docker://postgres/latest/dev --format="{{ mermaid . }}"
```

We can see that it outputs:

```mermaid
erDiagram
    users {
      double precision oops
    }
```

This breaks the Mermaid syntax, as type names cannot contain whitespace.

# Proposed fix

I've come up with a pretty basic fix for this issue by simply replacing all whitespace characters with an underscore (`_`). I've also added a unit test that breaks before this bugfix to prove the solution at least works in this scenario.

Re-running the same `atlas schema inspect` command as above using this new build produces:

```mermaid
erDiagram
    users {
      double_precision oops
    }
```