### PR TITLE
sql/sqlspec: support named default values for table columns

### DIFF
--- a/internal/integration/hclsqlspec/hclsqlspec_test.go
+++ b/internal/integration/hclsqlspec/hclsqlspec_test.go
@@ -68,7 +68,9 @@ table "users" {
 
 	column "account_active" {
 		type = boolean
-		default = true
+		default "DF_expr1" {
+			as = true
+		}
 	}
 
 	primary_key {
@@ -146,28 +148,58 @@ table "accounts" {
 				Schema: &schemahcl.Ref{V: "$schema.hi"},
 				Columns: []*sqlspec.Column{
 					{
-						Name:    "id",
-						Type:    &schemahcl.Type{T: "int"},
-						Null:    false,
-						Default: cty.NumberVal(big.NewFloat(123).SetPrec(512)),
+						Name: "id",
+						Type: &schemahcl.Type{T: "int"},
+						Null: false,
+						DefaultExtension: schemahcl.DefaultExtension{
+							Extra: schemahcl.Resource{
+								Attrs: []*schemahcl.Attr{
+									{K: "default", V: cty.NumberVal(big.NewFloat(123).SetPrec(512))},
+								},
+							},
+						},
 					},
 					{
-						Name:    "age",
-						Type:    &schemahcl.Type{T: "int"},
-						Null:    false,
-						Default: cty.NumberVal(big.NewFloat(10).SetPrec(512)),
+						Name: "age",
+						Type: &schemahcl.Type{T: "int"},
+						Null: false,
+						DefaultExtension: schemahcl.DefaultExtension{
+							Extra: schemahcl.Resource{
+								Attrs: []*schemahcl.Attr{
+									{K: "default", V: cty.NumberVal(big.NewFloat(10).SetPrec(512))},
+								},
+							},
+						},
 					},
 					{
-						Name:    "active",
-						Type:    &schemahcl.Type{T: "boolean"},
-						Null:    false,
-						Default: cty.BoolVal(true),
+						Name: "active",
+						Type: &schemahcl.Type{T: "boolean"},
+						Null: false,
+						DefaultExtension: schemahcl.DefaultExtension{
+							Extra: schemahcl.Resource{
+								Attrs: []*schemahcl.Attr{
+									{K: "default", V: cty.BoolVal(true)},
+								},
+							},
+						},
 					},
 					{
-						Name:    "account_active",
-						Type:    &schemahcl.Type{T: "boolean"},
-						Null:    false,
-						Default: cty.BoolVal(true),
+						Name: "account_active",
+						Type: &schemahcl.Type{T: "boolean"},
+						Null: false,
+						DefaultExtension: schemahcl.DefaultExtension{
+							Extra: schemahcl.Resource{
+								Children: []*schemahcl.Resource{
+									{
+										Type: "default",
+										Name: "DF_expr1",
+										Attrs: []*schemahcl.Attr{
+											{K: "as", V: cty.BoolVal(true)},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 				PrimaryKey: &sqlspec.PrimaryKey{
@@ -222,28 +254,52 @@ table "accounts" {
 				Schema: &schemahcl.Ref{V: "$schema.hi"},
 				Columns: []*sqlspec.Column{
 					{
-						Name:    "id",
-						Type:    &schemahcl.Type{T: "int"},
-						Null:    false,
-						Default: cty.NumberVal(big.NewFloat(123).SetPrec(512)),
+						Name: "id",
+						Type: &schemahcl.Type{T: "int"},
+						Null: false,
+						DefaultExtension: schemahcl.DefaultExtension{
+							Extra: schemahcl.Resource{
+								Attrs: []*schemahcl.Attr{
+									{K: "default", V: cty.NumberVal(big.NewFloat(123).SetPrec(512))},
+								},
+							},
+						},
 					},
 					{
-						Name:    "age",
-						Type:    &schemahcl.Type{T: "int"},
-						Null:    false,
-						Default: cty.NumberVal(big.NewFloat(10).SetPrec(512)),
+						Name: "age",
+						Type: &schemahcl.Type{T: "int"},
+						Null: false,
+						DefaultExtension: schemahcl.DefaultExtension{
+							Extra: schemahcl.Resource{
+								Attrs: []*schemahcl.Attr{
+									{K: "default", V: cty.NumberVal(big.NewFloat(10).SetPrec(512))},
+								},
+							},
+						},
 					},
 					{
-						Name:    "active",
-						Type:    &schemahcl.Type{T: "boolean"},
-						Null:    false,
-						Default: cty.BoolVal(true),
+						Name: "active",
+						Type: &schemahcl.Type{T: "boolean"},
+						Null: false,
+						DefaultExtension: schemahcl.DefaultExtension{
+							Extra: schemahcl.Resource{
+								Attrs: []*schemahcl.Attr{
+									{K: "default", V: cty.BoolVal(true)},
+								},
+							},
+						},
 					},
 					{
-						Name:    "user_active",
-						Type:    &schemahcl.Type{T: "boolean"},
-						Null:    false,
-						Default: cty.BoolVal(true),
+						Name: "user_active",
+						Type: &schemahcl.Type{T: "boolean"},
+						Null: false,
+						DefaultExtension: schemahcl.DefaultExtension{
+							Extra: schemahcl.Resource{
+								Attrs: []*schemahcl.Attr{
+									{K: "default", V: cty.BoolVal(true)},
+								},
+							},
+						},
 					},
 				},
 				PrimaryKey: &sqlspec.PrimaryKey{

--- a/sql/postgres/sqlspec_oss.go
+++ b/sql/postgres/sqlspec_oss.go
@@ -586,16 +586,18 @@ func convertIdentity(r *schemahcl.Resource) (*Identity, error) {
 // fixDefaultQuotes fixes the quotes on the Default field to be single quotes
 // instead of double quotes.
 func fixDefaultQuotes(spec *sqlspec.Column) error {
-	if spec.Default.Type() != cty.String {
-		return nil
-	}
-	if s := spec.Default.AsString(); sqlx.IsQuoted(s, '"') {
-		uq, err := strconv.Unquote(s)
-		if err != nil {
-			return err
+	if a, ok := spec.Attr("default"); ok {
+		if a.V.Type() != cty.String {
+			return nil
 		}
-		s = "'" + uq + "'"
-		spec.Default = cty.StringVal(s)
+		if s := a.V.AsString(); sqlx.IsQuoted(s, '"') {
+			uq, err := strconv.Unquote(s)
+			if err != nil {
+				return err
+			}
+			s = "'" + uq + "'"
+			a.V = cty.StringVal(s)
+		}
 	}
 	return nil
 }

--- a/sql/schema/schema.go
+++ b/sql/schema/schema.go
@@ -74,7 +74,11 @@ type (
 		// part of their child columns.
 		ForeignKeys []*ForeignKey
 	}
-
+	// NamedDefault defines a named default expression.
+	NamedDefault struct {
+		Expr
+		Name string
+	}
 	// ColumnType represents a column type that is implemented by the dialect.
 	ColumnType struct {
 		Type Type
@@ -768,6 +772,11 @@ func (e *EnumType) SpecType() string { return "enum" }
 
 // SpecName returns the name of the spec.
 func (e *EnumType) SpecName() string { return e.T }
+
+// Underlying returns underlying the expression.
+func (n *NamedDefault) Underlying() Expr {
+	return n.Expr
+}
 
 // UnderlyingExpr returns the underlying expression of x.
 func UnderlyingExpr(x Expr) Expr {

--- a/sql/sqlspec/sqlspec.go
+++ b/sql/sqlspec/sqlspec.go
@@ -53,10 +53,9 @@ type (
 
 	// Column holds a specification for a column in an SQL table.
 	Column struct {
-		Name    string          `spec:",name"`
-		Null    bool            `spec:"null"`
-		Type    *schemahcl.Type `spec:"type"`
-		Default cty.Value       `spec:"default"`
+		Name string          `spec:",name"`
+		Null bool            `spec:"null"`
+		Type *schemahcl.Type `spec:"type"`
 		schemahcl.DefaultExtension
 		Range *hcl.Range `spec:",range"`
 	}


### PR DESCRIPTION
```hcl
table "t1" {
  column "c1" {
    type = int
    default "DF__t1__c1" {
      as = 1
    }
  }
}
```
