### PR TITLE
sql/sqlspec: Revert support `name` attribute on the table resource (#2820)

### DIFF
--- a/internal/integration/hclsqlspec/hclsqlspec_test.go
+++ b/internal/integration/hclsqlspec/hclsqlspec_test.go
@@ -371,10 +371,6 @@ schema "account_b" {
 table "t2" {
 	schema = schema.account_b
 }
-table "t3" {
-	schema = schema.account_b
-	name = "foo"
-}
 `
 
 	for _, tt := range dialects {
@@ -396,14 +392,12 @@ table "t3" {
 						Realm: &r,
 						Tables: []*schema.Table{
 							{Name: "t2"},
-							{Name: "foo"},
 						},
 					},
 				},
 			}
 			exp.Schemas[0].Tables[0].Schema = exp.Schemas[0]
 			exp.Schemas[1].Tables[0].Schema = exp.Schemas[1]
-			exp.Schemas[1].Tables[1].Schema = exp.Schemas[1]
 			require.EqualValues(t, exp, &r)
 			hcl, err := tt.MarshalSpec(&r)
 			require.NoError(t, err)

--- a/sql/sqlspec/sqlspec.go
+++ b/sql/sqlspec/sqlspec.go
@@ -19,7 +19,7 @@ type (
 
 	// Table holds a specification for an SQL table.
 	Table struct {
-		Name        string         `spec:"name,name"`
+		Name        string         `spec:",name"`
 		Qualifier   string         `spec:",qualifier"`
 		Schema      *schemahcl.Ref `spec:"schema"`
 		Columns     []*Column      `spec:"column"`


### PR DESCRIPTION
This reverts commit f8a15b3aa05455cac4de72fd30bcc6c07969d2e5.
