### PR TITLE
sql/sqlite: remove query to sqlite_version()

### DIFF
--- a/sql/sqlite/diff_test.go
+++ b/sql/sqlite/diff_test.go
@@ -301,9 +301,8 @@ func TestDiff_TableDiff(t *testing.T) {
 		}(),
 	}
 	for _, tt := range tests {
-		db, m, err := sqlmock.New()
+		db, _, err := sqlmock.New()
 		require.NoError(t, err)
-		mock{m}.systemVars("3.36.0")
 		drv, err := Open(db)
 		require.NoError(t, err)
 		t.Run(tt.name, func(t *testing.T) {
@@ -315,9 +314,8 @@ func TestDiff_TableDiff(t *testing.T) {
 }
 
 func TestDiff_SchemaDiff(t *testing.T) {
-	db, m, err := sqlmock.New()
+	db, _, err := sqlmock.New()
 	require.NoError(t, err)
-	mock{m}.systemVars("3.36.0")
 	drv, err := Open(db)
 	require.NoError(t, err)
 	from := &schema.Schema{

--- a/sql/sqlite/inspect_test.go
+++ b/sql/sqlite/inspect_test.go
@@ -284,7 +284,6 @@ CREATE TABLE users(
 			db, m, err := sqlmock.New()
 			require.NoError(t, err)
 			mk := mock{m}
-			mk.systemVars("3.36.0")
 			drv, err := Open(db)
 			require.NoError(t, err)
 			tt.before(mk)
@@ -474,7 +473,6 @@ func TestRegex_Checks(t *testing.T) {
 		db, m, err := sqlmock.New()
 		require.NoError(t, err)
 		mk := mock{m}
-		mk.systemVars("3.36.0")
 		mk.tableExists(name, true, tt.input)
 		mk.noColumns(name)
 		mk.noIndexes(name)
@@ -535,7 +533,6 @@ func TestRegex_GeneratedExpr(t *testing.T) {
 		db, m, err := sqlmock.New()
 		require.NoError(t, err)
 		mk := mock{m}
-		mk.systemVars("3.36.0")
 		mk.tableExists(name, true, tt.input)
 		m.ExpectQuery(sqltest.Escape(fmt.Sprintf(columnsQuery, name))).
 			WillReturnRows(sqltest.Rows(fmt.Sprintf(`
@@ -558,15 +555,6 @@ func TestRegex_GeneratedExpr(t *testing.T) {
 
 type mock struct {
 	sqlmock.Sqlmock
-}
-
-func (m mock) systemVars(version string) {
-	m.ExpectQuery(sqltest.Escape("SELECT sqlite_version()")).
-		WillReturnRows(sqltest.Rows(`
-     version    
-----------------
- ` + version + `
-`))
 }
 
 func (m mock) tableExists(table string, exists bool, stmt ...string) {

--- a/sql/sqlite/migrate_test.go
+++ b/sql/sqlite/migrate_test.go
@@ -484,7 +484,6 @@ func TestPlanChanges(t *testing.T) {
 			db, mk, err := sqlmock.New()
 			require.NoError(t, err)
 			m := mock{mk}
-			m.systemVars("3.36.0")
 			if tt.mock != nil {
 				tt.mock(m)
 			}
@@ -625,9 +624,8 @@ func TestIndentedPlan(t *testing.T) {
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			db, mk, err := sqlmock.New()
+			db, _, err := sqlmock.New()
 			require.NoError(t, err)
-			mock{mk}.systemVars("3.36.0")
 			drv, err := Open(db)
 			require.NoError(t, err)
 			plan, err := drv.PlanChanges(context.Background(), "wantPlan", []schema.Change{&schema.AddTable{T: tt.T}}, func(opts *migrate.PlanOptions) {


### PR DESCRIPTION
The package is static and updated whenever we update the package