### PR TITLE
all: bump Go version to 1.24.9

### DIFF
--- a/cmd/atlas/go.mod
+++ b/cmd/atlas/go.mod
@@ -1,6 +1,6 @@
 module ariga.io/atlas/cmd/atlas
 
-go 1.24.6
+go 1.24.9
 
 replace ariga.io/atlas => ../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ariga.io/atlas
 
-go 1.24.6
+go 1.24.9
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/internal/integration/go.mod
+++ b/internal/integration/go.mod
@@ -1,6 +1,6 @@
 module ariga.io/atlas/internal/integration
 
-go 1.24.6
+go 1.24.9
 
 replace ariga.io/atlas => ../../
 


### PR DESCRIPTION
Fixes: https://avd.aquasec.com/nvd/2025/cve-2025-58187/