### PR TITLE
cmd/docker: print latest error when timeout

### DIFF
--- a/cmd/atlas/internal/docker/docker.go
+++ b/cmd/atlas/internal/docker/docker.go
@@ -386,7 +386,7 @@ func (c *Container) Wait(ctx context.Context, timeout time.Duration) error {
 		return err
 	}
 	pingURL := c.PingURL(*u)
-	for err := error(nil); ; {
+	for {
 		select {
 		case <-time.After(100 * time.Millisecond):
 			var client *sqlclient.Client


### PR DESCRIPTION
```
$ ./cmd/atlas/atlas schema diff \
  --from "sqlserver://sa:P@ssw0rd0995@:1433?database=master" \
  --to "file://schema.hcl" \
  --dev-url "docker://sqlserver/2022-latest/dev?v=1"
8ac741c3cf2b889df6fbf0f9787f0150ff2c95b00a4d247660bab1f399efa85c
Waiting for service to be ready ... 
Error: timeout: login is required to use the 'sqlserver' beta driver. See: https://atlasgo.io/cloud/beta-drivers: <nil>
```