### PR TITLE
all: bump Go version to 1.26.4

### DIFF
--- a/cmd/atlas/go.mod
+++ b/cmd/atlas/go.mod
@@ -1,6 +1,6 @@
 module ariga.io/atlas/cmd/atlas
 
-go 1.26.3
+go 1.26.4
 
 replace ariga.io/atlas => ../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ariga.io/atlas
 
-go 1.25.0
+go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/internal/integration/go.mod
+++ b/internal/integration/go.mod
@@ -1,6 +1,6 @@
 module ariga.io/atlas/internal/integration
 
-go 1.26.3
+go 1.26.4
 
 replace ariga.io/atlas => ../../
 


### PR DESCRIPTION
Fix https://github.com/ariga/atlas/issues/3746