### PR TITLE
Introducing Atlas Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Twitter](https://img.shields.io/twitter/url.svg?label=Follow%20%40ariga%2Fatlas&style=social&url=https%3A%2F%2Ftwitter.com%2Fatlasgo_io)](https://twitter.com/atlasgo_io)
 [![Discord](https://img.shields.io/discord/930720389120794674?label=discord&logo=discord&style=flat-square&logoColor=white)](https://discord.com/invite/zZ6sWVg6NT)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Atlas%20Guru-006BFF)](https://gurubase.io/g/atlas)
 
 <p>
   <a href="https://atlasgo.io" target="_blank">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Atlas Guru](https://gurubase.io/g/atlas) to Gurubase. Atlas Guru uses the data from this repo and data from the [docs](https://atlasgo.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "Atlas Guru", which highlights that Atlas now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Atlas Guru in Gurubase, just let me know that's totally fine.
