### PR TITLE
Fix/2802 mysql invisible attribute

### DIFF
--- a/sql/mysql/driver.go
+++ b/sql/mysql/driver.go
@@ -464,6 +464,7 @@ const (
 	currentTS     = "current_timestamp"
 	defaultGen    = "default_generated"
 	autoIncrement = "auto_increment"
+	invisible = "INVISIBLE" 
 
 	virtual    = "VIRTUAL"
 	stored     = "STORED"

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -837,6 +837,10 @@ type (
 		V int64
 	}
 
+	Invisible struct {
+		schema.Attr
+	}
+
 	// CreateOptions attribute for describing extra options used with CREATE TABLE.
 	CreateOptions struct {
 		schema.Attr

--- a/sql/mysql/inspect.go
+++ b/sql/mysql/inspect.go
@@ -294,6 +294,8 @@ func (i *inspect) addColumn(s *schema.Schema, rows *sql.Rows) error {
 	if err != nil {
 		return err
 	}
+	// The column has an expression default value,
+	// and it is handled in Driver.addColumn.
 	if attr.autoinc {
 		a := &AutoIncrement{}
 		if !sqlx.Has(t.Attrs, a) {
@@ -306,6 +308,9 @@ func (i *inspect) addColumn(s *schema.Schema, rows *sql.Rows) error {
 	}
 	if attr.onUpdate != "" {
 		c.Attrs = append(c.Attrs, &OnUpdate{A: attr.onUpdate})
+	}
+	if attr.invisible {
+		c.Attrs = append(c.Attrs, &Invisible{})
 	}
 	if x := expr.String; x != "" {
 		if !i.Maria() {
@@ -519,33 +524,56 @@ type extraAttr struct {
 	onUpdate         string
 	generatedType    string
 	defaultGenerated bool
+	invisible        bool
 }
 
 var (
-	reGenerateType = regexp.MustCompile(`(?i)^(stored|persistent|virtual) generated$`)
-	reTimeOnUpdate = regexp.MustCompile(`(?i)^(?:default_generated )?on update (current_timestamp(?:\(\d?\))?)$`)
+	reTimeOnUpdate  = regexp.MustCompile(`(?i)^(?:default_generated )?on update (current_timestamp(?:\(\d?\))?)$`)
+	reGenerateType  = regexp.MustCompile(`(?i)^(virtual|stored|persistent)( generated)?|generated always as \((.*)\) (stored|virtual|persistent)$`)
+	reAutoIncrement = regexp.MustCompile(`(?i)\bauto_increment\b`)
+	reDefaultGen    = regexp.MustCompile(`(?i)\bDEFAULT_GENERATED\b`)
+	reInvisible     = regexp.MustCompile(`(?i)\bINVISIBLE\b`)
 )
 
 // parseExtra returns a parsed version of the EXTRA column
 // from the INFORMATION_SCHEMA.COLUMNS table.
 func parseExtra(extra string) (*extraAttr, error) {
 	attr := &extraAttr{}
-	switch el := strings.ToLower(extra); {
-	case el == "", el == "null":
-	case el == defaultGen:
-		attr.defaultGenerated = true
-		// The column has an expression default value,
-		// and it is handled in Driver.addColumn.
-	case el == autoIncrement:
-		attr.autoinc = true
-	case reTimeOnUpdate.MatchString(extra):
-		attr.onUpdate = reTimeOnUpdate.FindStringSubmatch(extra)[1]
-	case reGenerateType.MatchString(extra):
-		attr.generatedType = reGenerateType.FindStringSubmatch(extra)[1]
-	default:
-		return nil, fmt.Errorf("unknown extra column attribute %q", extra)
+
+	if extra == "" || strings.ToLower(extra) == "null" {
+		return attr, nil
 	}
-	return attr, nil
+
+	if reDefaultGen.MatchString(extra) {
+		attr.defaultGenerated = true
+	}
+
+	if reAutoIncrement.MatchString(extra) {
+		attr.autoinc = true
+	}
+
+	if reInvisible.MatchString(extra) {
+		attr.invisible = true
+	}
+
+	if match := reTimeOnUpdate.FindStringSubmatch(extra); match != nil {
+		attr.onUpdate = match[1]
+	}
+
+	if match := reGenerateType.FindStringSubmatch(extra); match != nil {
+		if match[1] != "" {
+			attr.generatedType = strings.ToUpper(match[1])
+		} else if match[4] != "" {
+			attr.generatedType = strings.ToUpper(match[4])
+		}
+
+	}
+
+	if attr.defaultGenerated || attr.autoinc || attr.invisible || attr.onUpdate != "" || attr.generatedType != "" {
+		return attr, nil
+	}
+
+	return nil, fmt.Errorf("unknown extra column attribute %q", extra)
 }
 
 // showCreate sets and fixes schema elements that require information from

--- a/sql/mysql/migrate.go
+++ b/sql/mysql/migrate.go
@@ -600,6 +600,9 @@ func (s *state) column(b *sqlx.Builder, t *schema.Table, c *schema.Column) error
 			if a.V > 0 && !sqlx.Has(t.Attrs, &AutoIncrement{}) {
 				t.Attrs = append(t.Attrs, a)
 			}
+		case *Invisible:
+			b.P("INVISIBLE")
+
 		default:
 			s.attr(b, a)
 		}

--- a/sql/mysql/sqlspec.go
+++ b/sql/mysql/sqlspec.go
@@ -262,6 +262,15 @@ func convertColumn(spec *sqlspec.Column, _ *schema.Table) (*schema.Column, error
 			c.AddAttrs(&AutoIncrement{})
 		}
 	}
+	if attr, ok := spec.Attr("invisible"); ok {
+		b, err := attr.Bool()
+		if err != nil {
+			return nil, err
+		}
+		if b {
+			c.AddAttrs(&Invisible{})
+		}
+	}
 	if err := specutil.ConvertGenExpr(spec.Remain(), c, storedOrVirtual); err != nil {
 		return nil, err
 	}
@@ -383,6 +392,9 @@ func columnSpec(c *schema.Column, t *schema.Table) (*sqlspec.Column, error) {
 	}
 	if sqlx.Has(c.Attrs, &AutoIncrement{}) {
 		spec.Extra.Attrs = append(spec.Extra.Attrs, schemahcl.BoolAttr("auto_increment", true))
+	}
+	if sqlx.Has(c.Attrs, &Invisible{}) {
+		spec.Extra.Attrs = append(spec.Extra.Attrs, schemahcl.BoolAttr("invisible", true))
 	}
 	if x := (schema.GeneratedExpr{}); sqlx.Has(c.Attrs, &x) {
 		spec.Extra.Children = append(spec.Extra.Children, specutil.FromGenExpr(x, storedOrVirtual))


### PR DESCRIPTION
### Description

This pull request fixes [Issue #2802](https://github.com/ariga/atlas/issues/2802) by supporting the `INVISIBLE` column attribute in MySQL. 
### Main Changes
* Adjust the `parseExtra` to support mul multiple attribute values in "extra" column using regex
* Adjusting `inspect` to support invisible attribute
* Adjusting `migrate` and `sqlspec` to support invisible attribute
* Adjusting and adding relevant test

### How to Test

1. **Create a Docker Compose File**

   In the root directory of your project, create a `docker-compose.yml` file with the following content:

   ```yaml
   version: '3.8'

   services:
     mysql:
       image: mysql:8.0
       container_name: mysql_atlas_bug_test
       restart: unless-stopped
       environment:
         MYSQL_ROOT_PASSWORD: rootpassword
         MYSQL_DATABASE: atlas_bug_test
         MYSQL_USER: testuser
         MYSQL_PASSWORD: testpassword
       ports:
         - "3306:3306"
       volumes:
         - ./mysql/init:/docker-entrypoint-initdb.d
         - mysql_data:/var/lib/mysql
       command: --default-authentication-plugin=mysql_native_password

   volumes:
     mysql_data:
   ```

2. **Add the Schema**

   In the root directory, create a folder named `mysql/init` and add a SQL file (e.g., `init.sql`) with the following content:

   ```sql
   USE atlas_bug_test;

   CREATE TABLE users (
       id INT AUTO_INCREMENT PRIMARY KEY,
       username VARCHAR(50) NOT NULL,
       email VARCHAR(100) NOT NULL,
       email_length INT GENERATED ALWAYS AS (CHAR_LENGTH(email)) STORED INVISIBLE
   );
   ```

3. **Compile the Code**

   Compile your Atlas project to ensure all changes are built.

4. **Run the Inspection Command**

   Execute the following command to inspect the schema:

   ```bash
   atlas schema inspect --url mysql://testuser:testpassword@localhost:3306/atlas_bug_test > schema.atlas
   ```
