### PR TITLE
cmd/atlas: bump Go version to 1.25.9

### DIFF
--- a/cmd/atlas/go.mod
+++ b/cmd/atlas/go.mod
@@ -1,6 +1,6 @@
 module ariga.io/atlas/cmd/atlas
 
-go 1.25.0
+go 1.25.9
 
 replace ariga.io/atlas => ../..
 

--- a/internal/integration/go.mod
+++ b/internal/integration/go.mod
@@ -1,6 +1,6 @@
 module ariga.io/atlas/internal/integration
 
-go 1.25.0
+go 1.25.9
 
 replace ariga.io/atlas => ../../
 


### PR DESCRIPTION
Close https://github.com/ariga/atlas/issues/3713