### PR TITLE
cmd/atlas: extendctx can return an error

### DIFF
--- a/cmd/atlas/main.go
+++ b/cmd/atlas/main.go
@@ -49,9 +49,14 @@ func main() {
 		<-stop // will not block if no signal received due to main routine exiting
 		os.Exit(1)
 	}()
-	ctx, done := initialize(extendContext(ctx))
+	ctx, err := extendContext(ctx)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ctx, done := initialize(ctx)
 	update := checkForUpdate(ctx)
-	err := cmdapi.Root.ExecuteContext(ctx)
+	err = cmdapi.Root.ExecuteContext(ctx)
 	if u := update(); u != "" {
 		fmt.Fprintln(os.Stderr, u)
 	}

--- a/cmd/atlas/main_oss.go
+++ b/cmd/atlas/main_oss.go
@@ -10,7 +10,9 @@ import (
 	"context"
 )
 
-func extendContext(ctx context.Context) context.Context { return ctx }
+func extendContext(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
 
 func vercheckEndpoint(context.Context) string {
 	return vercheckURL


### PR DESCRIPTION
already reviewed internally 