### PR TITLE
fix: set priority for tidb create databases

### DIFF
--- a/sql/mysql/tidb.go
+++ b/sql/mysql/tidb.go
@@ -35,6 +35,9 @@ type (
 // dropped if its foreign key was not dropped before.
 func priority(change schema.Change) int {
 	switch c := change.(type) {
+	case *schema.AddSchema:
+		// CREATE DATABASE must come before any tables in that database.
+		return 0
 	case *schema.ModifyTable:
 		// each modifyTable should have a single change since we apply `flat` before we sort.
 		return priority(c.Changes[0])


### PR DESCRIPTION
Previously the priorities were not set for create database statements for TiDB causing the DDL to be ordered such that tables were tried to be created to databases that did not exist.