### PR TITLE
sql/sqltool: remove call to parent `Checksum()`

### DIFF
--- a/sql/sqltool/tool.go
+++ b/sql/sqltool/tool.go
@@ -120,9 +120,6 @@ func (d *GolangMigrateDir) Files() ([]migrate.File, error) {
 
 // Checksum implements Dir.Checksum. By default, it calls Files() and creates a checksum from them.
 func (d *GolangMigrateDir) Checksum() (migrate.HashFile, error) {
-	if d, ok := d.FS.(migrate.Dir); ok {
-		return d.Checksum()
-	}
 	files, err := d.Files()
 	if err != nil {
 		return nil, err
@@ -396,9 +393,6 @@ func (d *FlywayDir) Files() ([]migrate.File, error) {
 
 // Checksum implements Dir.Checksum. By default, it calls Files() and creates a checksum from them.
 func (d *FlywayDir) Checksum() (migrate.HashFile, error) {
-	if d, ok := d.FS.(migrate.Dir); ok {
-		return d.Checksum()
-	}
 	files, err := d.Files()
 	if err != nil {
 		return nil, err

--- a/sql/sqltool/tool_test.go
+++ b/sql/sqltool/tool_test.go
@@ -288,9 +288,7 @@ func TestChecksum(t *testing.T) {
 				return d
 			}(),
 			files: []string{
-				"1_initial.down.sql",
 				"1_initial.up.sql",
-				"2_second_migration.down.sql",
 				"2_second_migration.up.sql",
 			},
 		},
@@ -331,11 +329,9 @@ func TestChecksum(t *testing.T) {
 			}(),
 			files: []string{
 				"B2__baseline.sql",
-				"R__views.sql",
-				"U1__initial.sql",
-				"V1__initial.sql",
-				"V2__second_migration.sql",
 				"V3__third_migration.sql",
+				"v3/V3_1__fourth_migration.sql",
+				"R__views.sql",
 			},
 		},
 		{


### PR DESCRIPTION
The parent can be local directory, that takes all files - including `.down.sql` for golang-migrate format.

Ref: https://github.com/ariga/atlas/pull/1642, https://github.com/ariga/atlas/pull/1652