### PR TITLE
Upversion actions/checkout

### DIFF
--- a/.github/workflows/cd-docker-push-cockroach_oss.yaml
+++ b/.github/workflows/cd-docker-push-cockroach_oss.yaml
@@ -12,7 +12,7 @@ jobs:
   build-services:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version: '1.22'

--- a/.github/workflows/cd-docker-push-mysql_oss.yaml
+++ b/.github/workflows/cd-docker-push-mysql_oss.yaml
@@ -36,7 +36,7 @@ jobs:
           - dialect: mariadb:10.7
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/cd-website_oss.yaml
+++ b/.github/workflows/cd-website_oss.yaml
@@ -13,7 +13,7 @@ jobs:
       run:
         working-directory: ./doc/website
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: 16

--- a/.github/workflows/ci-dialect_oss.yaml
+++ b/.github/workflows/ci-dialect_oss.yaml
@@ -27,7 +27,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -54,7 +54,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -81,7 +81,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -108,7 +108,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -135,7 +135,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -162,7 +162,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -188,7 +188,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -214,7 +214,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -240,7 +240,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -266,7 +266,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -292,7 +292,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -318,7 +318,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -344,7 +344,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -357,7 +357,7 @@ jobs:
   integration-sqlite:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -372,7 +372,7 @@ jobs:
         ports:
           - 4309:4000
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -387,7 +387,7 @@ jobs:
         ports:
           - 4310:4000
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -402,7 +402,7 @@ jobs:
         ports:
           - 26257:26257
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod

--- a/.github/workflows/ci-go_oss.yaml
+++ b/.github/workflows/ci-go_oss.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '1.22'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run linters
         uses: golangci/golangci-lint-action@v3
         with:
@@ -34,7 +34,7 @@ jobs:
   generate-cmp:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -59,7 +59,7 @@ jobs:
       matrix:
         go: [ "1.22" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
@@ -73,7 +73,7 @@ jobs:
   cli:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod
@@ -84,7 +84,7 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: cmd/atlas/go.mod

--- a/.github/workflows/ci-revisions_oss.yaml
+++ b/.github/workflows/ci-revisions_oss.yaml
@@ -18,7 +18,7 @@ jobs:
   revisions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-go@v4

--- a/.github/workflows/ci-website_oss.yaml
+++ b/.github/workflows/ci-website_oss.yaml
@@ -11,7 +11,7 @@ jobs:
       run:
         working-directory: ./doc/website
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: 16


### PR DESCRIPTION
This PR upversions the github action `actions/checkout` to `actions/checkout@v4`.

Lower versions ran on Node.js 16, which is deprecated by Github. Runs using v2 have a deprecation warning, as can be viewed at the bottom of https://github.com/ariga/atlas/actions/runs/10334038800

v4 runs on Node.js 20, which clears these deprecation warnings. 

More information on this can be found at https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
