### PR TITLE
cmd/atlas/internal/cmdlog: detect and print error during migrate plan

### DIFF
--- a/cmd/atlas/internal/cmdlog/cmdlog_test.go
+++ b/cmd/atlas/internal/cmdlog/cmdlog_test.go
@@ -617,4 +617,17 @@ func TestMigrateApply(t *testing.T) {
   -- 3 checks ok, 1 failure
   -- 2 sql statements
 `, b.String())
+
+	// Error during plan stage.
+	b.Reset()
+	log.Applied = nil
+	log.Error = `sql/migrate: scanning statements from "20240116000003.sql": 5:115: unclosed quote '\''`
+	require.NoError(t, cmdlog.MigrateApplyTemplate.Execute(&b, log))
+	require.Equal(t, `Migrating to version 20240116000003 from 20240116000001 (2 migrations in total):
+
+    sql/migrate: scanning statements from "20240116000003.sql": 5:115: unclosed quote '\''
+
+  -------------------------
+  -- 10ms
+`, b.String())
 }

--- a/sql/migrate/migrate.go
+++ b/sql/migrate/migrate.go
@@ -783,7 +783,9 @@ func (e *Executor) Execute(ctx context.Context, m File) (err error) {
 	}
 	stmts, err := e.fileStmts(m)
 	if err != nil {
-		return fmt.Errorf("sql/migrate: scanning statements from %q: %w", m.Name(), err)
+		err = fmt.Errorf("sql/migrate: scanning statements from %q: %w", m.Name(), err)
+		e.log.Log(LogError{Error: err})
+		return err
 	}
 	// Create checksums for the statements.
 	var (


### PR DESCRIPTION
Fixed this:
<img width="1157" alt="image" src="https://github.com/ariga/atlas/assets/7413593/b5c29c08-2cd1-4760-8240-fb2199969f06">
