### PR TITLE
Fixed documentation typo in `projects.mdx`

### DIFF
--- a/doc/md/atlas-schema/projects.mdx
+++ b/doc/md/atlas-schema/projects.mdx
@@ -294,7 +294,7 @@ data "hcl_schema" "app" {
 }
 
 env "local" {
-  src = data.hcl_schema.app.url
+  src = data.hcl_schema.app.path
   url = "sqlite://test?mode=memory&_fk=1"
 }
 ```


### PR DESCRIPTION
A documentation example had a typo referencing `src = data.hcl_schema.app.url` when it should be `src = data.hcl_schema.app.path`