### PR TITLE
sql/schema: add diff mode

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -685,6 +685,8 @@ func migrateDiffRun(cmd *cobra.Command, args []string, flags migrateDiffFlags, e
 	if f, indent, err = mayIndent(u, f, flags.format); err != nil {
 		return err
 	}
+	diffOpts := diffOptions(cmd, env)
+	diffOpts = append(diffOpts, schema.DiffNormalized())
 	// If there is a state-loader that requires a custom
 	// 'migrate diff' handling, offload it the work.
 	if d, ok := cmdext.States.Differ(flags.desiredURLs); ok {
@@ -694,7 +696,7 @@ func migrateDiffRun(cmd *cobra.Command, args []string, flags migrateDiffFlags, e
 			Indent:  indent,
 			Dir:     dir,
 			Dev:     dev,
-			Options: diffOptions(cmd, env),
+			Options: diffOpts,
 		})
 		return maskNoPlan(cmd, err)
 	}
@@ -713,7 +715,7 @@ func migrateDiffRun(cmd *cobra.Command, args []string, flags migrateDiffFlags, e
 	opts := []migrate.PlannerOption{
 		migrate.PlanFormat(f),
 		migrate.PlanWithIndent(indent),
-		migrate.PlanWithDiffOptions(diffOptions(cmd, env)...),
+		migrate.PlanWithDiffOptions(diffOpts...),
 	}
 	if dev.URL.Schema != "" {
 		// Disable tables qualifier in schema-mode.

--- a/internal/integration/testdata/mysql/cli-migrate-diff-mode-normalized.txt
+++ b/internal/integration/testdata/mysql/cli-migrate-diff-mode-normalized.txt
@@ -1,0 +1,35 @@
+only mysql
+
+atlas migrate hash
+
+# Migrate diff wants to drop the unique index.
+atlas migrate diff --dev-url URL --to file://./schema.sql
+! stdout 'no changes'
+cmpmig 1 expected.sql
+
+-- migrations/1.sql --
+CREATE TABLE `ref` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id`)
+) CHARSET utf8mb4 COLLATE utf8mb4_bin;
+CREATE TABLE `tbl` (
+  `ref_id` bigint NOT NULL,
+  UNIQUE INDEX `u_ref_id` (`ref_id`), -- expected to be dropped
+  INDEX `ref_id` (`ref_id`),
+  FOREIGN KEY (`ref_id`) REFERENCES `ref` (`id`)
+) CHARSET utf8mb4 COLLATE utf8mb4_bin;
+
+-- schema.sql --
+CREATE TABLE `ref` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id`)
+) CHARSET utf8mb4 COLLATE utf8mb4_bin;
+CREATE TABLE `tbl` (
+  `ref_id` bigint NOT NULL,
+  INDEX `ref_id` (`ref_id`),
+  FOREIGN KEY (`ref_id`) REFERENCES `ref` (`id`)
+) CHARSET utf8mb4 COLLATE utf8mb4_bin;
+
+-- expected.sql --
+-- Modify "tbl" table
+ALTER TABLE `tbl` DROP INDEX `u_ref_id`;

--- a/sql/internal/sqlx/diff.go
+++ b/sql/internal/sqlx/diff.go
@@ -82,7 +82,7 @@ type (
 	// If the DiffDriver implements the Normalizer interface, TableDiff normalizes its table
 	// inputs before starting the diff process.
 	Normalizer interface {
-		Normalize(from, to *schema.Table) error
+		Normalize(from, to *schema.Table, opts *schema.DiffOptions) error
 	}
 
 	// TableFinder wraps the FindTable method, providing more
@@ -297,7 +297,7 @@ func (d *Diff) tableDiff(from, to *schema.Table, opts *schema.DiffOptions) ([]sc
 	}
 	// Normalizing tables before starting the diff process.
 	if n, ok := d.DiffDriver.(Normalizer); ok {
-		if err := n.Normalize(from, to); err != nil {
+		if err := n.Normalize(from, to, opts); err != nil {
 			return nil, err
 		}
 	}

--- a/sql/migrate/migrate.go
+++ b/sql/migrate/migrate.go
@@ -135,9 +135,9 @@ func (f StateReaderFunc) ReadState(ctx context.Context) (*schema.Realm, error) {
 // List of migration planning modes.
 const (
 	PlanModeUnset        PlanMode = iota // Driver default.
-	PlanModeInPlace                      // Changes are applied inplace (e.g., 'schema diff').
-	PlanModeDeferred                     // Changes are planned for future applying (e.g., 'migrate diff').
-	PlanModeDump                         // Schema creation dump (e.g., 'schema inspect').
+	PlanModeInPlace                      // Changes are applied in place (e.g. 'schema diff').
+	PlanModeDeferred                     // Changes are planned for future applying (e.g. 'migrate diff').
+	PlanModeDump                         // Schema creation dump (e.g. 'schema inspect').
 	PlanModeUnsortedDump                 // Schema creation demo without sorting dependencies.
 )
 

--- a/sql/mysql/diff.go
+++ b/sql/mysql/diff.go
@@ -210,7 +210,10 @@ func (*diff) ReferenceChanged(from, to schema.ReferenceOption) bool {
 }
 
 // Normalize implements the sqlx.Normalizer interface.
-func (d *diff) Normalize(from, to *schema.Table) error {
+func (d *diff) Normalize(from, to *schema.Table, opts *schema.DiffOptions) error {
+	if opts.Mode.Is(schema.DiffModeNormalized) {
+		return nil // already normalized
+	}
 	indexes := make([]*schema.Index, 0, len(from.Indexes))
 	for _, idx := range from.Indexes {
 		// MySQL requires that foreign key columns be indexed; Therefore, if the child

--- a/sql/postgres/crdb.go
+++ b/sql/postgres/crdb.go
@@ -72,7 +72,7 @@ func (i *crdbInspect) InspectRealm(ctx context.Context, opts *schema.InspectReal
 }
 
 // Normalize implements the sqlx.Normalizer.
-func (cd *crdbDiff) Normalize(from, to *schema.Table) error {
+func (cd *crdbDiff) Normalize(from, to *schema.Table, _ *schema.DiffOptions) error {
 	cd.normalize(from)
 	cd.normalize(to)
 	return nil

--- a/sql/sqlite/diff.go
+++ b/sql/sqlite/diff.go
@@ -167,7 +167,7 @@ func (*diff) ReferenceChanged(from, to schema.ReferenceOption) bool {
 }
 
 // Normalize implements the sqlx.Normalizer interface.
-func (d *diff) Normalize(from, to *schema.Table) error {
+func (d *diff) Normalize(from, to *schema.Table, _ *schema.DiffOptions) error {
 	used := make([]bool, len(to.ForeignKeys))
 	// In SQLite, there is no easy way to get the foreign-key constraint
 	// name, except for parsing the CREATE statement. Therefore, we check


### PR DESCRIPTION
If the input to diffing is already normalized, we can skip manual normalization that as in place before there was the dev connection.