### PR TITLE
sql/sqlite: update driver name from sqlite3 to sqlite

### DIFF
--- a/atlasexec/atlas_migrate_test.go
+++ b/atlasexec/atlas_migrate_test.go
@@ -347,7 +347,7 @@ func TestAtlasMigrate_Apply(t *testing.T) {
 		Env: "test",
 	})
 	require.NoError(t, err)
-	require.Equal(t, "sqlite3", got.Env.Driver)
+	require.Equal(t, "sqlite", got.Env.Driver)
 	require.Equal(t, "file://migrations", got.Env.Dir)
 	require.Equal(t, "sqlite://file?_fk=1&cache=shared&mode=memory", got.Env.URL.String())
 	require.Equal(t, "20230926085734", got.Target)
@@ -668,7 +668,7 @@ func TestAtlasMigrate_Lint(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, 4, len(got.Steps))
-		require.Equal(t, "sqlite3", got.Env.Driver)
+		require.Equal(t, "sqlite", got.Env.Driver)
 		require.Equal(t, "testdata/migrations", got.Env.Dir)
 		require.Equal(t, "sqlite://file?mode=memory", got.Env.URL.String())
 		require.Equal(t, 1, len(got.Files))

--- a/atlasexec/atlas_schema_test.go
+++ b/atlasexec/atlas_schema_test.go
@@ -716,10 +716,10 @@ func TestSchema_Apply(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("TEST_ARGS", tt.args)
-			t.Setenv("TEST_STDOUT", `{"Driver":"sqlite3"}`)
+			t.Setenv("TEST_STDOUT", `{"Driver":"sqlite"}`)
 			result, err := c.SchemaApply(context.Background(), tt.params)
 			require.NoError(t, err)
-			require.Equal(t, "sqlite3", result.Driver)
+			require.Equal(t, "sqlite", result.Driver)
 		})
 	}
 }
@@ -771,9 +771,9 @@ func TestSchema_ApplyEnvs(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.SetEnv(map[string]string{
 		"TEST_ARGS": "schema apply --format {{ json . }} --env test",
-		"TEST_STDOUT": `{"Driver":"sqlite3","URL":{"Scheme":"sqlite","Host":"local-su.db"}}
-{"Driver":"sqlite3","URL":{"Scheme":"sqlite","Host":"local-pi.db"}}
-{"Driver":"sqlite3","URL":{"Scheme":"sqlite","Host":"local-bu.db"}}`,
+		"TEST_STDOUT": `{"Driver":"sqlite","URL":{"Scheme":"sqlite","Host":"local-su.db"}}
+{"Driver":"sqlite","URL":{"Scheme":"sqlite","Host":"local-pi.db"}}
+{"Driver":"sqlite","URL":{"Scheme":"sqlite","Host":"local-bu.db"}}`,
 		"TEST_STDERR": `Abort: The plan "From" hash does not match the current state hash (passed with --from):
 
   [31m- iHZMQ1EoarAXt/KU0KQbBljbbGs8gVqX2ZBXefePSGE=[0m[90m (plan value)[0m

--- a/cmd/atlas/internal/cmdapi/migrate_test.go
+++ b/cmd/atlas/internal/cmdapi/migrate_test.go
@@ -520,7 +520,7 @@ env "local" {
 			require.Empty(t, r.Pending)
 			require.Empty(t, r.Applied)
 			require.NotEmpty(t, r.Tenant)
-			require.Equal(t, "sqlite3", r.Driver)
+			require.Equal(t, "sqlite", r.Driver)
 		}
 		_, err = db.Exec("INSERT INTO `tenants` (`name`) VALUES (NULL)")
 		require.NoError(t, err)
@@ -1261,7 +1261,7 @@ func TestMigrate_StatusJSON(t *testing.T) {
 		"--format", "{{ json .Env.Driver }}",
 	)
 	require.NoError(t, err)
-	require.Equal(t, `"sqlite3"`, s)
+	require.Equal(t, `"sqlite"`, s)
 }
 
 func TestMigrate_Set(t *testing.T) {

--- a/cmd/atlas/internal/migrate/migrate.go
+++ b/cmd/atlas/internal/migrate/migrate.go
@@ -63,9 +63,11 @@ func (r *EntRevisions) Dialect() string {
 func EntDialect(d string) string {
 	switch {
 	case d == mysql.DriverMaria:
-		return mysql.DriverName // Ent does not support "mariadb" as dialect.
+		return dialect.MySQL // Ent does not support "mariadb" as dialect.
 	case strings.HasPrefix(d, "libsql"):
-		return sqlite.DriverName // Ent does not support "libsql" as dialect.
+		return dialect.SQLite // Ent does not support "libsql" as dialect.
+	case d == sqlite.DriverName:
+		return dialect.SQLite // Ent does not support "sqlite" as dialect.
 	default:
 		return d
 	}
@@ -97,7 +99,7 @@ func NewEntRevisions(ctx context.Context, ac *sqlclient.Client, opts ...Option) 
 			return nil, err
 		}
 	}
-	if r.Dialect() == sqlite.DriverName && r.schema != "" && r.schema != "main" {
+	if r.Dialect() == dialect.SQLite && r.schema != "" && r.schema != "main" {
 		return nil, fmt.Errorf("cannot store revisions-table in a separate schema (%q) with SQLite driver", r.schema)
 	}
 	// Create the connection with the underlying migrate.Driver to have it inside a possible transaction.

--- a/sql/sqlite/driver.go
+++ b/sql/sqlite/driver.go
@@ -46,7 +46,7 @@ var _ interface {
 } = (*Driver)(nil)
 
 // DriverName holds the name used for registration.
-const DriverName = "sqlite3"
+const DriverName = "sqlite"
 
 func init() {
 	sqlclient.Register(
@@ -55,7 +55,7 @@ func init() {
 		sqlclient.RegisterDriverOpener(Open),
 		sqlclient.RegisterTxOpener(OpenTx),
 		sqlclient.RegisterCodec(codec, codec),
-		sqlclient.RegisterFlavours("sqlite"),
+		sqlclient.RegisterFlavours("sqlite3"),
 		sqlclient.RegisterURLParser(urlparse{}),
 	)
 	sqlclient.Register(
@@ -88,7 +88,7 @@ func (urlparse) ParseURL(u *url.URL) *sqlclient.URL {
 
 func opener(_ context.Context, u *url.URL) (*sqlclient.Client, error) {
 	ur := urlparse{}.ParseURL(u)
-	db, err := sql.Open(DriverName, ur.DSN)
+	db, err := sql.Open("sqlite3", ur.DSN)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As we discussed earlier, using `sqlite` for the driver name provides better consistency in the codebase.