### PR TITLE
cmd/atlas/internal/cmdlog: indent new line in apply log

### DIFF
--- a/cmd/atlas/internal/cmdlog/cmdlog.go
+++ b/cmd/atlas/internal/cmdlog/cmdlog.go
@@ -291,6 +291,7 @@ var (
 		"upper":      strings.ToUpper,
 		"json":       jsonEncode,
 		"json_merge": jsonMerge,
+		"indent_ln":  indentLn,
 	})
 
 	// MigrateApplyTemplate holds the default template of the 'migrate apply' command.
@@ -303,7 +304,7 @@ No migration files to execute
 Migrating to version {{ cyan .Target }}{{ with .Current }} from {{ cyan . }}{{ end }} ({{ len .Pending }} migrations in total):
 {{ range $i, $f := .Applied }}
   {{ yellow "--" }} migrating version {{ cyan $f.File.Version }}{{ range $f.Applied }}
-    {{ cyan "->" }} {{ . }}{{ end }}
+    {{ cyan "->" }} {{ indent_ln . 7 }}{{ end }}
   {{- with .Error }}
     {{ redBgWhiteFg .Text }}
   {{- else }}
@@ -904,4 +905,9 @@ func jsonMerge(objects ...string) (string, error) {
 
 func dec(i int) int {
 	return i - 1
+}
+
+func indentLn(input string, indent int) string {
+	pad := strings.Repeat(" ", indent)
+	return strings.ReplaceAll(input, "\n", "\n"+pad)
 }

--- a/internal/integration/testdata/sqlite/cli-migrate-apply.txt
+++ b/internal/integration/testdata/sqlite/cli-migrate-apply.txt
@@ -9,7 +9,12 @@ atlas migrate hash
 atlas migrate apply --url URL
 stdout 'Migrating to version 2 \(2 migrations in total\):'
 stdout '-- migrating version 1'
-stdout '-> CREATE TABLE `users` \(`id` integer NOT NULL, `age` integer NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY \(`id`\)\);'
+stdout '-> CREATE TABLE `users` \('
+stdout '  `id` integer NOT NULL,'
+stdout '  `age` integer NOT NULL,'
+stdout '  `name` TEXT NOT NULL,'
+stdout '  PRIMARY KEY \(`id`\)'
+stdout '\);'
 stdout '-- migrating version 2'
 stdout '-> CREATE TABLE `pets` \(`id` integer NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY \(`id`\)\);'
 stdout '-- 2 migrations'
@@ -117,7 +122,12 @@ atlas schema inspect --url URL --exclude atlas_schema_revisions --exclude users 
 cmp stdout broken.hcl
 
 -- migrations/1_first.sql --
-CREATE TABLE `users` (`id` integer NOT NULL, `age` integer NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY (`id`));
+CREATE TABLE `users` (
+  `id` integer NOT NULL,
+  `age` integer NOT NULL,
+  `name` TEXT NOT NULL,
+  PRIMARY KEY (`id`)
+);
 
 -- migrations/2_second.sql --
 CREATE TABLE `pets` (`id` integer NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY (`id`));
@@ -140,7 +150,12 @@ table "broken" {
 schema "main" {
 }
 -- users.sql --
-CREATE TABLE `users` (`id` integer NOT NULL, `age` integer NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY (`id`))
+CREATE TABLE `users` (
+  `id` integer NOT NULL,
+  `age` integer NOT NULL,
+  `name` TEXT NOT NULL,
+  PRIMARY KEY (`id`)
+)
 
 -- pets.sql --
 CREATE TABLE `pets` (`id` integer NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY (`id`))


### PR DESCRIPTION
Previously, if applying migration files which statements that contained new lines, it looked like this:
![image](https://github.com/ariga/atlas/assets/12862103/3cc622c5-1545-4d87-b8df-2bd69e628548)

After this change it is properly indented:
![image](https://github.com/ariga/atlas/assets/12862103/5d636b7e-731a-47fa-8d5a-aa88ba67c729)
