### PR TITLE
doc/md: fix values.yaml in monitoring docs

### DIFF
--- a/doc/md/monitoring/05-helm.mdx
+++ b/doc/md/monitoring/05-helm.mdx
@@ -38,6 +38,15 @@ apiKeySecret:
   key: api-key
 image:
   tag: "latest"
+livenessProbe:
+  httpGet:
+    path: /livez
+    port: 80
+readinessProbe:
+  initialDelaySeconds: 5
+  httpGet:
+    path: /readyz
+    port: 80
 extraEnvs:
   - name: ATLAS_AGENT_DB_PASSWORD
     valueFrom:


### PR DESCRIPTION
default port is 80, not 8080