### PR TITLE
Add a no-schema flag

### DIFF
--- a/cmd/atlas/internal/cmdapi/cmdapi.go
+++ b/cmd/atlas/internal/cmdapi/cmdapi.go
@@ -285,6 +285,7 @@ const (
 	flagConfig         = "config"
 	flagContext        = "context"
 	flagDevURL         = "dev-url"
+	flagNoSchema       = "no-schema"
 	flagDirURL         = "dir"
 	flagDirFormat      = "dir-format"
 	flagDryRun         = "dry-run"
@@ -352,6 +353,10 @@ func addFlagDevURL(set *pflag.FlagSet, target *string) {
 		"",
 		"[driver://username:password@address/dbname?param=value] select a dev database using the URL format",
 	)
+}
+
+func addFlagNoSchema(set *pflag.FlagSet, target *bool) {
+	set.BoolVar(target, flagNoSchema, false, "omit schema from the output")
 }
 
 func addFlagDryRun(set *pflag.FlagSet, target *bool) {

--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -573,6 +573,7 @@ type migrateDiffFlags struct {
 	desiredURLs       []string
 	dirURL, dirFormat string
 	devURL            string
+	noSchema          bool
 	schemas           []string
 	lockTimeout       time.Duration
 	format            string
@@ -616,6 +617,7 @@ an HCL, SQL, or ORM schema. See: https://atlasgo.io/versioned/diff`,
 	cmd.Flags().SortFlags = false
 	addFlagToURLs(cmd.Flags(), &flags.desiredURLs)
 	addFlagDevURL(cmd.Flags(), &flags.devURL)
+	addFlagNoSchema(cmd.Flags(), &flags.noSchema)
 	addFlagDirURL(cmd.Flags(), &flags.dirURL)
 	addFlagDirFormat(cmd.Flags(), &flags.dirFormat)
 	addFlagSchemas(cmd.Flags(), &flags.schemas)
@@ -700,10 +702,24 @@ func migrateDiffRun(cmd *cobra.Command, args []string, flags migrateDiffFlags, e
 		migrate.PlanWithIndent(indent),
 		migrate.PlanWithDiffOptions(env.DiffOptions()...),
 	}
+
+	// Disable tables qualifier in schema-mode.
 	if dev.URL.Schema != "" {
-		// Disable tables qualifier in schema-mode.
-		opts = append(opts, migrate.PlanWithSchemaQualifier(flags.qualifier))
+		if flags.noSchema {
+			opts = append(opts, migrate.PlanWithSchemaQualifier(""))
+		} else {
+			opts = append(opts, migrate.PlanWithSchemaQualifier(flags.qualifier))
+		}
 	}
+
+	if flags.noSchema {
+		opts = append(opts, migrate.PlanWithDiffOptions(schema.DiffSkipChanges(
+			&schema.AddSchema{},
+			&schema.DropSchema{},
+			&schema.ModifySchema{},
+		)))
+	}
+
 	// Plan the changes and create a new migration file.
 	pl := migrate.NewPlanner(dev.Driver, dir, opts...)
 	plan, err := func() (*migrate.Plan, error) {


### PR DESCRIPTION
The PR adds a no-schema flag so that the generated migrations don't include a schema qualifier. This allows to generate cross-schema migrations