### PR TITLE
cmd/atlas/internal/cmdapi: support schema attrs in env:// references

### DIFF
--- a/cmd/atlas/internal/cmdapi/project.go
+++ b/cmd/atlas/internal/cmdapi/project.go
@@ -249,6 +249,25 @@ func (e *Env) VarFromURL(s string) (string, error) {
 		sv = e.URL
 	case "dev":
 		sv = e.DevURL
+	case "src":
+		switch n := len(e.Schemas); {
+		case n == 0:
+			return "", fmt.Errorf("env://%s: no schema defined in env %q", u.Host, e.Name)
+		case n > 1:
+			return "", fmt.Errorf("env://%s: expect one schema in env %q, got %d", u.Host, e.Name, n)
+		case n == 1:
+			sv = e.Schemas[0]
+		}
+	case "schema.src":
+		if e.Schema == nil || e.Schema.Src == "" {
+			return "", fmt.Errorf("env://%s: no schema defined in env %q", u.Host, e.Name)
+		}
+		sv = e.Schema.Src
+	case "migration.dir":
+		if e.Migration == nil || e.Migration.Dir == "" {
+			return "", fmt.Errorf("env://%s: no migration dir defined in env %q", u.Host, e.Name)
+		}
+		sv = e.Migration.Dir
 	default:
 		attr, ok := e.Attr(u.Host)
 		if !ok {

--- a/cmd/atlas/internal/cmdapi/project_test.go
+++ b/cmd/atlas/internal/cmdapi/project_test.go
@@ -221,6 +221,15 @@ env "multi" {
 		sources, err := env.Sources()
 		require.NoError(t, err)
 		require.EqualValues(t, []string{"local/app.hcl"}, sources)
+
+		v, err := env.VarFromURL("env://dev")
+		require.NoError(t, err)
+		require.Equal(t, "docker://mysql/8", v)
+		_, err = env.VarFromURL("env://src")
+		require.EqualError(t, err, `env://src: expect one schema in env "local", got 2`)
+		v, err = env.VarFromURL("env://migration.dir")
+		require.NoError(t, err)
+		require.Equal(t, "file://migrations", v)
 	})
 	t.Run("multi", func(t *testing.T) {
 		_, envs, err := EnvByName(&cobra.Command{}, "multi", nil)


### PR DESCRIPTION
Just for convenience, we should support these standard attributes.