### PR TITLE
schemahcl: fix memory leak in patchRefs func

### DIFF
--- a/schemahcl/schemahcl.go
+++ b/schemahcl/schemahcl.go
@@ -393,13 +393,13 @@ func patchRefs(spec *Resource) error {
 }
 
 func (r addrRef) patch(resource *Resource) error {
-	cp := r.copy().load(resource, "")
+	r.load(resource, "")
 	for _, attr := range resource.Attrs {
 		if !attr.IsRef() {
 			continue
 		}
 		ref := attr.V.EncapsulatedValue().(*Ref)
-		referenced, ok := cp[ref.V]
+		referenced, ok := r[ref.V]
 		if !ok {
 			return fmt.Errorf("broken reference to %q", ref.V)
 		}
@@ -408,19 +408,11 @@ func (r addrRef) patch(resource *Resource) error {
 		}
 	}
 	for _, ch := range resource.Children {
-		if err := cp.patch(ch); err != nil {
+		if err := r.patch(ch); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func (r addrRef) copy() addrRef {
-	n := make(addrRef)
-	for k, v := range r {
-		n[k] = v
-	}
-	return n
 }
 
 // load the references from the children of the resource.


### PR DESCRIPTION
**before**:
![Screen Shot 2023-12-03 at 16 05 59](https://github.com/ariga/atlas/assets/63970571/d72242e2-5f44-4d9b-806e-15cba63e49aa)
memory:
![image](https://github.com/ariga/atlas/assets/63970571/cf2cef12-70cb-42a0-a736-b78325932d47)

[before.pdf](https://github.com/ariga/atlas/files/13539225/before.pdf)


**after**:
![Screen Shot 2023-12-03 at 16 06 28](https://github.com/ariga/atlas/assets/63970571/52f7ef61-e399-40eb-967c-75e552bd72e7)
memory:
![image](https://github.com/ariga/atlas/assets/63970571/92cf5ccd-e4ad-43aa-b8c8-ad67d1c8f769)

[mem_after.pdf](https://github.com/ariga/atlas/files/13539221/mem_after.pdf)



