### PR TITLE
Add schema parsing for unix scheme urls

### DIFF
--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -318,7 +318,7 @@ func (parser) ParseURL(u *url.URL) *sqlclient.URL {
 	v := u.Query()
 	v.Set("parseTime", "true")
 	u.RawQuery = v.Encode()
-	return &sqlclient.URL{URL: u, DSN: dsn(u), Schema: strings.TrimPrefix(u.Path, "/")}
+	return &sqlclient.URL{URL: u, DSN: dsn(u), Schema: parseSchema(u)}
 }
 
 // ChangeSchema implements the sqlclient.SchemaChanger interface.
@@ -371,6 +371,17 @@ func dsn(u *url.URL) string {
 		b.WriteString(p)
 	}
 	return b.String()
+}
+
+// parseSchema returns the schema of the url
+// if it exists empty string otherwise.
+func parseSchema(u *url.URL) string {
+	if strings.HasSuffix(u.Scheme, "+unix") {
+		v := u.Query()
+		return v.Get("database")
+	} else {
+		return strings.TrimPrefix(u.Path, "/")
+	}
 }
 
 // MySQL standard column types as defined in its codebase. Name and order

--- a/sql/mysql/driver_test.go
+++ b/sql/mysql/driver_test.go
@@ -39,6 +39,20 @@ func TestParser_ParseURL(t *testing.T) {
 			require.Equal(t, d, p.DSN)
 		}
 	})
+	t.Run("Schema", func(t *testing.T) {
+		for u, d := range map[string]string{
+			"mysql://user:pass@localhost:3306/my_db?foo=bar":    "my_db",
+			"mysql://user:pass@localhost:3306?foo=bar":          "",
+			"mysql+unix:///path/to/socket":                      "",
+			"mysql+unix://user:pass@/path/to/socket":            "",
+			"mysql+unix://user@/path/to/socket?database=dbname": "dbname",
+		} {
+			u1, err := url.Parse(u)
+			require.NoError(t, err)
+			p := parser{}.ParseURL(u1)
+			require.Equal(t, d, p.Schema)
+		}
+	})
 }
 
 func TestDriver_LockAcquired(t *testing.T) {


### PR DESCRIPTION
Fix for #2472

Faced the same issue (altough with atlas migrate) when trying to migrate through a unix socket, seems the issue is here: 

```go
return &sqlclient.URL{URL: u, DSN: dsn(u), Schema: strings.TrimPrefix(u.Path, "/")}
```

Since the url path for unix sockets can contain multiple `/` characters.

Steps to reproduce issue (tested on macOS):

```bash
brew install mysql
mysql.server start
mysql -u root

# mysql 
create schema test;

# in atlas cmd directory, current master branch
go build .
./atlas schema inspect -u "mysql+unix://root@/tmp/mysql.sock?database=test"

# Error: mysql: schema "tmp/mysql.sock" was not found

git checkout fix-unix-schema-parse
go build .
./atlas schema inspect -u "mysql+unix://root@/tmp/mysql.sock?database=test"

# schema "test" {
#   charset = "utf8mb4"
#   collate = "utf8mb4_0900_ai_ci"
# } 
```

There is a function in the go-sql-driver/mysql that could be used to parse the DSN and extract the schema, but didn't want to add another dependency to this repo without approval so kept it simple here! 

Feel free to suggest improvements or comments on the code, I don't have all the context of atlas so might have missed something! @ttc0419 could maybe have a look and see if it solved the issue for them as well!