### PR TITLE
internal/ci: support running custom code in generated ci steps

### DIFF
--- a/internal/ci/ci_dialect.tmpl
+++ b/internal/ci/ci_dialect.tmpl
@@ -53,7 +53,15 @@ jobs:
       {{- with .Steps }}
       {{- range . }}
       - name: {{ .Name }}
-        uses: {{ .Action }}
+        {{- with .Run }}
+        run: |
+          {{- range $line := split . "\n" }}
+          {{ $line | trim }}
+          {{- end }}
+        {{- end }}
+        {{- with .Action }}
+        uses:  {{ . }}
+        {{- end }}
         {{- with .With }}
         with:
           {{- range . }}

--- a/internal/ci/main.go
+++ b/internal/ci/main.go
@@ -49,12 +49,8 @@ type (
 func init() {
 	t := template.New("")
 	t.Funcs(template.FuncMap{
-		"split": func(s string, sep string) []string {
-			return strings.Split(s, sep)
-		},
-		"trim": func(s string) string {
-			return strings.TrimSpace(s)
-		},
+		"split": strings.Split,
+		"trim":  strings.TrimSpace,
 	})
 	tpl = template.Must(t.ParseFS(tplFS, "*.tmpl"))
 }

--- a/internal/ci/main.go
+++ b/internal/ci/main.go
@@ -46,19 +46,15 @@ type (
 	}
 )
 
-func init() {
-	t := template.New("")
-	t.Funcs(template.FuncMap{
-		"split": strings.Split,
-		"trim":  strings.TrimSpace,
-	})
-	tpl = template.Must(t.ParseFS(tplFS, "*.tmpl"))
-}
-
 var (
 	//go:embed *.tmpl
 	tplFS embed.FS
-	tpl   *template.Template
+	tpl   = template.Must(template.New("").
+		Funcs(template.FuncMap{
+			"split": strings.Split,
+			"trim":  strings.TrimSpace,
+		}).
+		ParseFS(tplFS, "*.tmpl"))
 
 	mysqlOptions = []string{
 		`--health-cmd "mysqladmin ping -ppass"`,

--- a/internal/ci/main.go
+++ b/internal/ci/main.go
@@ -23,6 +23,7 @@ type (
 	Step struct {
 		Name   string
 		Action string
+		Run    string
 		With   []string
 	}
 	// Credentials is used to pull images from a private registry.
@@ -45,10 +46,23 @@ type (
 	}
 )
 
+func init() {
+	t := template.New("")
+	t.Funcs(template.FuncMap{
+		"split": func(s string, sep string) []string {
+			return strings.Split(s, sep)
+		},
+		"trim": func(s string) string {
+			return strings.TrimSpace(s)
+		},
+	})
+	tpl = template.Must(t.ParseFS(tplFS, "*.tmpl"))
+}
+
 var (
 	//go:embed *.tmpl
 	tplFS embed.FS
-	tpl   = template.Must(template.ParseFS(tplFS, "*.tmpl"))
+	tpl   *template.Template
 
 	mysqlOptions = []string{
 		`--health-cmd "mysqladmin ping -ppass"`,


### PR DESCRIPTION
this code:

```go
			Steps: []Step{
				{
					Name:   "Run CockroachDB",
					Action: "docker",
					With: []string{
						"args: run",
					},
				},
				{
					Name: "Run Atlas",
					Run: "echo 'CREATE DATABASE test\n" +
						"echo 'CREATE DATABASE test2'",
				},
			},
```

will generate the next steps:


```yaml
+      - name: Run CockroachDB
+        uses:  docker
+        with:
+          args: run
+      - name: Run Atlas
+        run: |
+          echo 'CREATE DATABASE test
+          echo 'CREATE DATABASE test2'
```