### PR TITLE
sql: support diffing check expressions when diff is normalized

### DIFF
--- a/cmd/atlas/internal/cmdapi/cmdapi_oss.go
+++ b/cmd/atlas/internal/cmdapi/cmdapi_oss.go
@@ -253,7 +253,7 @@ func migrateDiffRun(cmd *cobra.Command, args []string, flags migrateDiffFlags, e
 	if f, indent, err = mayIndent(u, f, flags.format); err != nil {
 		return err
 	}
-	diffOpts := append(diffOptions(cmd, env), schema.DiffNormalized())
+	diffOpts := diffOptions(cmd, env)
 	// If there is a state-loader that requires a custom
 	// 'migrate diff' handling, offload it the work.
 	if d, ok := cmdext.States.Differ(flags.desiredURLs); ok {
@@ -481,7 +481,7 @@ var specOptions []schemahcl.Option
 
 // diffOptions returns environment-aware diff options.
 func diffOptions(_ *cobra.Command, env *Env) []schema.DiffOption {
-	return env.DiffOptions()
+	return append(env.DiffOptions(), schema.DiffNormalized())
 }
 
 // openClient allows opening environment-aware clients.

--- a/sql/mysql/diff.go
+++ b/sql/mysql/diff.go
@@ -66,7 +66,7 @@ func (*diff) SchemaObjectDiff(_, _ *schema.Schema, _ *schema.DiffOptions) ([]sch
 }
 
 // TableAttrDiff returns a changeset for migrating table attributes from one state to the other.
-func (d *diff) TableAttrDiff(from, to *schema.Table) ([]schema.Change, error) {
+func (d *diff) TableAttrDiff(from, to *schema.Table, opts *schema.DiffOptions) ([]schema.Change, error) {
 	var changes []schema.Change
 	if change := d.autoIncChange(from.Attrs, to.Attrs); change != noChange {
 		changes = append(changes, change)
@@ -94,7 +94,7 @@ func (d *diff) TableAttrDiff(from, to *schema.Table) ([]schema.Change, error) {
 	// also cannot be dropped using "DROP CONSTRAINTS", but can be modified and dropped
 	// using "MODIFY COLUMN".
 	var checks []schema.Change
-	for _, c := range sqlx.CheckDiff(from, to, func(c1, c2 *schema.Check) bool {
+	for _, c := range sqlx.CheckDiffMode(from, to, opts.Mode, func(c1, c2 *schema.Check) bool {
 		return enforced(c1.Attrs) == enforced(c2.Attrs)
 	}) {
 		drop, ok := c.(*schema.DropCheck)

--- a/sql/postgres/diff_oss.go
+++ b/sql/postgres/diff_oss.go
@@ -57,7 +57,7 @@ func skipDefaultComment(s *schema.Schema, public string) []schema.Attr {
 }
 
 // TableAttrDiff returns a changeset for migrating table attributes from one state to the other.
-func (d *diff) TableAttrDiff(from, to *schema.Table) ([]schema.Change, error) {
+func (d *diff) TableAttrDiff(from, to *schema.Table, opts *schema.DiffOptions) ([]schema.Change, error) {
 	var changes []schema.Change
 	if change := sqlx.CommentDiff(from.Attrs, to.Attrs); change != nil {
 		changes = append(changes, change)
@@ -70,7 +70,7 @@ func (d *diff) TableAttrDiff(from, to *schema.Table) ([]schema.Change, error) {
 		return nil, err
 	}
 	changes = append(changes, change...)
-	return append(changes, sqlx.CheckDiff(from, to, func(c1, c2 *schema.Check) bool {
+	return append(changes, sqlx.CheckDiffMode(from, to, opts.Mode, func(c1, c2 *schema.Check) bool {
 		return sqlx.Has(c1.Attrs, &NoInherit{}) == sqlx.Has(c2.Attrs, &NoInherit{})
 	})...), nil
 }

--- a/sql/sqlite/diff.go
+++ b/sql/sqlite/diff.go
@@ -41,7 +41,7 @@ func (*diff) SchemaObjectDiff(_, _ *schema.Schema, _ *schema.DiffOptions) ([]sch
 }
 
 // TableAttrDiff returns a changeset for migrating table attributes from one state to the other.
-func (d *diff) TableAttrDiff(from, to *schema.Table) ([]schema.Change, error) {
+func (d *diff) TableAttrDiff(from, to *schema.Table, opts *schema.DiffOptions) ([]schema.Change, error) {
 	var changes []schema.Change
 	for _, a := range []schema.Attr{&WithoutRowID{}, &Strict{}} {
 		switch {
@@ -55,7 +55,7 @@ func (d *diff) TableAttrDiff(from, to *schema.Table) ([]schema.Change, error) {
 			})
 		}
 	}
-	return append(changes, sqlx.CheckDiff(from, to)...), nil
+	return append(changes, sqlx.CheckDiffMode(from, to, opts.Mode)...), nil
 }
 
 func (*diff) ViewAttrChanges(_, _ *schema.View) []schema.Change {


### PR DESCRIPTION
Until now, checks were skipped in comparisons before dev-databases was a thing in Atlas. Now, that dev-databases are a standard (must-have) thing in Atlas, objects are ~always normalized, allowing us to consistently compare expressions.

**Approved internally.**