### PR TITLE
doc/md: rename postgres alignment analyzer from ar101 to pg110

### DIFF
--- a/doc/md/guides/guides.mdx
+++ b/doc/md/guides/guides.mdx
@@ -165,9 +165,9 @@ import { Card, CardImage } from "../components/card";
     image={CardImage.Postgres}
   />
   <Card
-    name="Optimal data alignment (AR101)"
+    name="Optimal data alignment (PG110)"
     description="This guide is for achieving optimal data alignment in PostgreSQL with Atlas"
-    url="/guides/postgres/ar-101"
+    url="/guides/postgres/pg-110"
     image={CardImage.Postgres}
   />
   <Card

--- a/doc/md/guides/postgres/pg-110.md
+++ b/doc/md/guides/postgres/pg-110.md
@@ -1,7 +1,7 @@
 ---
-id: ar-101
-title: Optimal data alignment in tables (AR101)
-slug: /guides/postgres/ar-101
+id: pg-110
+title: Optimal data alignment in tables (PG110)
+slug: /guides/postgres/pg-110
 ---
 
 ### Alignment and Padding in PostgreSQL

--- a/doc/md/guides/postgres/pg-110.md
+++ b/doc/md/guides/postgres/pg-110.md
@@ -183,9 +183,9 @@ CREATE TABLE users (
 );
 ```
 
-Once the Atlas CI check is completed, you should see the following message inside Atlas Lint Report:
+Once the Atlas CI check is completed, you should see the following code suggestion in your pull request:
 
-![atlasci](https://atlasgo.io/uploads/images/atlas-lint-report.png)
+![atlasci](https://atlasgo.io/uploads/images/atlas-lint-suggestion.png)
 
 Awesome! The Atlas CI check has analyzed the migration file and suggested the best possible arrangement of columns in order to optimize the space taken by padding per row.
 

--- a/doc/md/lint/analyzers.mdx
+++ b/doc/md/lint/analyzers.mdx
@@ -232,8 +232,6 @@ The following schema change checks are provided by Atlas:
 
 | **Check**                                 | **Short Description**                                                                        |
 |-------------------------------------------|----------------------------------------------------------------------------------------------|
-| **AR**                                    | Atlas cloud checks                                                                           |
-| [AR101](#AR101)                           | Creating table with non-optimal data alignment                                               |
 | **BC**                                    | **[Backward incompatible changes](#backward-incompatible-changes)**                          |
 | [BC101](#BC101)                           | Renaming a table                                                                             |
 | [BC102](#BC102)                           | Renaming a column                                                                            |
@@ -268,6 +266,8 @@ The following schema change checks are provided by Atlas:
 | [NM104](#NM104)                           | Index name violates the naming convention                                                    |
 | [NM105](#NM105)                           | Foreign-key constraint name violates the naming convention                                   |
 | [NM106](#NM106)                           | Check constraint name violates the naming convention                                         |
+| **PG**                                    | PostgreSQL specific checks                                                                   |
+| [PG110](#PG110)                           | Creating table with non-optimal data alignment                                               |
 | **PG1**                                   | **[Concurrent Indexes](#concurrent-index-policy-postgresql)**                                |
 | [PG101](#PG101)                           | Missing the `CONCURRENTLY` in index creation                                                 |
 | [PG102](#PG102)                           | Missing the `CONCURRENTLY` in index deletion                                                 |
@@ -556,7 +556,7 @@ ALTER TABLE `new_users` RENAME TO `users`;
 PRAGMA foreign_keys = on;
 ```
 
-#### AR101 {#AR101}
+#### PG110 {#PG110}
 
 Creating a table with optimal data alignment may help minimize the amount of required disk space.
 For example consider the next Postgres table on a 64-bit system:

--- a/doc/website/sidebars.js
+++ b/doc/website/sidebars.js
@@ -438,8 +438,8 @@ module.exports = {
                 },
                 {
                     type: 'doc',
-                    id: 'guides/postgres/ar-101',
-                    label: 'Optimal data alignment (AR101)'
+                    id: 'guides/postgres/pg-110',
+                    label: 'Optimal data alignment (PG110)'
                 },
                 {
                     type: 'doc',


### PR DESCRIPTION
image used:
![image](https://github.com/ariga/atlas/assets/63970571/77a01d02-dbd6-4628-8f0a-f071069eb014)
