### PR TITLE
allow libsql to work with versioned migrations

### DIFF
--- a/cmd/atlas/go.mod
+++ b/cmd/atlas/go.mod
@@ -17,13 +17,13 @@ require (
 	github.com/google/uuid v1.4.0
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/lib/pq v1.10.9
-	github.com/libsql/libsql-client-go v0.0.0-20230602133133-5905f0c4f8a5
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pganalyze/pg_query_go/v4 v4.2.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
+	github.com/tursodatabase/libsql-client-go v0.0.0-20240220085343-4ae0eb9d0898
 	github.com/vektah/gqlparser/v2 v2.5.1
 	github.com/zclconf/go-cty v1.8.0
 	gocloud.dev v0.36.0
@@ -84,7 +84,7 @@ require (
 	github.com/klauspost/compress v1.15.15 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/libsql/sqlite-antlr4-parser v0.0.0-20230512205400-b2348f0d1196 // indirect
+	github.com/libsql/sqlite-antlr4-parser v0.0.0-20230802215326-5cb5bb604475 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect

--- a/cmd/atlas/go.sum
+++ b/cmd/atlas/go.sum
@@ -299,6 +299,8 @@ github.com/libsql/libsql-client-go v0.0.0-20230602133133-5905f0c4f8a5 h1:thfvsTY
 github.com/libsql/libsql-client-go v0.0.0-20230602133133-5905f0c4f8a5/go.mod h1:XaIcfeMOJ1w1L/TELMmzOXkAGZKRYF/QSWTqgwOT4R8=
 github.com/libsql/sqlite-antlr4-parser v0.0.0-20230512205400-b2348f0d1196 h1:XBs+xh9/OM9kMvK7W9a3SEReC5x26z22cbYn0K6cUW4=
 github.com/libsql/sqlite-antlr4-parser v0.0.0-20230512205400-b2348f0d1196/go.mod h1:20nXSmcf0nAscrzqsXeC2/tA3KkV2eCiJqYuyAgl+ss=
+github.com/libsql/sqlite-antlr4-parser v0.0.0-20230802215326-5cb5bb604475 h1:6PfEMwfInASh9hkN83aR0j4W/eKaAZt/AURtXAXlas0=
+github.com/libsql/sqlite-antlr4-parser v0.0.0-20230802215326-5cb5bb604475/go.mod h1:20nXSmcf0nAscrzqsXeC2/tA3KkV2eCiJqYuyAgl+ss=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -393,6 +395,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/tursodatabase/libsql-client-go v0.0.0-20240220085343-4ae0eb9d0898 h1:1MvEhzI5pvP27e9Dzz861mxk9WzXZLSJwzOU67cKTbU=
+github.com/tursodatabase/libsql-client-go v0.0.0-20240220085343-4ae0eb9d0898/go.mod h1:9bKuHS7eZh/0mJndbUOrCx8Ej3PlsRDszj4L7oVYMPQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=

--- a/cmd/atlas/internal/migrate/migrate_test.go
+++ b/cmd/atlas/internal/migrate/migrate_test.go
@@ -15,6 +15,7 @@ import (
 	"ariga.io/atlas/sql/migrate"
 	"ariga.io/atlas/sql/sqlclient"
 	"ariga.io/atlas/sql/sqltool"
+	"entgo.io/ent/dialect"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
@@ -147,6 +148,45 @@ func runRevisionsTests(ctx context.Context, t *testing.T, drv migrate.Driver, r 
 	id1, err = r.ID(ctx, "v0.10.1")
 	require.NoError(t, err)
 	require.Equal(t, id, id1)
+}
+
+func TestGetEntDialect(t *testing.T) {
+	tests := []struct {
+		name     string
+		acName   string
+		expected string
+	}{
+		{
+			name:     "libsql dialect",
+			acName:   "libsql",
+			expected: dialect.SQLite,
+		},
+		{
+			name:     "sqlite dialect",
+			acName:   "sqlite3",
+			expected: dialect.SQLite,
+		},
+		{
+			name:     "Other dialect",
+			acName:   "mysql",
+			expected: dialect.MySQL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ac := &sqlclient.Client{
+				Name: tt.acName,
+			}
+
+			r := &EntRevisions{ac: ac}
+
+			dialect := r.getEntDialect()
+			if dialect != tt.expected {
+				t.Errorf("Unexpected dialect. Got: %s, want: %s", dialect, tt.expected)
+			}
+		})
+	}
 }
 
 type (

--- a/cmd/atlas/main.go
+++ b/cmd/atlas/main.go
@@ -26,8 +26,8 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
-	_ "github.com/libsql/libsql-client-go/libsql"
 	_ "github.com/mattn/go-sqlite3"
+	_ "github.com/tursodatabase/libsql-client-go/libsql"
 )
 
 func main() {


### PR DESCRIPTION
**Issue**: 
- When using `libsql` with versioned migrations I would get an "unsupported dialect" error from Ent 
- The old `libsql` driver did not support `time.Time`

**PR Includes**:

- Updates the `libsql` client to the `github.com/tursodatabase/libsql-client-go`
- Uses the `dialect.Sqlite`  for ent versioned migrations when using `libsql` driver

This allows the use of the following in migrations: 
```
env "turso" {
  url     = "libsql://<REPLACE WITH YOUR SUBDOMAIN>?authToken=${var.token}"
  exclude = ["_litestream*"]
}
```