### PR TITLE
sql/internal/sqlx: indirect drop trigger dropping

### DIFF
--- a/sql/internal/sqlx/plan.go
+++ b/sql/internal/sqlx/plan.go
@@ -679,8 +679,14 @@ func depOfDrop(o schema.Object, c schema.Change) bool {
 	switch c := c.(type) {
 	case *schema.DropTable:
 		deps = c.T.Deps
+		for _, t := range c.T.Triggers {
+			deps = append(deps, t.Deps...)
+		}
 	case *schema.DropView:
 		deps = c.V.Deps
+		for _, t := range c.V.Triggers {
+			deps = append(deps, t.Deps...)
+		}
 	case *schema.DropFunc:
 		deps = c.F.Deps
 	case *schema.DropProc:

--- a/sql/internal/sqlx/plan_test.go
+++ b/sql/internal/sqlx/plan_test.go
@@ -194,4 +194,19 @@ func TestSortChanges(t *testing.T) {
 	}
 	planned = SortChanges(changes)
 	require.Equal(t, []schema.Change{changes[2], changes[1], changes[0]}, planned)
+
+	// No changes.
+	planned = SortChanges([]schema.Change{
+		&schema.DropFunc{F: f1},
+		&schema.DropTable{T: t1},
+	})
+	require.Equal(t, []schema.Change{&schema.DropFunc{F: f1}, &schema.DropTable{T: t1}}, planned)
+
+	// The table must be dropped before the function if one of its triggers depends on the function.
+	t1.Triggers = []*schema.Trigger{tr1}
+	planned = SortChanges([]schema.Change{
+		&schema.DropFunc{F: f1},
+		&schema.DropTable{T: t1},
+	})
+	require.Equal(t, []schema.Change{&schema.DropTable{T: t1}, &schema.DropFunc{F: f1}}, planned)
 }


### PR DESCRIPTION
Triggers are not explicitly dropped as they are dropped together with the table they attach to