### PR TITLE
sql/migrate: fix truncation of Unicode arguments in directives

### DIFF
--- a/sql/migrate/dir.go
+++ b/sql/migrate/dir.go
@@ -274,7 +274,7 @@ const (
 	directivePrefixSQL  = "-- "
 )
 
-var reDirective = regexp.MustCompile(`^([ -~]*)atlas:(\w+)(?: +([ -~]*))*`)
+var reDirective = regexp.MustCompile(`^([ -~]*)atlas:(\w+)(?: +(.+))*`)
 
 // directive searches in the content a line that matches a directive
 // with the given prefix and name. For example:

--- a/sql/migrate/dir_test.go
+++ b/sql/migrate/dir_test.go
@@ -430,11 +430,11 @@ alter table users drop column id;
 -- atlas:import
 -- atlas:import bar baz
 -- atlas:import qux
+-- atlas:import files_📄
 
 alter table users drop column id;
 `))
-	require.Equal(t, []string{"foo", "", "bar baz", "qux"}, f.Directive("import"))
-
+	require.Equal(t, []string{"foo", "", "bar baz", "qux", "files_📄"}, f.Directive("import"))
 	f = migrate.NewLocalFile("1.sql", []byte("-- atlas:import foo\n"))
 	require.Equal(t, []string{"foo"}, f.Directive("import"))
 }


### PR DESCRIPTION
Fixes: https://github.com/ariga/atlas/issues/3647