### PR TITLE
all: update go version

### DIFF
--- a/cmd/atlas/go.mod
+++ b/cmd/atlas/go.mod
@@ -1,8 +1,6 @@
 module ariga.io/atlas/cmd/atlas
 
-go 1.22.3
-
-toolchain go1.22.5
+go 1.22.5
 
 replace ariga.io/atlas => ../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module ariga.io/atlas
 
-go 1.22.3
-
-toolchain go1.22.4
+go 1.22.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/internal/integration/go.mod
+++ b/internal/integration/go.mod
@@ -1,8 +1,6 @@
 module ariga.io/atlas/internal/integration
 
-go 1.22.3
-
-toolchain go1.22.5
+go 1.22.5
 
 replace ariga.io/atlas => ../../
 


### PR DESCRIPTION
Fix CVE-2024-24791. Updating "just" the toolchain is not enough.