### PR TITLE
internal/integration: fixed newline for diff

### DIFF
--- a/internal/integration/script_test.go
+++ b/internal/integration/script_test.go
@@ -323,7 +323,7 @@ func cmdCmpShow(ts *testscript.TestScript, args []string, show func(schema, name
 	}
 	var sb strings.Builder
 	ts.Check(diff.Text("show", fname, t1, t2, &sb))
-	ts.Fatalf(sb.String())
+	ts.Fatalf("\n%s", sb.String())
 }
 
 func (t *myTest) cmdCmpHCL(ts *testscript.TestScript, _ bool, args []string) {
@@ -388,7 +388,7 @@ func cmdCmpHCL(ts *testscript.TestScript, args []string, inspect func(schema str
 	}
 	var sb strings.Builder
 	ts.Check(diff.Text("inspect", fname, f1, f2, &sb))
-	ts.Fatalf(sb.String())
+	ts.Fatalf("\n%s", sb.String())
 }
 
 func (t *myTest) cmdExec(ts *testscript.TestScript, _ bool, args []string) {
@@ -503,7 +503,7 @@ func cmdCmpMig(ts *testscript.TestScript, _ bool, args []string) {
 			if len(exLines) != len(acLines) {
 				var sb strings.Builder
 				ts.Check(diff.Text(f.Name(), args[1], expected, actual, &sb))
-				ts.Fatalf(sb.String())
+				ts.Fatalf("\n%s", sb.String())
 			}
 			for i := range exLines {
 				// Skip liquibase changeset comments since they contain a timestamp.
@@ -513,7 +513,7 @@ func cmdCmpMig(ts *testscript.TestScript, _ bool, args []string) {
 				if exLines[i] != acLines[i] {
 					var sb strings.Builder
 					ts.Check(diff.Text(f.Name(), args[1], expected, actual, &sb))
-					ts.Fatalf(sb.String())
+					ts.Fatalf("\n%s", sb.String())
 				}
 			}
 			return


### PR DESCRIPTION
Before:
<img width="630" alt="Screenshot 2025-01-20 at 22 58 48" src="https://github.com/user-attachments/assets/73eab032-0d59-4ff4-8222-8ccd2dc222e2" />

After:
<img width="488" alt="Screenshot 2025-01-20 at 22 59 12" src="https://github.com/user-attachments/assets/6a0a28dc-1059-4241-8210-f23c1f4ec0c3" />
