### PR TITLE
cmd/atlas: suggest standard build in case of errors

### DIFF
--- a/cmd/atlas/main_oss.go
+++ b/cmd/atlas/main_oss.go
@@ -8,6 +8,13 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	"ariga.io/atlas/cmd/atlas/internal/cmdlog"
+	"ariga.io/atlas/cmd/atlas/internal/cmdstate"
 )
 
 func extendContext(ctx context.Context) (context.Context, error) {
@@ -20,5 +27,32 @@ func vercheckEndpoint(context.Context) string {
 
 // initialize is a no-op for the OSS version.
 func initialize(ctx context.Context) (context.Context, func(error)) {
-	return ctx, func(error) {}
+	return ctx, func(err error) {
+		if err == nil {
+			return
+		}
+		const errorsFileName = "community_error.json"
+		type prompt struct {
+			LastSuggested time.Time `json:"last_suggested"`
+		}
+		state := &cmdstate.File[prompt]{Name: errorsFileName}
+		prev, err := state.Read()
+		if err != nil || time.Since(prev.LastSuggested) < 24*time.Hour {
+			return
+		}
+		release := "curl -sSf https://atlasgo.sh | sh"
+		if runtime.GOOS == "windows" {
+			release = "https://release.ariga.io/atlas/atlas-windows-amd64-latest.exe"
+		}
+		if err := cmdlog.WarnOnce(os.Stderr, cmdlog.ColorCyan(fmt.Sprintf(`You're running the community build of Atlas, which may differ from the official version.
+If this error persists, try installing the official version as a troubleshooting step:
+
+  %s
+
+More installation options: https://atlasgo.io/docs#installation
+`, release))); err == nil {
+			prev.LastSuggested = time.Now()
+			_ = state.Write(prev)
+		}
+	}
 }


### PR DESCRIPTION
Too many errors due to incorrect builds. We can at least notify the users about this:
<img width="850" height="160" alt="image" src="https://github.com/user-attachments/assets/3c5020d4-6eea-4f1e-a3c5-d7dc76b8c897" />
