### PR TITLE
sql/mysql: allow migrating from int64 to uint64

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,9 @@ issues:
     - path: sql/migrate/dir.go
       linters:
         - gosec
+    - path: sql/mysql/inspect_oss.go
+      linters:
+        - gosec
     - path: sql/migrate/lex.go
       linters:
         - revive

--- a/sql/mysql/inspect_oss.go
+++ b/sql/mysql/inspect_oss.go
@@ -900,6 +900,11 @@ type (
 	}
 )
 
+// NewAutoIncrement returns an "auto increment" attribute.
+func NewAutoIncrement(v uint64) *AutoIncrement {
+	return &AutoIncrement{V: max(0, int64(v))} // Keep BC with old ent versions.
+}
+
 // addIndex adds an index to the list of indexes
 // that needs further processing.
 func (s *showTable) addFullText(idx *schema.Index) {


### PR DESCRIPTION
Let new ent versions to use the constructor, and old ones use the struct literal.

A BC will be added in a few months from now