### PR TITLE
fix: an error that occurs when collation contains hyphen or dot

### DIFF
--- a/sql/postgres/migrate_oss.go
+++ b/sql/postgres/migrate_oss.go
@@ -1081,7 +1081,7 @@ func (s *state) indexParts(b *sqlx.Builder, idx *schema.Index) (err error) {
 
 func (s *state) partAttrs(b *sqlx.Builder, idx *schema.Index, p *schema.IndexPart) error {
 	if c := (schema.Collation{}); sqlx.Has(p.Attrs, &c) {
-		b.P("COLLATE").Ident(strconv.Quote(c.V))
+		b.P("COLLATE").Ident(collate.V)
 	}
 	if op := (IndexOpClass{}); sqlx.Has(p.Attrs, &op) {
 		d, err := op.DefaultFor(idx, p)

--- a/sql/postgres/migrate_oss.go
+++ b/sql/postgres/migrate_oss.go
@@ -817,7 +817,7 @@ func (s *state) alterType(b *sqlx.Builder, alter *changeGroup, t *schema.Table, 
 		b.P("TYPE", f)
 	}
 	if collate := (schema.Collation{}); sqlx.Has(c.To.Attrs, &collate) {
-		b.P("COLLATE", collate.V)
+		b.P("COLLATE", strconv.Quote(collate.V))
 	}
 	if using := (ConvertUsing{}); sqlx.Has(c.Extra, &using) {
 		b.P("USING", using.X)
@@ -1012,7 +1012,7 @@ func (s *state) column(b *sqlx.Builder, c *schema.Column) error {
 	b.P("NULL")
 	s.columnDefault(b, c)
 	if collate := (schema.Collation{}); sqlx.Has(c.Attrs, &collate) {
-		b.P("COLLATE").Ident(collate.V)
+		b.P("COLLATE").Ident(strconv.Quote(collate.V))
 	}
 	switch hasI, hasX := sqlx.Has(c.Attrs, &Identity{}), sqlx.Has(c.Attrs, &schema.GeneratedExpr{}); {
 	case hasI && hasX:
@@ -1081,7 +1081,7 @@ func (s *state) indexParts(b *sqlx.Builder, idx *schema.Index) (err error) {
 
 func (s *state) partAttrs(b *sqlx.Builder, idx *schema.Index, p *schema.IndexPart) error {
 	if c := (schema.Collation{}); sqlx.Has(p.Attrs, &c) {
-		b.P("COLLATE").Ident(c.V)
+		b.P("COLLATE").Ident(strconv.Quote(c.V))
 	}
 	if op := (IndexOpClass{}); sqlx.Has(p.Attrs, &op) {
 		d, err := op.DefaultFor(idx, p)

--- a/sql/postgres/migrate_oss.go
+++ b/sql/postgres/migrate_oss.go
@@ -1081,7 +1081,7 @@ func (s *state) indexParts(b *sqlx.Builder, idx *schema.Index) (err error) {
 
 func (s *state) partAttrs(b *sqlx.Builder, idx *schema.Index, p *schema.IndexPart) error {
 	if c := (schema.Collation{}); sqlx.Has(p.Attrs, &c) {
-		b.P("COLLATE").Ident(collate.V)
+		b.P("COLLATE").Ident(c.V)
 	}
 	if op := (IndexOpClass{}); sqlx.Has(p.Attrs, &op) {
 		d, err := op.DefaultFor(idx, p)

--- a/sql/postgres/migrate_oss.go
+++ b/sql/postgres/migrate_oss.go
@@ -1012,7 +1012,7 @@ func (s *state) column(b *sqlx.Builder, c *schema.Column) error {
 	b.P("NULL")
 	s.columnDefault(b, c)
 	if collate := (schema.Collation{}); sqlx.Has(c.Attrs, &collate) {
-		b.P("COLLATE").Ident(strconv.Quote(collate.V))
+		b.P("COLLATE").Ident(collate.V)
 	}
 	switch hasI, hasX := sqlx.Has(c.Attrs, &Identity{}), sqlx.Has(c.Attrs, &schema.GeneratedExpr{}); {
 	case hasI && hasX:

--- a/sql/postgres/migrate_oss.go
+++ b/sql/postgres/migrate_oss.go
@@ -817,7 +817,7 @@ func (s *state) alterType(b *sqlx.Builder, alter *changeGroup, t *schema.Table, 
 		b.P("TYPE", f)
 	}
 	if collate := (schema.Collation{}); sqlx.Has(c.To.Attrs, &collate) {
-		b.P("COLLATE", strconv.Quote(collate.V))
+		b.P("COLLATE").Ident(collate.V)
 	}
 	if using := (ConvertUsing{}); sqlx.Has(c.Extra, &using) {
 		b.P("USING", using.X)


### PR DESCRIPTION
I noticed this error while using the ent.
The collation of the migration file generated using `migrate.NamedDiff` in ent will be output without double quotation marks. The following error occurs when migrating the generated file.

```sh
ERROR:  syntax error at or near "-"
LINE 255: ...ALTER COLUMN "name" TYPE text COLLATE ja-x-icu;
```

The same error occurs if the collation contains a dot in the collation will also cause an error.

e.g. `en_US.UTF-8`

The version in which I found this error is a bit old, but I believe it reproduces in the latest version.

- ariga.io/atlas v0.19.1-0.20240203083654-5948b60a8e43
- entgo.io/ent v0.13.1

The fix for the cause of this error is L820. The other two were mechanically corrected because they were using COLLATE.