### PR TITLE
schemahcl: speedup eval schemas

### DIFF
--- a/schemahcl/schemahcl.go
+++ b/schemahcl/schemahcl.go
@@ -311,13 +311,13 @@ func (s *State) EvalFiles(paths []string, v any, input map[string]cty.Value) err
 // using the result.
 func (s *State) Eval(parsed *hclparse.Parser, v any, input map[string]cty.Value) error {
 	var (
+		hasVars      bool
 		ctx          = s.newCtx()
 		files        = parsed.Files()
 		fileNames    = make([]string, 0, len(files))
 		metaBlocks   = make(map[string][]*hclsyntax.Block, len(files))
 		staticBlocks = make([]*hclsyntax.Block, 0, len(files))
 		reg          = &blockDef{
-			fields:   make(map[string]struct{}),
 			children: make(map[string]*blockDef),
 		}
 	)
@@ -337,11 +337,12 @@ func (s *State) Eval(parsed *hclparse.Parser, v any, input map[string]cty.Value)
 		for _, b := range body.Blocks {
 			switch {
 			case b.Type == BlockVariable:
+				hasVars = true
 			case b.Body != nil && b.Body.Attributes[forEachAttr] != nil:
 				metaBlocks[name] = append(metaBlocks[name], b)
 			default:
 				blocks = append(blocks, b)
-				reg.child(extractDef(b, reg))
+				reg.addChild(b, 0)
 			}
 		}
 		body.Blocks = blocks
@@ -364,7 +365,7 @@ func (s *State) Eval(parsed *hclparse.Parser, v any, input map[string]cty.Value)
 					return err
 				}
 				// Extract the definition of the top-level is enough.
-				reg.child(extractDef(b, reg))
+				reg.addChild(b, 0)
 				blocks = append(blocks, nb...)
 				files[name].Body.(*hclsyntax.Body).Blocks = append(files[name].Body.(*hclsyntax.Body).Blocks, nb...)
 			}
@@ -397,7 +398,7 @@ func (s *State) Eval(parsed *hclparse.Parser, v any, input map[string]cty.Value)
 	}
 	for _, name := range fileNames {
 		file := files[name]
-		r, err := s.resource(ctx, vr, file)
+		r, err := s.resource(ctx, vr, file, reg)
 		if err != nil {
 			return err
 		}
@@ -408,8 +409,13 @@ func (s *State) Eval(parsed *hclparse.Parser, v any, input map[string]cty.Value)
 	if err := vr.Err(); err != nil {
 		return err
 	}
-	if err := patchRefs(spec); err != nil {
-		return err
+	// Has variables with or without default values.
+	if hasVars {
+		// In case some blocks get their names dynamically (e.g., name = var.x),
+		// we need to update the references from the stub label to its final name.
+		if err := patchRefs(spec); err != nil {
+			return err
+		}
 	}
 	if err := spec.As(v); err != nil {
 		return fmt.Errorf("schemahcl: failed reading spec as %T: %w", v, err)
@@ -447,7 +453,7 @@ func (r addrRef) patch(resource *Resource) error {
 		if !ok {
 			return fmt.Errorf("broken reference to %q", ref.V)
 		}
-		if name, err := referenced.FinalName(); err == nil {
+		if name, err := referenced.FinalName(); err == nil && name != referenced.Name {
 			ref.V = strings.ReplaceAll(ref.V, referenced.Name, name)
 		}
 	}
@@ -478,7 +484,7 @@ func (r addrRef) load(res *Resource, track string) addrRef {
 }
 
 // resource converts the hcl file to a schemahcl.Resource.
-func (s *State) resource(ctx *hcl.EvalContext, vr SchemaValidator, file *hcl.File) (*Resource, error) {
+func (s *State) resource(ctx *hcl.EvalContext, vr SchemaValidator, file *hcl.File, dec *blockDef) (*Resource, error) {
 	body, ok := file.Body.(*hclsyntax.Body)
 	if !ok {
 		return nil, fmt.Errorf("schemahcl: expected remainder to be of type *hclsyntax.Body")
@@ -500,11 +506,12 @@ func (s *State) resource(ctx *hcl.EvalContext, vr SchemaValidator, file *hcl.Fil
 		if blk.Type == BlockVariable {
 			continue
 		}
-		ctx, err := setBlockVars(ctx.NewChild(), blk.Body)
+		cdec := dec.child(blk.Type)
+		ctx, err := setLocalVars(ctx.NewChild(), blk.Body, cdec)
 		if err != nil {
 			return nil, err
 		}
-		resource, err := s.toResource(ctx, vr, blk, []string{blk.Type})
+		resource, err := s.toResource(ctx, vr, blk, []string{blk.Type}, dec.children[blk.Type])
 		if err != nil {
 			return nil, err
 		}
@@ -514,6 +521,35 @@ func (s *State) resource(ctx *hcl.EvalContext, vr SchemaValidator, file *hcl.Fil
 		return nil, err
 	}
 	return res, nil
+}
+
+// setLocalVars extends the context with the local block variables (references) so they
+// can be referenced in later stages. For example, an index block may reference its sibling
+// column blocks by their names:
+//
+//	table "t" {
+//	  column "c1" { ... }
+//	  index "i1" { columns = [column.c1] }
+//	}
+func setLocalVars(ctx *hcl.EvalContext, b *hclsyntax.Body, dec *blockDef) (*hcl.EvalContext, error) {
+	vars, err := blockVars(b.Blocks, "", dec)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case ctx.Variables == nil:
+		ctx.Variables = vars
+	case len(ctx.Variables) >= len(vars):
+		for k, v := range vars {
+			ctx.Variables[k] = v
+		}
+	default:
+		for k, v := range ctx.Variables {
+			vars[k] = v
+		}
+		ctx.Variables = vars
+	}
+	return ctx, nil
 }
 
 // mayScopeContext returns a new limited context for the given scope with access only
@@ -652,7 +688,7 @@ func isOneRef(v cty.Value) bool {
 	return t.IsObjectType() && t.HasAttribute("__ref")
 }
 
-func (s *State) toResource(ctx *hcl.EvalContext, vr SchemaValidator, block *hclsyntax.Block, scope []string) (spec *Resource, err error) {
+func (s *State) toResource(ctx *hcl.EvalContext, vr SchemaValidator, block *hclsyntax.Block, scope []string, dec *blockDef) (spec *Resource, err error) {
 	closeScope, err := vr.ValidateBlock(ctx, block)
 	if err != nil {
 		return nil, err
@@ -675,11 +711,12 @@ func (s *State) toResource(ctx *hcl.EvalContext, vr SchemaValidator, block *hcls
 	}
 	spec.Attrs = attrs
 	for _, blk := range block.Body.Blocks {
-		ctx, err := setBlockVars(ctx.NewChild(), blk.Body)
+		cdec := dec.child(blk.Type)
+		ctx, err := setLocalVars(ctx.NewChild(), blk.Body, cdec)
 		if err != nil {
 			return nil, err
 		}
-		r, err := s.toResource(ctx, vr, blk, append(scope, blk.Type))
+		r, err := s.toResource(ctx, vr, blk, append(scope, blk.Type), cdec)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
```
benchmark                old ns/op     new ns/op     delta
Benchmark_EvalHCL-16     196478424     170294770     -13.33%

benchmark                old allocs     new allocs     delta
Benchmark_EvalHCL-16     1069863        926489         -13.40%

benchmark                old bytes     new bytes     delta
Benchmark_EvalHCL-16     133138506     122031348     -8.34%
```