### PR TITLE
fix: update total statements in the migration when it is being executed

### DIFF
--- a/sql/migrate/migrate.go
+++ b/sql/migrate/migrate.go
@@ -812,6 +812,12 @@ func (e *Executor) Execute(ctx context.Context, m File) (err error) {
 			Hash:        hash,
 		}
 	}
+
+	// Update total statements in the existing revision to support
+	// statement-level granularity in cases when users add new statements to
+	// existing migrations to resolve partial failures.
+	r.Total = len(stmts)
+
 	// Save once to mark as started in the database.
 	if err = e.writeRevision(ctx, r); err != nil {
 		return err


### PR DESCRIPTION
The reason for this is that users are required to edit existing migration files to resolve partial failure issues. Without keeping total in sync, such migration would be considered still pending, because total != applied. 

This fix was NOT tested in all possible use cases, but only in the one described in the linked issue and it resolves it.

Issue: #2455 