### PR TITLE
internal/integration: share `$PATH` with command when execute with output redirect

### DIFF
--- a/internal/integration/script_test.go
+++ b/internal/integration/script_test.go
@@ -441,7 +441,11 @@ func cmdCLI(ts *testscript.TestScript, neg bool, args []string, dbURL, devURL, c
 		stderr := &bytes.Buffer{}
 		cmd.Stderr = stderr
 		cmd.Dir = workDir
-		cmd.Env = append(cmd.Env, "HOME="+ts.Getenv("HOME"))
+		cmd.Env = append(cmd.Env,
+			"HOME="+ts.Getenv("HOME"),
+			"PATH="+ts.Getenv("PATH"),
+			"DOCKER_HOST="+ts.Getenv("DOCKER_HOST"),
+		)
 		if err := cmd.Run(); err != nil && !neg {
 			ts.Fatalf("\n[stderr]\n%s", stderr)
 		}


### PR DESCRIPTION
This is needed for `atlas schema inspect --url='file://migrations' --dev-url='docker://clickhouse' > schema.hcl` works in testscript.
Because atlas will looking for `docker` binary in `$PATH` environment.