### PR TITLE
sql/migrate: support controlling the execution order

### DIFF
--- a/.github/workflows/ci-go_oss.yaml
+++ b/.github/workflows/ci-go_oss.yaml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ "1.20", "1.21" ]
+        go: [ "1.21" ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v4

--- a/cmd/atlas/internal/cmdapi/cmdapi.go
+++ b/cmd/atlas/internal/cmdapi/cmdapi.go
@@ -304,6 +304,7 @@ const (
 	flagSchemaShort    = "s"
 	flagTo             = "to"
 	flagTxMode         = "tx-mode"
+	flagExecOrder      = "exec-order"
 	flagURL            = "url"
 	flagURLShort       = "u"
 	flagVar            = "var"

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -1670,7 +1670,7 @@ func setMigrateEnvFlags(cmd *cobra.Command, env *Env) error {
 		if err := maySetFlag(cmd, flagLockTimeout, env.Migration.LockTimeout); err != nil {
 			return err
 		}
-		if err := maySetFlag(cmd, flagExecOrder, strings.ToLower(env.Migration.ExecOrder)); err != nil {
+		if err := maySetFlag(cmd, flagExecOrder, strings.ReplaceAll(strings.ToLower(env.Migration.ExecOrder), "_", "-")); err != nil {
 			return err
 		}
 	case "diff", "checkpoint":

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -57,17 +57,29 @@ type migrateApplyFlags struct {
 	allowDirty      bool   // allow working on a database that already has resources
 	baselineVersion string // apply with this version as baseline
 	txMode          string // (none, file, all)
+	execOrder       string // (linear, linear-skip, non-linear)
 	context         string // Run context. See cloudapi.DeployContextInput.
 }
 
-func (f *migrateApplyFlags) migrateOptions() (opts []migrate.ExecutorOption) {
+func (f *migrateApplyFlags) migrateOptions() ([]migrate.ExecutorOption, error) {
+	var opts []migrate.ExecutorOption
 	if f.allowDirty {
 		opts = append(opts, migrate.WithAllowDirty(true))
 	}
 	if v := f.baselineVersion; v != "" {
 		opts = append(opts, migrate.WithBaselineVersion(v))
 	}
-	return
+	if v := f.execOrder; v != "" && v != execOrderLinear {
+		switch v {
+		case execOrderLinearSkip:
+			opts = append(opts, migrate.WithExecOrder(migrate.ExecOrderLinearSkip))
+		case execOrderNonLinear:
+			opts = append(opts, migrate.WithExecOrder(migrate.ExecOrderNonLinear))
+		default:
+			return nil, fmt.Errorf("unknown execution order: %q", v)
+		}
+	}
+	return opts, nil
 }
 
 func migrateApplyCmd() *cobra.Command {
@@ -132,6 +144,7 @@ If run with the "--dry-run" flag, atlas will not execute any SQL.`,
 	addFlagLockTimeout(cmd.Flags(), &flags.lockTimeout)
 	cmd.Flags().StringVarP(&flags.baselineVersion, flagBaseline, "", "", "start the first migration after the given baseline version")
 	cmd.Flags().StringVarP(&flags.txMode, flagTxMode, "", txModeFile, "set transaction mode [none, file, all]")
+	cmd.Flags().StringVarP(&flags.execOrder, flagExecOrder, "", execOrderLinear, "set file execution order [linear, linear-skip, non-linear]")
 	cmd.Flags().StringVar(&flags.context, flagContext, "", "describes what triggered this command (e.g., GitHub Action)")
 	cobra.CheckErr(cmd.Flags().MarkHidden(flagContext))
 	cmd.Flags().BoolVarP(&flags.allowDirty, flagAllowDirty, "", false, "allow start working on a non-clean database")
@@ -205,7 +218,11 @@ func migrateApplyRun(cmd *cobra.Command, args []string, flags migrateApplyFlags,
 		return err
 	}
 	// Determine pending files.
-	opts := append(flags.migrateOptions(), migrate.WithOperatorVersion(operatorVersion()), migrate.WithLogger(report))
+	opts, err := flags.migrateOptions()
+	if err != nil {
+		return err
+	}
+	opts = append(opts, migrate.WithOperatorVersion(operatorVersion()), migrate.WithLogger(report))
 	ex, err := migrate.NewExecutor(client.Driver, dir, rrw, opts...)
 	if err != nil {
 		return err
@@ -1425,6 +1442,10 @@ const (
 	txModeNone = "none"
 	txModeAll  = "all"
 	txModeFile = "file"
+
+	execOrderLinear     = "linear"
+	execOrderLinearSkip = "linear-skip"
+	execOrderNonLinear  = "non-linear"
 )
 
 // tx handles wrapping migration execution in transactions.
@@ -1647,6 +1668,9 @@ func setMigrateEnvFlags(cmd *cobra.Command, env *Env) error {
 			return err
 		}
 		if err := maySetFlag(cmd, flagLockTimeout, env.Migration.LockTimeout); err != nil {
+			return err
+		}
+		if err := maySetFlag(cmd, flagExecOrder, strings.ToLower(env.Migration.ExecOrder)); err != nil {
 			return err
 		}
 	case "diff", "checkpoint":

--- a/cmd/atlas/internal/cmdapi/project.go
+++ b/cmd/atlas/internal/cmdapi/project.go
@@ -76,6 +76,7 @@ type (
 		Dir             string `spec:"dir"`
 		Format          string `spec:"format"`
 		Baseline        string `spec:"baseline"`
+		ExecOrder       string `spec:"exec_order"`
 		LockTimeout     string `spec:"lock_timeout"`
 		RevisionsSchema string `spec:"revisions_schema"`
 	}
@@ -472,6 +473,7 @@ func parseConfig(path, env string, vars map[string]cty.Value) (*Project, error) 
 			cmdext.DataSources,
 			cfg.InitBlock(),
 			schemahcl.WithScopedEnums("env.migration.format", cmdmigrate.Formats...),
+			schemahcl.WithScopedEnums("env.migration.exec_order", "LINEAR", "LINEAR_SKIP", "NON_LINEAR"),
 			schemahcl.WithScopedEnums("env.lint.review", ReviewModes...),
 			schemahcl.WithScopedEnums("lint.review", ReviewModes...),
 			schemahcl.WithVariables(map[string]cty.Value{

--- a/cmd/atlas/internal/cmdapi/project_test.go
+++ b/cmd/atlas/internal/cmdapi/project_test.go
@@ -70,6 +70,7 @@ env "local" {
     format = atlas
     lock_timeout = "1s"
     revisions_schema = "revisions"
+    exec_order = LINEAR_SKIP
   }
   lint {
     latest = 1
@@ -127,6 +128,7 @@ env "multi" {
 				Format:          cmdmigrate.FormatAtlas,
 				LockTimeout:     "1s",
 				RevisionsSchema: "revisions",
+				ExecOrder:       "LINEAR_SKIP",
 			},
 			Diff: &Diff{
 				SkipChanges: &SkipChanges{

--- a/doc/md/atlas-schema/projects.mdx
+++ b/doc/md/atlas-schema/projects.mdx
@@ -861,6 +861,7 @@ set or map item. See the example [below](#multi-environment-example).
 - `migration` - A block defines the migration configuration of the env.
   - `dir` - The [URL](../concepts/url.mdx) to the migration directory.
   - `baseline` - An optional version to start the migration history from. Read more [here](../versioned/apply.mdx#existing-databases).
+  - `exec_order` - Set the file execution order [`LINEAR` (default), `LINEAR_SKIP`, `NON_LINEAR`]. Read more [here](../versioned/apply.mdx#execution-order).
   - `lock_timeout` - An optional timeout to wait for a database lock to be released. Defaults to `10s`. 
   - `revisions_schema` - An optional name to control the schema that the revisions table resides in.
 

--- a/doc/md/reference.md
+++ b/doc/md/reference.md
@@ -94,6 +94,7 @@ If run with the "--dry-run" flag, atlas will not execute any SQL.
       --lock-timeout duration     set how long to wait for the database lock (default 10s)
       --baseline string           start the first migration after the given baseline version
       --tx-mode string            set transaction mode [none, file, all] (default "file")
+      --exec-order string         set file execution order [linear, linear-skip, non-linear] (default "linear")
       --allow-dirty               allow start working on a non-clean database
 
 ```

--- a/doc/md/versioned/apply.mdx
+++ b/doc/md/versioned/apply.mdx
@@ -192,6 +192,36 @@ The `--atlas:txmode` directive can be used to override the transaction mode for 
 CREATE INDEX CONCURRENTLY name_idx ON users (name);
 ```
 
+### Execution Order
+
+The `--exec-order` flag controls how Atlas computes and executes pending migration files to the database.
+Atlas supports three different order execution modes:
+
+- `linear` (default) - Atlas expects a linear history and fails if it encounters files that were added out of order.
+  This option ensures files are executed in a consistent order, guaranteeing deterministic behavior. It can be enforced
+  in CI using the `atlas migrate lint` command. Learn more about [non-linear changes](/lint/analyzers#non-linear-changes)
+  in the documentation.
+- `linear-skip` - This option is a softer version of `linear`, meaning that if Atlas encounters a new file that was not
+   added in sequential order (its version is lower than the database version), it will be skipped.
+- `non-linear` - This option directs Atlas to execute migration files that were added out of order. Note, although
+  this option can be useful in local development, it is strongly discouraged in real production environments.
+  Executing files out of order cannot guarantee deterministic behavior and may lead to failures (e.g., conflicted migrations).
+  Rolling back to a specific version of the migration directory might be challenging, as the state of the database could differ
+  from the state of the directory.
+
+#### Handling Out-of-Order Errors {#non-linear-error}
+
+If you encounter this issue during deployment, it means that Atlas was not set up in your CI, which is why the issue was
+not caught beforehand. Let's go through the steps to set up Atlas for your CI and fix this error:
+
+- Configure Atlas to run for every PR or a change in the master branch that affects the migration directory. Learn more on
+  how to integrate it into your [GitHub Actions](/cloud/setup-ci) or [GitLab](/guides/ci-platforms/gitlab) CI pipelines.
+- Run `atlas migrate rebase <versions>` to rebase the problematic files reported by Atlas. Then, create a PR.
+- At this stage, if Atlas CI is set up, it will verify that the migration directory is _replay-able_ and that the rebased
+  migration file(s) can be executed without any issues.
+- Running `atlas migrate apply` (deployment) again should pass without this error.
+
+
 ### Existing Databases
 
 #### Baseline migration

--- a/doc/website/docusaurus.config.js
+++ b/doc/website/docusaurus.config.js
@@ -243,7 +243,7 @@ module.exports = {
           {
             from: '/ui/intro',
             to: '/cloud/getting-started',
-          }
+          },
         ],
       },
     ],

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ariga.io/atlas
 
-go 1.20
+go 1.21
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/internal/ci/jobs_oss.go
+++ b/internal/ci/jobs_oss.go
@@ -9,7 +9,7 @@ package main
 //go:generate go run . -flavor Community -suffix oss
 
 func init() {
-	data.GoVersions = goVersions{"1.20", "1.21"}
+	data.GoVersions = goVersions{"1.21"}
 	data.Jobs = append(jobs,
 		Job{
 			Version: "tidb5",

--- a/sql/sqltool/tool.go
+++ b/sql/sqltool/tool.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -575,7 +576,7 @@ func flywayVersionCompare(v1, v2 string) int {
 		}
 		return ret
 	}
-	return compareSliceInt(parse(v1), parse(v2))
+	return slices.Compare(parse(v1), parse(v2))
 }
 
 func unexpectedPragmaErr(f migrate.File, line int, pragma string) error {
@@ -639,24 +640,3 @@ var (
 	_ dirPath = (*GooseDir)(nil)
 	_ dirPath = (*LiquibaseDir)(nil)
 )
-
-// Copied from golang.org/x/exp/slices.Compare
-func compareSliceInt(s1, s2 []int) int {
-	s2len := len(s2)
-	for i, v1 := range s1 {
-		if i >= s2len {
-			return +1
-		}
-		v2 := s2[i]
-		switch {
-		case v1 < v2:
-			return -1
-		case v1 > v2:
-			return +1
-		}
-	}
-	if len(s1) < s2len {
-		return -1
-	}
-	return 0
-}


### PR DESCRIPTION
Also, changing the default behavior to error (instead of skip) in case non-linear history

(cmd tests will be pushed soon)
