### PR TITLE
sql/sqlx: fix miss makezero bug with `byKeys` sort

### DIFF
--- a/sql/internal/sqlx/plan.go
+++ b/sql/internal/sqlx/plan.go
@@ -369,7 +369,7 @@ func byKeys[T any](m map[string]T) []struct {
 	vs := make([]struct {
 		K string
 		V T
-	}, len(m))
+	}, 0, len(m))
 	for k, v := range m {
 		vs = append(vs, struct {
 			K string


### PR DESCRIPTION
when I want to add feature for linter [makezero](https://github.com/ashanbrown/makezero) , so I run some github action for real world repos, and the action report this bug.
