### PR TITLE
cmd/atlas/internal/cmdapi: add command line flag for lock name

### DIFF
--- a/cmd/atlas/internal/cmdapi/cmdapi.go
+++ b/cmd/atlas/internal/cmdapi/cmdapi.go
@@ -283,6 +283,7 @@ const (
 	flagGitDir         = "git-dir"
 	flagLatest         = "latest"
 	flagLockTimeout    = "lock-timeout"
+	flagLockName       = "lock-name"
 	flagLog            = "log"
 	flagPlan           = "plan"
 	flagRevisionSchema = "revisions-schema"
@@ -313,6 +314,10 @@ func addFlagDirFormat(set *pflag.FlagSet, target *string) {
 
 func addFlagLockTimeout(set *pflag.FlagSet, target *time.Duration) {
 	set.DurationVar(target, flagLockTimeout, 10*time.Second, "set how long to wait for the database lock")
+}
+
+func addFlagLockName(set *pflag.FlagSet, target *string, defaultVal string) {
+	set.StringVar(target, flagLockName, defaultVal, "set lock name for database lock")
 }
 
 // addFlagURL adds a URL flag. If given, args[0] override the name, args[1] the shorthand, args[2] the default value.

--- a/cmd/atlas/internal/cmdapi/migrate_oss.go
+++ b/cmd/atlas/internal/cmdapi/migrate_oss.go
@@ -60,7 +60,7 @@ func migrateApplyRun(cmd *cobra.Command, args []string, flags migrateApplyFlags,
 	// Prevent usage printing after input validation.
 	cmd.SilenceUsage = true
 	// Acquire a lock.
-	unlock, err := client.Driver.Lock(ctx, applyLockValue, flags.lockTimeout)
+	unlock, err := client.Driver.Lock(ctx, flags.lockName, flags.lockTimeout)
 	if err != nil {
 		return fmt.Errorf("acquiring database lock: %w", err)
 	}

--- a/cmd/atlas/internal/cmdapi/project.go
+++ b/cmd/atlas/internal/cmdapi/project.go
@@ -79,6 +79,7 @@ type (
 		Baseline        string   `spec:"baseline"`
 		ExecOrder       string   `spec:"exec_order"`
 		LockTimeout     string   `spec:"lock_timeout"`
+		LockName        string   `spec:"lock_name"`
 		RevisionsSchema string   `spec:"revisions_schema"`
 		Repo            *Repo    `spec:"repo"`
 	}

--- a/cmd/atlas/internal/cmdapi/project_test.go
+++ b/cmd/atlas/internal/cmdapi/project_test.go
@@ -81,6 +81,7 @@ env "local" {
     dir = "file://migrations"
     format = atlas
     lock_timeout = "1s"
+	lock_name = "migrate_lock"
     revisions_schema = "revisions"
     exec_order = LINEAR_SKIP
   }
@@ -158,6 +159,7 @@ env "multi" {
 				Dir:             "file://migrations",
 				Format:          cmdmigrate.FormatAtlas,
 				LockTimeout:     "1s",
+				LockName:        "migrate_lock",
 				RevisionsSchema: "revisions",
 				ExecOrder:       "LINEAR_SKIP",
 			},


### PR DESCRIPTION
In our application we use single database and different schemas for each microservice. There are several reasons for using this kind of setup.

The migrate command used a fixed name for the migration lock (PG advisory lock). That caused issues in our application: one microservice running a lenghty migration caused all other microservices to be waiting for the lock to check and run their migrations.

To remedy the situation, this commit makes the lock name to be configurable using a command line flag. Condirered also making the locking to use schema name as lock name, but that might not be what other applications want. Introducing a separate command line flag for the lock name offers the most flexible solution.

The default behaviour is the same as before. If the lock name flag is not given, the old fixed name is used for lock.