### PR TITLE
Add mariadb 10.6 & 10.11

### DIFF
--- a/.github/workflows/cd-docker-push-mysql_oss.yaml
+++ b/.github/workflows/cd-docker-push-mysql_oss.yaml
@@ -38,7 +38,9 @@ jobs:
           - dialect: mariadb:10.3
           - dialect: mariadb:10.3.13
             platforms: linux/amd64
+          - dialect: mariadb:10.6
           - dialect: mariadb:10.7
+          - dialect: mariadb:10.11
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I need 10.11 and 10.6 MariaDB versions (latest is 12, which is way too modern and the other versions are super old), I am adding them to the docker build job. Let me know if I missed anywhere.

Thanks,