### PR TITLE
fix for PostgreSQL domain definition in HCL can fail creation due to …

### DIFF
--- a/cmd/atlas/internal/cmdext/reader.go
+++ b/cmd/atlas/internal/cmdext/reader.go
@@ -313,18 +313,22 @@ func parseHCLPaths(paths ...string) (*hclparse.Parser, error) {
 		case err != nil:
 			return nil, err
 		case stat.IsDir():
-			dir, err := os.ReadDir(path)
+			err := filepath.Walk(path, func(fp string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					return nil
+				}
+				if filepath.Ext(fp) == FileTypeHCL || strings.HasSuffix(fp, FileTypeTest) {
+					if err := mayParse(p, fp); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
 			if err != nil {
 				return nil, err
-			}
-			for _, f := range dir {
-				// Skip nested dirs.
-				if f.IsDir() {
-					continue
-				}
-				if err := mayParse(p, filepath.Join(path, f.Name())); err != nil {
-					return nil, err
-				}
 			}
 		default:
 			if err := mayParse(p, path); err != nil {


### PR DESCRIPTION
…a missing dependency #3671

fix applied for this is 
Update [parseHCLPaths](vscode-file://vscode-app/c:/Users/akhil/AppData/Local/Programs/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to scan all files (including nested directories).
Parse all files, then build a dependency graph based on references (e.g., function calls in domains).
Topologically sort files and load them in dependency order.


Recursively collect all .hcl files.
After parsing, analyze references to build a dependency graph.
Sort files by dependency and parse in that order.