### PR TITLE
Fix TiDB DDL `CREATE DATABASE` ordering and add support for TiDB Auto random

### DIFF
--- a/sql/mysql/inspect_oss.go
+++ b/sql/mysql/inspect_oss.go
@@ -529,6 +529,7 @@ func (i *inspect) showCreate(ctx context.Context, s *schema.Schema) error {
 }
 
 var reAutoinc = regexp.MustCompile(`(?i)\s*AUTO_INCREMENT\s*=\s*(\d+)\s*`)
+var reAutoRandom = regexp.MustCompile(`(?i)AUTO_RANDOM(?:\((\d+)\))?`)
 
 // createStmt loads the CREATE TABLE statement for the table.
 func (i *inspect) createStmt(ctx context.Context, t *schema.Table) (*CreateStmt, error) {
@@ -798,6 +799,13 @@ type (
 	AutoIncrement struct {
 		schema.Attr
 		V int64
+	}
+
+	// AutoRandom attribute for TiDB columns with AUTO_RANDOM.
+	// V represents the number of shard bits (1-16, default 5).
+	AutoRandom struct {
+		schema.Attr
+		V int // Shard bits
 	}
 
 	// CreateOptions attribute for describing extra options used with CREATE TABLE.

--- a/sql/mysql/migrate_oss.go
+++ b/sql/mysql/migrate_oss.go
@@ -576,6 +576,12 @@ func (s *state) column(b *sqlx.Builder, t *schema.Table, c *schema.Column) error
 			if a.V > 0 && !sqlx.Has(t.Attrs, &AutoIncrement{}) {
 				t.Attrs = append(t.Attrs, a)
 			}
+		case *AutoRandom:
+			if a.V != 5 {
+				b.P(fmt.Sprintf("AUTO_RANDOM(%d)", a.V))
+			} else {
+				b.P("AUTO_RANDOM")
+			}
 		default:
 			s.attr(b, a)
 		}

--- a/sql/mysql/sqlspec_oss.go
+++ b/sql/mysql/sqlspec_oss.go
@@ -401,6 +401,13 @@ func columnSpec(c *schema.Column, t *schema.Table) (*sqlspec.Column, error) {
 	if sqlx.Has(c.Attrs, &AutoIncrement{}) {
 		spec.Extra.Attrs = append(spec.Extra.Attrs, schemahcl.BoolAttr("auto_increment", true))
 	}
+	if ar := (&AutoRandom{}); sqlx.Has(c.Attrs, ar) {
+		if ar.V != 5 {
+			spec.Extra.Attrs = append(spec.Extra.Attrs, schemahcl.IntAttr("auto_random", ar.V))
+		} else {
+			spec.Extra.Attrs = append(spec.Extra.Attrs, schemahcl.BoolAttr("auto_random", true))
+		}
+	}
 	if x := (schema.GeneratedExpr{}); sqlx.Has(c.Attrs, &x) {
 		spec.Extra.Children = append(spec.Extra.Children, specutil.FromGenExpr(x, storedOrVirtual))
 	}


### PR DESCRIPTION
Fixes Atlas positioning CREATE TABLE statements before the matching database would be created and adds support for TiDBs AUTO_RANDOM feature like AUTO_INCREMENT already is supported.