### PR TITLE
sql/internal/sqlx: allow drivers checking if proc depends on object

### DIFF
--- a/sql/internal/specutil/convert.go
+++ b/sql/internal/specutil/convert.go
@@ -941,7 +941,7 @@ func fromDependsOn[T interface{ AddDeps(...schema.Object) T }](loc string, t T, 
 			})
 		}
 		if err != nil {
-			return fmt.Errorf("find %s refrence for %s.depends_on[%d]: %w", p[0].T, loc, i, err)
+			return fmt.Errorf("find %s reference for %s.depends_on[%d]: %w", p[0].T, loc, i, err)
 		}
 		t.AddDeps(o)
 	}

--- a/sql/internal/sqlx/plan.go
+++ b/sql/internal/sqlx/plan.go
@@ -392,6 +392,8 @@ type SortOptions struct {
 	FuncDepO func(*schema.Func, schema.Object) bool
 	// ProcDepT reports if a procedure depends on the given table.
 	ProcDepT func(*schema.Proc, *schema.Table) bool
+	// ProcDepO reports if a procedure depends on the given object.
+	ProcDepO func(*schema.Proc, schema.Object) bool
 	// ViewDepT reports if a view depends on the given table.
 	ViewDepT func(*schema.View, *schema.Table) bool
 	// CompareFuncArgs set to true to compare function arguments.


### PR DESCRIPTION
Already approved internally. 