### PR TITLE
cmd/atlas/internal/migratelint: passing underlying driver to scanner

### DIFF
--- a/cmd/atlas/internal/migratelint/lint_oss.go
+++ b/cmd/atlas/internal/migratelint/lint_oss.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (d *DevLoader) stmts(_ context.Context, f migrate.File, _ bool) ([]*migrate.Stmt, error) {
-	stmts, err := migrate.FileStmtDecls(d.Dev, f)
+	stmts, err := migrate.FileStmtDecls(d.Dev.Driver, f)
 	if err != nil {
 		return nil, &FileError{File: f.Name(), Err: fmt.Errorf("scanning statements: %w", err)}
 	}


### PR DESCRIPTION
sqlclient.Client is migrate.Driver but hide all extra methods implemented by the underlying driver.

Fixed https://github.com/ariga/atlas/issues/2699