### PR TITLE
sql/migrate: support `GO` command in lexer

### DIFF
--- a/sql/migrate/lex_test.go
+++ b/sql/migrate/lex_test.go
@@ -28,6 +28,7 @@ func TestLocalFile_Stmts(t *testing.T) {
 				BackslashEscapes: true,
 				EscapedStringExt: true,
 				HashComments:     !strings.Contains(f.Name(), "_pg"),
+				GoCommand:        strings.Contains(f.Name(), "_ms"),
 			},
 		}
 		decls, err := sc.Scan(string(f.Bytes()))

--- a/sql/migrate/testdata/lex/19_ms_gocmd.sql
+++ b/sql/migrate/testdata/lex/19_ms_gocmd.sql
@@ -1,0 +1,14 @@
+go
+SELECT 1
+-- comment here
+GO
+SELECT 2 -- another comment
+GO
+SELECT 3 GO
+GO
+SELECT 4
+GOTO
+SELECT 5
+GO 11
+SELECT 6
+GO

--- a/sql/migrate/testdata/lex/19_ms_gocmd.sql.golden
+++ b/sql/migrate/testdata/lex/19_ms_gocmd.sql.golden
@@ -1,0 +1,14 @@
+
+-- end --
+SELECT 1
+-- comment here
+-- end --
+SELECT 2 -- another comment
+-- end --
+SELECT 3 GO
+-- end --
+SELECT 4
+GOTO
+SELECT 5
+-- end --
+SELECT 6

--- a/sql/migrate/testdata/lex/20_ms_go-delim.sql
+++ b/sql/migrate/testdata/lex/20_ms_go-delim.sql
@@ -1,0 +1,16 @@
+-- atlas:delimiter \nGO
+
+go
+SELECT 1
+-- comment here
+GO
+SELECT 2 -- another comment
+GO
+SELECT 3 GO
+gO
+SELECT 4
+GOTO -- this command is truncated by delimiter
+SELECT 5
+GO 11
+SELECT 6
+GO

--- a/sql/migrate/testdata/lex/20_ms_go-delim.sql.golden
+++ b/sql/migrate/testdata/lex/20_ms_go-delim.sql.golden
@@ -1,0 +1,15 @@
+
+-- end --
+SELECT 1
+-- comment here
+-- end --
+SELECT 2 -- another comment
+-- end --
+SELECT 3 GO
+-- end --
+SELECT 4
+-- end --
+TO -- this command is truncated by delimiter
+SELECT 5
+-- end --
+SELECT 6


### PR DESCRIPTION
The newline character can be a part of statement delimiter
