### PR TITLE
atlasexec: count every reported level

### DIFF
--- a/atlasexec/atlas_security.go
+++ b/atlasexec/atlas_security.go
@@ -47,7 +47,7 @@ type (
 		Name        string `json:"Name"`                  // Extension the vulnerability was reported for.
 		Version     string `json:"Version"`               // Its installed version.
 		ID          string `json:"ID"`                    // e.g., CVE-2024-10977.
-		Level       string `json:"Level"`                 // Severity as the Security Graph grades it. May be empty.
+		Level       string `json:"Level"`                 // Severity as the Security Graph grades it. Always set.
 		Severity    string `json:"Severity"`              // CVSS rating of the record. Empty if it carries none.
 		Title       string `json:"Title,omitempty"`       // Empty for the records with no assigned title.
 		Description string `json:"Description,omitempty"` // Verbatim, may run to a paragraph.
@@ -124,15 +124,13 @@ func (s *SecurityScan) Count() int {
 	return n
 }
 
-// Levels returns the number of issues per severity level, highest first. Levels
-// that reported none are omitted, as are the issues left ungraded.
+// Levels returns the number of issues per severity level, highest first,
+// and omits the levels that reported none.
 func (s *SecurityScan) Levels() []SecurityScanLevel {
 	counts := make(map[string]int)
 	for _, t := range s.Targets {
 		for _, v := range t.Vulnerabilities {
-			if v.Level != "" {
-				counts[strings.ToUpper(v.Level)]++
-			}
+			counts[strings.ToUpper(v.Level)]++
 		}
 	}
 	levels := make([]SecurityScanLevel, 0, len(counts))

--- a/atlasexec/atlas_security_test.go
+++ b/atlasexec/atlas_security_test.go
@@ -159,9 +159,9 @@ func TestSecurityVulnerability_LevelText(t *testing.T) {
 			text: `Extension "ext" version "1.0" is vulnerable to CVE-0000-0001 (CRITICAL): Arbitrary code execution. Upgrade to 1.1`,
 		},
 		{
-			name: "no version, level or suggestion",
-			v:    &atlasexec.SecurityVulnerability{Name: "ext", ID: "CVE-0000-0002"},
-			text: `Extension "ext" is vulnerable to CVE-0000-0002`,
+			name: "no version or suggestion",
+			v:    &atlasexec.SecurityVulnerability{Name: "ext", ID: "CVE-0000-0002", Level: "ELEVATED"},
+			text: `Extension "ext" is vulnerable to CVE-0000-0002 (ELEVATED)`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Levels skipped the records without a level while Count kept them, so a breakdown could not add up to its total. The Security Graph grades every record it reports, hence there is nothing to skip: bucket them all, as the CLI does.