### PR TITLE
doc: remove duplicate word "another" in migrate diff command

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -508,7 +508,7 @@ func migrateDiffCmd() *cobra.Command {
 			Short: "Compute the diff between the migration directory and a desired state and create a new migration file.",
 			Long: `The 'atlas migrate diff' command uses the dev-database to calculate the current state of the migration directory
 by executing its files. It then compares its state to the desired state and create a new migration file containing
-SQL statements for moving from the current to the desired state. The desired state can be another another database,
+SQL statements for moving from the current to the desired state. The desired state can be another database,
 an HCL, SQL, or ORM schema. See: https://atlasgo.io/versioned/diff`,
 			Example: `  atlas migrate diff --dev-url "docker://mysql/8/dev" --to "file://schema.hcl"
   atlas migrate diff --dev-url "docker://postgres/15/dev?search_path=public" --to "file://atlas.hcl" add_users_table


### PR DESCRIPTION
Remove the duplicate word "another" in atlas migrate diff command