### PR TITLE
sql/sqlx: fix spacing on the new lines

### DIFF
--- a/sql/internal/sqlx/sqlx.go
+++ b/sql/internal/sqlx/sqlx.go
@@ -273,7 +273,7 @@ func (b *Builder) P(phrases ...string) *Builder {
 		if p == "" {
 			continue
 		}
-		if b.Len() > 0 && b.lastByte() != ' ' && b.lastByte() != '(' {
+		if b.Len() > 0 && !slices.Contains([]byte{' ', '(', '\n'}, b.lastByte()) {
 			b.WriteByte(' ')
 		}
 		b.WriteString(p)


### PR DESCRIPTION
currently, `.NL().P("FOO")` write ` FOO` in the new line, this commit remove the space before `FOO`
