### PR TITLE
schemahcl: reduce eval mem usage

### DIFF
--- a/schemahcl/extension.go
+++ b/schemahcl/extension.go
@@ -547,10 +547,16 @@ func scanAttr(key string, r *Resource, field reflect.Value) error {
 	return nil
 }
 
+// specCache holds a cache for type-spec fields descriptions.
+var specCache sync.Map
+
 // specFields uses reflection to find struct fields that are tagged with "spec"
 // and returns a list of mappings from the tag to the field name.
 func specFields(ext any) []fieldDesc {
 	t := indirect(reflect.TypeOf(ext))
+	if d, ok := specCache.Load(t); ok {
+		return d.([]fieldDesc)
+	}
 	var fields []fieldDesc
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
@@ -564,6 +570,7 @@ func specFields(ext any) []fieldDesc {
 		}
 		fields = append(fields, d)
 	}
+	specCache.Store(t, fields)
 	return fields
 }
 

--- a/sql/postgres/sqlspec.go
+++ b/sql/postgres/sqlspec.go
@@ -900,7 +900,6 @@ var TypeRegistry = schemahcl.NewRegistry(
 		schemahcl.NewTypeSpec(TypeDateRange),
 		schemahcl.NewTypeSpec(TypeDateMultiRange),
 		schemahcl.NewTypeSpec("hstore"),
-		schemahcl.NewTypeSpec("sql", schemahcl.WithAttributes(&schemahcl.TypeAttr{Name: "def", Required: true, Kind: reflect.String})),
 	),
 	// PostgreSQL internal, pseudo, and special types.
 	schemahcl.WithSpecs(func() (specs []*schemahcl.TypeSpec) {

--- a/sql/postgres/sqlspec_test.go
+++ b/sql/postgres/sqlspec_test.go
@@ -12,7 +12,6 @@ import (
 	"ariga.io/atlas/sql/internal/spectest"
 	"ariga.io/atlas/sql/internal/sqlx"
 	"ariga.io/atlas/sql/schema"
-	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/stretchr/testify/require"
 )
 
@@ -2238,53 +2237,4 @@ schema "s2" {
 schema "s3" {
 }
 `, string(buf))
-}
-
-func TestEvalHCLError(t *testing.T) {
-	for _, tt := range []struct {
-		text, err string
-	}{
-		{
-			text: `
-			table "test" {
-			  column "id" {
-			    type = string
-			  }
-			}`,
-			err: `schema.hcl:4,15-21: Unknown column.type; There is no type named "string".`,
-		},
-		{
-			text: `
-			table "test" {
-			  index "i" {
-			    type = unknown
-			  }
-			}`,
-			err: `schema.hcl:4,15-22: Unknown index.type; There is no type named "unknown".`,
-		},
-		{
-			text: `
-			table "test" {
-			  foreign_key "f" {
-			    on_delete = unknown
-			  }
-			}`,
-			err: `schema.hcl:4,20-27: Unknown foreign_key.on_delete; There is no on_delete named "unknown".`,
-		},
-		{
-			text: `
-			table "test" {
-			  partition {
-			    type = UNKNOWN
-			  }
-			}`,
-			err: `schema.hcl:4,15-22: Unknown partition.type; There is no type named "UNKNOWN".`,
-		},
-	} {
-		p := hclparse.NewParser()
-		_, diags := p.ParseHCL([]byte(tt.text), "schema.hcl")
-		require.False(t, diags.HasErrors())
-		err := EvalHCL.Eval(p, &schema.Schema{}, nil)
-		require.EqualError(t, err, tt.err)
-	}
 }


### PR DESCRIPTION
```
benchmark              old ns/op     new ns/op     delta
BenchmarkSchema-16     569319394     238469401     -58.11%

benchmark              old allocs     new allocs     delta
BenchmarkSchema-16     1327927        1174085        -11.59%

benchmark              old bytes     new bytes     delta
BenchmarkSchema-16     293956792     186829161     -36.44%
```