### PR TITLE
doc/md/atlas-schema: add clickhouse hcl syntax for primary key expressions

### DIFF
--- a/doc/md/atlas-schema/hcl.mdx
+++ b/doc/md/atlas-schema/hcl.mdx
@@ -622,6 +622,9 @@ primary key.
 
 #### Example
 
+<Tabs>
+<TabItem label="Columns" value="columns">
+
 ```hcl
 primary_key {
   columns = [column.id]
@@ -632,7 +635,36 @@ primary_key {
 
 | Name    | Kind      | Type                     | Description                                                    |
 |---------|-----------|--------------------------|----------------------------------------------------------------|
-| columns | resource  | reference (list)         | A list of references to columns that comprise the primary key. |
+| columns | attribute | reference (list)         | A list of references to columns that comprise the primary key. |
+
+</TabItem>
+<TabItem label="Expressions" value="expr">
+
+:::info
+Note, primary key expressions are supported by ClickHouse.
+::: 
+
+```hcl
+primary_key {
+  on {
+    column = column.id
+  }
+  on {
+    expr = "c1 + c2"
+  }
+}
+```
+
+#### Properties
+
+| Name    | Kind      | Type                     | Description                                                    |
+|---------|-----------|--------------------------|----------------------------------------------------------------|
+| on      | resource  | schema.IndexPart (list)  | The index parts that comprise the index                        |
+
+</TabItem>
+</Tabs>
+
+
 
 ## Foreign Key
 


### PR DESCRIPTION
<img width="910" alt="Screenshot 2024-06-20 at 01 18 58" src="https://github.com/ariga/atlas/assets/16095902/c2b4d02f-7841-4ba1-bf0f-049ecfdeb240">

<img width="917" alt="Screenshot 2024-06-20 at 01 22 47" src="https://github.com/ariga/atlas/assets/16095902/287be7de-9022-4d74-9a30-edfc51707e9d">
