### PR TITLE
sql/migrate: add FormatFile for TemplateFormatter

### DIFF
--- a/cmd/atlas/internal/cmdext/reader.go
+++ b/cmd/atlas/internal/cmdext/reader.go
@@ -44,10 +44,11 @@ type (
 )
 
 // Close redirects calls to Close to the enclosed io.Closer.
-func (r *StateReadCloser) Close() {
+func (r *StateReadCloser) Close() error {
 	if r.Closer != nil {
-		r.Closer.Close()
+		return r.Closer.Close()
 	}
+	return nil
 }
 
 // StateReaderSQL returns a migrate.StateReader from an SQL file or a directory of migrations.

--- a/cmd/atlas/internal/cmdlog/cmdlog.go
+++ b/cmd/atlas/internal/cmdlog/cmdlog.go
@@ -31,6 +31,7 @@ import (
 
 var (
 	ColorCyan         = color.CyanString
+	ColorGray         = color.New(color.Attribute(90))
 	ColorGreen        = color.HiGreenString
 	ColorRed          = color.HiRedString
 	ColorRedBgWhiteFg = color.New(color.FgHiWhite, color.BgHiRed).SprintFunc()

--- a/cmd/atlas/internal/migratelint/run.go
+++ b/cmd/atlas/internal/migratelint/run.go
@@ -16,7 +16,6 @@ import (
 	"text/template"
 	"time"
 
-	"ariga.io/atlas/cmd/atlas/internal/cmdlog"
 	"ariga.io/atlas/sql/migrate"
 	"ariga.io/atlas/sql/sqlcheck"
 	"ariga.io/atlas/sql/sqlclient"
@@ -187,7 +186,7 @@ func (r *Runner) analyze(ctx context.Context, files []*sqlcheck.File) error {
 
 var (
 	// TemplateFuncs are global functions available in templates.
-	TemplateFuncs = cmdlog.WithColorFuncs(template.FuncMap{
+	TemplateFuncs = template.FuncMap{
 		"json": func(v any, args ...string) (string, error) {
 			var (
 				b   []byte
@@ -226,7 +225,12 @@ var (
 			}
 			return append(lines, strings.Join(words[j:], " "))
 		},
-	})
+		"cyan":         color.CyanString,
+		"green":        color.HiGreenString,
+		"red":          color.HiRedString,
+		"redBgWhiteFg": color.New(color.FgHiWhite, color.BgHiRed).SprintFunc(),
+		"yellow":       color.YellowString,
+	}
 	// DefaultTemplate is the default template used by the CI job.
 	DefaultTemplate = template.Must(template.New("report").
 			Funcs(TemplateFuncs).

--- a/sql/migrate/dir.go
+++ b/sql/migrate/dir.go
@@ -561,6 +561,18 @@ func (t TemplateFormatter) Format(plan *Plan) ([]File, error) {
 	return files, nil
 }
 
+// FormatFile is like Format, but expects and returns a single file.
+func (t TemplateFormatter) FormatFile(p *Plan) (File, error) {
+	files, err := t.Format(p)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) != 1 {
+		return nil, fmt.Errorf("expected a single file, got %d", len(files))
+	}
+	return files[0], nil
+}
+
 // FormatTo calls Format and writes the files' content to the given writer.
 func (t TemplateFormatter) FormatTo(plan *Plan, w io.Writer) error {
 	files, err := t.Format(plan)


### PR DESCRIPTION
Avoid `len` checks whenever `Format` is called on the default template. 